### PR TITLE
Add marker clustering with custom map pins

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef } from 'react';
 import 'leaflet/dist/leaflet.css';
 import './map.css';
-import type 'leaflet.markercluster';
 import { createMarkerClusterGroup } from './cluster';
 
 const DEFAULT_COORDINATES: [number, number] = [20, 0];

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -2,9 +2,21 @@
 
 import { useEffect, useRef } from 'react';
 import 'leaflet/dist/leaflet.css';
+import './map.css';
+import type 'leaflet.markercluster';
+import { createMarkerClusterGroup } from './cluster';
 
 const DEFAULT_COORDINATES: [number, number] = [20, 0];
 const DEFAULT_ZOOM = 2;
+
+const mockPlaces = [
+  { id: '1', lat: 35.68, lng: 139.76, type: 'owner' },
+  { id: '2', lat: 40.71, lng: -74.0, type: 'community' },
+  { id: '3', lat: 48.85, lng: 2.35, type: 'directory' },
+  { id: '4', lat: -33.86, lng: 151.2, type: 'unverified' }
+] as const;
+
+type PlaceType = (typeof mockPlaces)[number]['type'];
 
 export default function MapClient() {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
@@ -15,6 +27,8 @@ export default function MapClient() {
 
     const initializeMap = async () => {
       const L = await import('leaflet');
+      const LMC = await import('leaflet.markercluster');
+      void LMC;
 
       if (!isMounted || !mapContainerRef.current || mapInstanceRef.current) return;
 
@@ -27,6 +41,40 @@ export default function MapClient() {
         attribution: '&copy; OpenStreetMap contributors'
       }).addTo(map);
 
+      const iconSize: [number, number] = [32, 32];
+      const iconAnchor: [number, number] = [16, 32];
+
+      const iconMap: Record<PlaceType, import('leaflet').Icon> = {
+        owner: L.icon({
+          iconUrl: '/pins/owner.svg',
+          iconSize,
+          iconAnchor
+        }),
+        community: L.icon({
+          iconUrl: '/pins/community.svg',
+          iconSize,
+          iconAnchor
+        }),
+        directory: L.icon({
+          iconUrl: '/pins/directory.svg',
+          iconSize,
+          iconAnchor
+        }),
+        unverified: L.icon({
+          iconUrl: '/pins/unverified.svg',
+          iconSize,
+          iconAnchor
+        })
+      };
+
+      const cluster = await createMarkerClusterGroup(L);
+
+      mockPlaces.forEach((place) => {
+        const icon = iconMap[place.type];
+        cluster.addLayer(L.marker([place.lat, place.lng], { icon }));
+      });
+
+      cluster.addTo(map);
       mapInstanceRef.current = map;
     };
 

--- a/components/map/cluster.ts
+++ b/components/map/cluster.ts
@@ -6,8 +6,7 @@
  */
 export async function createMarkerClusterGroup(
   L: typeof import('leaflet'),
-  options?: MarkerClusterGroupOptions
 ) {
   await import('leaflet.markercluster');
-  return L.markerClusterGroup(options);
+  return L.markerClusterGroup();
 }

--- a/components/map/cluster.ts
+++ b/components/map/cluster.ts
@@ -1,0 +1,14 @@
+import type { MarkerClusterGroupOptions } from 'leaflet.markercluster';
+
+/**
+ * Dynamically loads the Leaflet MarkerCluster plugin and returns a configured cluster group.
+ *
+ * This helper keeps imports client-side to avoid SSR issues.
+ */
+export async function createMarkerClusterGroup(
+  L: typeof import('leaflet'),
+  options?: MarkerClusterGroupOptions
+) {
+  await import('leaflet.markercluster');
+  return L.markerClusterGroup(options);
+}

--- a/components/map/cluster.ts
+++ b/components/map/cluster.ts
@@ -1,4 +1,3 @@
-import type { MarkerClusterGroupOptions } from 'leaflet.markercluster';
 
 /**
  * Dynamically loads the Leaflet MarkerCluster plugin and returns a configured cluster group.

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -1,0 +1,14 @@
+.leaflet-marker-icon {
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.leaflet-marker-icon:hover {
+  transform: scale(1.12);
+  z-index: 1000;
+}
+
+.leaflet-marker-icon.leaflet-interactive:active,
+.leaflet-marker-icon.leaflet-interactive.leaflet-marker-draggable.leaflet-clickable:active {
+  transform: scale(1.05);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "leaflet": "^1.9.4",
     "next": "15.0.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "leaflet.markercluster": "^1.5.3"
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.12",
@@ -24,6 +25,7 @@
     "eslint-config-next": "15.0.0",
     "postcss": "8.4.47",
     "tailwindcss": "3.4.10",
-    "typescript": "5.6.2"
+    "typescript": "5.6.2",
+    "@types/leaflet.markercluster": "^1.5.4"
   }
 }

--- a/public/pins/community.svg
+++ b/public/pins/community.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path d="M16 2C10.477 2 6 6.477 6 12c0 7.5 10 18 10 18s10-10.5 10-18c0-5.523-4.477-10-10-10Z" fill="#10B981" stroke="#065F46" stroke-width="1.5"/>
+  <path d="M10 12c0-3.314 2.686-6 6-6s6 2.686 6 6c0 1.18-.336 2.28-.916 3.208A6.003 6.003 0 0 1 10 12Z" fill="#ECFDF3"/>
+</svg>

--- a/public/pins/directory.svg
+++ b/public/pins/directory.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path d="M16 2C10.477 2 6 6.477 6 12c0 7.5 10 18 10 18s10-10.5 10-18c0-5.523-4.477-10-10-10Z" fill="#F59E0B" stroke="#92400E" stroke-width="1.5"/>
+  <rect x="11" y="9" width="10" height="6" rx="1.5" fill="#FFFBEB"/>
+  <rect x="11" y="16" width="10" height="2" rx="1" fill="#FFFBEB"/>
+</svg>

--- a/public/pins/owner.svg
+++ b/public/pins/owner.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path d="M16 2C10.477 2 6 6.477 6 12c0 7.5 10 18 10 18s10-10.5 10-18c0-5.523-4.477-10-10-10Z" fill="#4F46E5" stroke="#1F2937" stroke-width="1.5"/>
+  <circle cx="16" cy="12" r="5" fill="#EEF2FF"/>
+</svg>

--- a/public/pins/unverified.svg
+++ b/public/pins/unverified.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path d="M16 2C10.477 2 6 6.477 6 12c0 7.5 10 18 10 18s10-10.5 10-18c0-5.523-4.477-10-10-10Z" fill="#9CA3AF" stroke="#4B5563" stroke-width="1.5"/>
+  <path d="M16 9v5" stroke="#F9FAFB" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="16" cy="17" r="1.25" fill="#F9FAFB"/>
+</svg>


### PR DESCRIPTION
## Summary
- add MarkerCluster helper, mock pin data, and client-side initialization for clustered markers on the map
- include custom SVG pin assets with hover/click styling for new map markers
- add Leaflet MarkerCluster dependencies for clustering support

## Testing
- npm install *(fails: 403 Forbidden when fetching @types/leaflet)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928648bfa948328aec2395d6b8247e5)