### PR TITLE
Prevent drawer flicker when reselecting pin

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -51,11 +51,18 @@ export default function MapClient() {
   const bottomSheetRef = useRef<HTMLDivElement | null>(null);
   const [isMobile, setIsMobile] = useState(false);
 
-  const openDrawerForPlace = useCallback((placeId: string) => {
-    setSelectedPlaceId(placeId);
-    setDrawerOpen(true);
-    setDrawerMode("full");
-  }, []);
+  const openDrawerForPlace = useCallback(
+    (placeId: string) => {
+      if (selectedPlaceId === placeId) {
+        return;
+      }
+
+      setSelectedPlaceId(placeId);
+      setDrawerOpen(true);
+      setDrawerMode("full");
+    },
+    [selectedPlaceId],
+  );
 
   const closeDrawer = useCallback(() => {
     setSelectedPlaceId(null);


### PR DESCRIPTION
## Summary
- add guard to pin click handler to ignore reselecting the currently open place
- keep drawer mode and active marker styling untouched when clicking the same pin

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69305de2207883289555e2f82120e5a1)