### PR TITLE
Implement mobile bottom sheet for place details

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -74,7 +74,7 @@ export default function MapClient() {
     let isMounted = true;
 
     const updateIsMobile = () => {
-      setIsMobile(window.innerWidth < 1024);
+      setIsMobile(window.innerWidth <= 768);
     };
 
     updateIsMobile();

--- a/components/map/MobileBottomSheet.css
+++ b/components/map/MobileBottomSheet.css
@@ -1,0 +1,240 @@
+.cpm-bottom-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  pointer-events: none;
+}
+
+.cpm-bottom-sheet__panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #f7f7f7;
+  border-radius: 18px 18px 0 0;
+  box-shadow: 0 -10px 32px rgba(0, 0, 0, 0.16);
+  display: flex;
+  flex-direction: column;
+  transform: translateY(100%);
+  transition: transform 0.25s ease, height 0.25s ease;
+  pointer-events: auto;
+  overflow: hidden;
+  touch-action: pan-y;
+}
+
+.cpm-bottom-sheet.open .cpm-bottom-sheet__panel {
+  transform: translateY(0);
+}
+
+.cpm-bottom-sheet__handle {
+  display: grid;
+  place-items: center;
+  padding: 10px 0 2px;
+  cursor: grab;
+}
+
+.cpm-bottom-sheet__handle-bar {
+  display: inline-block;
+  width: 48px;
+  height: 5px;
+  border-radius: 999px;
+  background: #d1d5db;
+}
+
+.cpm-bottom-sheet__header {
+  padding: 8px 16px 12px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.cpm-bottom-sheet__title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.cpm-bottom-sheet__title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.cpm-bottom-sheet__title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 800;
+  color: #0f172a;
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.cpm-bottom-sheet__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.cpm-bottom-sheet__badge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.cpm-bottom-sheet__meta-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.9375rem;
+  color: #475569;
+  text-transform: capitalize;
+}
+
+.cpm-bottom-sheet__category {
+  font-weight: 700;
+  color: #111827;
+}
+
+.cpm-bottom-sheet__meta-dot {
+  color: #cbd5e1;
+}
+
+.cpm-bottom-sheet__address {
+  color: #475569;
+  font-weight: 600;
+}
+
+.cpm-bottom-sheet__content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cpm-bottom-sheet__section {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.04);
+}
+
+.cpm-bottom-sheet__section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.cpm-bottom-sheet__section-title {
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: #6b7280;
+  text-transform: uppercase;
+}
+
+.cpm-bottom-sheet__pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.cpm-bottom-sheet__pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #f4f5f7;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #111827;
+  text-transform: capitalize;
+}
+
+.cpm-bottom-sheet__pill.muted {
+  background: #f8fafc;
+  color: #475569;
+  font-weight: 600;
+}
+
+.cpm-bottom-sheet__muted {
+  color: #9ca3af;
+  font-size: 0.875rem;
+}
+
+.cpm-bottom-sheet__carousel {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scroll-snap-type: x mandatory;
+}
+
+.cpm-bottom-sheet__carousel-item {
+  flex: 0 0 auto;
+  width: 220px;
+  height: 140px;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #e5e7eb;
+  scroll-snap-align: start;
+}
+
+.cpm-bottom-sheet__photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.cpm-bottom-sheet__body {
+  margin: 0;
+  color: #1f2937;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.cpm-bottom-sheet__body.muted {
+  color: #6b7280;
+}
+
+.cpm-bottom-sheet__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.cpm-bottom-sheet__link {
+  color: #2563eb;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.cpm-bottom-sheet__link:hover {
+  text-decoration: underline;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cpm-bottom-sheet__panel {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated mobile bottom sheet component with peek and expanded states and full place details
- style the bottom sheet for smooth slide animations, photo carousel, and mobile-friendly layout
- adjust the map client mobile breakpoint to 768px and keep drawer logic intact for desktop

## Testing
- npm run lint *(fails: npm not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693233efb3ec8328b407462a7ec7b0ab)