### PR TITLE
Prevent drawer from closing when clicking markers

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -262,6 +262,12 @@ export default function MapClient() {
     if (!selectedPlaceId && !drawerOpen) return;
 
     const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (event.target instanceof HTMLElement) {
+        if (event.target.closest(".leaflet-marker-icon")) {
+          return;
+        }
+      }
+
       if (drawerRef.current && event.target instanceof Node) {
         if (drawerRef.current.contains(event.target)) {
           return;


### PR DESCRIPTION
## Summary
- skip closing the drawer when pointer events originate from Leaflet marker icons to avoid flicker
- preserve existing outside-click handling for drawer and bottom sheet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930672562108328bb7e5d64388b4584)