### PR TITLE
Fix duplicate drawer close when clicking map

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -210,9 +210,6 @@ export default function MapClient() {
       };
 
       map.on("moveend zoomend", updateVisibleMarkers);
-      map.on("click", () => {
-        closeDrawer();
-      });
       mapInstanceRef.current = map;
 
       await fetchPlacesAndBuildIndex();
@@ -261,7 +258,7 @@ export default function MapClient() {
   useEffect(() => {
     if (!selectedPlaceId && !drawerOpen) return;
 
-    const handleClick = (event: MouseEvent) => {
+    const handlePointerDown = (event: PointerEvent) => {
       const target = event.target;
 
       if (target instanceof Element) {
@@ -283,10 +280,10 @@ export default function MapClient() {
       closeDrawer();
     };
 
-    document.addEventListener("click", handleClick);
+    document.addEventListener("pointerdown", handlePointerDown);
 
     return () => {
-      document.removeEventListener("click", handleClick);
+      document.removeEventListener("pointerdown", handlePointerDown);
     };
   }, [closeDrawer, drawerOpen, selectedPlaceId]);
 


### PR DESCRIPTION
## Summary
- remove the Leaflet map click handler that redundantly triggered drawer close
- rely on a single document-level pointerdown listener that ignores markers, drawer, and bottom sheet content

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693255a2d9a08328a53e3cc949a03062)