### PR TITLE
Fix drawer outside click handling for map markers

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -262,20 +262,20 @@ export default function MapClient() {
     if (!selectedPlaceId && !drawerOpen) return;
 
     const handleClick = (event: MouseEvent) => {
-      if (event.target instanceof Node) {
-        if (
-          event.target.closest(
-            ".leaflet-marker-icon, .cpm-pin, .cluster-marker",
-          )
-        ) {
+      const target = event.target;
+
+      if (target instanceof Element) {
+        if (target.closest(".leaflet-marker-icon, .cpm-pin, .cluster-marker")) {
+          return;
+        }
+      }
+
+      if (target instanceof Node) {
+        if (drawerRef.current?.contains(target)) {
           return;
         }
 
-        if (drawerRef.current?.contains(event.target)) {
-          return;
-        }
-
-        if (bottomSheetRef.current?.contains(event.target)) {
+        if (bottomSheetRef.current?.contains(target)) {
           return;
         }
       }

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -261,15 +261,21 @@ export default function MapClient() {
   useEffect(() => {
     if (!selectedPlaceId && !drawerOpen) return;
 
-    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
-      if (drawerRef.current && event.target instanceof Node) {
-        if (drawerRef.current.contains(event.target)) {
+    const handleClick = (event: MouseEvent) => {
+      if (event.target instanceof Node) {
+        if (
+          event.target.closest(
+            ".leaflet-marker-icon, .cpm-pin, .cluster-marker",
+          )
+        ) {
           return;
         }
-      }
 
-      if (bottomSheetRef.current && event.target instanceof Node) {
-        if (bottomSheetRef.current.contains(event.target)) {
+        if (drawerRef.current?.contains(event.target)) {
+          return;
+        }
+
+        if (bottomSheetRef.current?.contains(event.target)) {
           return;
         }
       }
@@ -277,12 +283,10 @@ export default function MapClient() {
       closeDrawer();
     };
 
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("touchstart", handlePointerDown);
+    document.addEventListener("click", handleClick);
 
     return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("click", handleClick);
     };
   }, [closeDrawer, drawerOpen, selectedPlaceId]);
 


### PR DESCRIPTION
## Summary
- switch the global outside-click listener to use a single click handler compatible with marker stopPropagation
- ignore clicks originating from marker, pin, or cluster elements so they no longer prematurely close the drawer

## Testing
- Not run (lint prompts for initial configuration)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930702be9248328bbf390e5e3a94b65)