### PR TITLE
Add stats trends API endpoint

### DIFF
--- a/app/api/stats/trends/route.ts
+++ b/app/api/stats/trends/route.ts
@@ -1,5 +1,7 @@
-import { monthlyTrends, weeklyTrends } from '@/lib/stats/trends';
+import { NextResponse } from "next/server";
+
+import { monthlyTrends, weeklyTrends } from "@/lib/stats/trends";
 
 export async function GET() {
-  return Response.json({ weekly: weeklyTrends, monthly: monthlyTrends });
+  return NextResponse.json({ weekly: weeklyTrends, monthly: monthlyTrends });
 }


### PR DESCRIPTION
## Summary
- add a /api/stats/trends endpoint that returns weekly and monthly trend snapshots
- expose seeded owner, community, and total values for use on the stats page

## Testing
- not run (eslint prompt requires interactive setup)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384154a254832898785e7038ed9909)