### PR TITLE
Add stats dashboard for rankings and category trends

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ out/
 .nuxt/
 dist/
 
+# Temporary test builds
+.tmp-tests/
+
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js\# public

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,3 +1,12 @@
+import { NextResponse } from "next/server";
+
+import { categoryTrends, countryRankings } from "@/lib/stats/dashboard";
+import { monthlyTrends, weeklyTrends } from "@/lib/stats/trends";
+
 export async function GET() {
-  return Response.json({ message: 'Stats API placeholder' });
+  return NextResponse.json({
+    verificationTrends: { weekly: weeklyTrends, monthly: monthlyTrends },
+    countries: countryRankings,
+    categoryTrends,
+  });
 }

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,18 +1,27 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
+import type { CategoryTrendPoint, CountryRanking } from '@/lib/stats/dashboard';
 import type { MonthlyTrendPoint, WeeklyTrendPoint } from '@/lib/stats/trends';
+import { CountrySortKey, filterCategoryTrends, formatPeriodLabel, getCategoryNames, sortCountries } from '@/lib/stats/utils';
 
-type TrendResponse = {
-  weekly: WeeklyTrendPoint[];
-  monthly: MonthlyTrendPoint[];
+type StatsResponse = {
+  verificationTrends: {
+    weekly: WeeklyTrendPoint[];
+    monthly: MonthlyTrendPoint[];
+  };
+  countries: CountryRanking[];
+  categoryTrends: {
+    weekly: CategoryTrendPoint[];
+    monthly: CategoryTrendPoint[];
+  };
 };
 
 type FetchState = {
   loading: boolean;
   error?: string;
-  data?: TrendResponse;
+  data?: StatsResponse;
 };
 
 type ChartSeries = {
@@ -86,7 +95,7 @@ function LineChart({ labels, series }: { labels: string[]; series: ChartSeries[]
           const x = xScale(index);
           const y = height - padding + 16;
           return (
-            <text key={label} x={x} y={y} className="fill-gray-500 text-[10px]" textAnchor="middle">
+            <text key={label + index} x={x} y={y} className="fill-gray-500 text-[10px]" textAnchor="middle">
               {label}
             </text>
           );
@@ -133,7 +142,7 @@ function BarChart({ labels, series }: { labels: string[]; series: ChartSeries[] 
           const baseX = padding + labelIndex * groupWidth;
           const labelY = height - padding + 16;
           return (
-            <g key={label}>
+            <g key={label + labelIndex}>
               {series.map((item, seriesIndex) => {
                 const value = item.values[labelIndex] ?? 0;
                 const barHeight = yScale(value);
@@ -164,37 +173,61 @@ function BarChart({ labels, series }: { labels: string[]; series: ChartSeries[] 
   );
 }
 
+function Card({ title, eyebrow, description, children }: { title: string; eyebrow: string; description: string; children: ReactNode }) {
+  return (
+    <div className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200">
+      <div className="mb-4 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-sky-700">{eyebrow}</p>
+          <h2 className="text-xl font-semibold">{title}</h2>
+          <p className="text-sm text-gray-600">{description}</p>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
 export default function StatsPage() {
   const [state, setState] = useState<FetchState>({ loading: true });
+  const [countrySort, setCountrySort] = useState<CountrySortKey>('total');
+  const [countryLimit, setCountryLimit] = useState(6);
+  const [selectedCategory, setSelectedCategory] = useState<string>('');
 
   useEffect(() => {
-    const fetchTrends = async () => {
+    const fetchStats = async () => {
       try {
-        const response = await fetch('/api/stats/trends');
+        const response = await fetch('/api/stats');
         if (!response.ok) {
           throw new Error('Unable to load stats');
         }
-        const data = (await response.json()) as TrendResponse;
+        const data = (await response.json()) as StatsResponse;
         setState({ loading: false, data });
+        const categories = getCategoryNames(data.categoryTrends.weekly);
+        setSelectedCategory(categories[0] ?? '');
       } catch (error) {
         setState({ loading: false, error: (error as Error).message });
       }
     };
 
-    fetchTrends();
+    fetchStats();
   }, []);
 
   const weeklySeries = useMemo(() => {
     if (!state.data) return null;
 
     return [
-      { label: 'Owner verified', color: chartColors.owner, values: state.data.weekly.map((entry) => entry.owner) },
+      {
+        label: 'Owner verified',
+        color: chartColors.owner,
+        values: state.data.verificationTrends.weekly.map((entry) => entry.owner),
+      },
       {
         label: 'Community verified',
         color: chartColors.community,
-        values: state.data.weekly.map((entry) => entry.community),
+        values: state.data.verificationTrends.weekly.map((entry) => entry.community),
       },
-      { label: 'Total places', color: chartColors.total, values: state.data.weekly.map((entry) => entry.total) },
+      { label: 'Total places', color: chartColors.total, values: state.data.verificationTrends.weekly.map((entry) => entry.total) },
     ];
   }, [state.data]);
 
@@ -202,55 +235,215 @@ export default function StatsPage() {
     if (!state.data) return null;
 
     return [
-      { label: 'Owner verified', color: chartColors.owner, values: state.data.monthly.map((entry) => entry.owner) },
+      {
+        label: 'Owner verified',
+        color: chartColors.owner,
+        values: state.data.verificationTrends.monthly.map((entry) => entry.owner),
+      },
       {
         label: 'Community verified',
         color: chartColors.community,
-        values: state.data.monthly.map((entry) => entry.community),
+        values: state.data.verificationTrends.monthly.map((entry) => entry.community),
       },
-      { label: 'Total places', color: chartColors.total, values: state.data.monthly.map((entry) => entry.total) },
+      { label: 'Total places', color: chartColors.total, values: state.data.verificationTrends.monthly.map((entry) => entry.total) },
     ];
   }, [state.data]);
+
+  const sortedCountries = useMemo(
+    () => sortCountries(state.data?.countries ?? [], countrySort, countryLimit),
+    [state.data?.countries, countrySort, countryLimit],
+  );
+
+  const countrySeries = useMemo<ChartSeries[]>(
+    () => [
+      { label: 'Owner verified', color: chartColors.owner, values: sortedCountries.map((country) => country.owner) },
+      { label: 'Community verified', color: chartColors.community, values: sortedCountries.map((country) => country.community) },
+    ],
+    [sortedCountries],
+  );
+
+  const categoryNames = useMemo(() => (state.data ? getCategoryNames(state.data.categoryTrends.weekly) : []), [state.data]);
+
+  const weeklyCategory = useMemo(() => {
+    if (!state.data || !selectedCategory) return [] as CategoryTrendPoint[];
+    return filterCategoryTrends(state.data.categoryTrends.weekly, selectedCategory);
+  }, [selectedCategory, state.data]);
+
+  const monthlyCategory = useMemo(() => {
+    if (!state.data || !selectedCategory) return [] as CategoryTrendPoint[];
+    return filterCategoryTrends(state.data.categoryTrends.monthly, selectedCategory);
+  }, [selectedCategory, state.data]);
+
+  const weeklyCategorySeries = useMemo(() => {
+    if (!weeklyCategory.length) return null;
+
+    return [
+      { label: 'Owner verified', color: chartColors.owner, values: weeklyCategory.map((entry) => entry.owner) },
+      {
+        label: 'Community verified',
+        color: chartColors.community,
+        values: weeklyCategory.map((entry) => entry.community),
+      },
+      { label: 'Total places', color: chartColors.total, values: weeklyCategory.map((entry) => entry.total) },
+    ];
+  }, [weeklyCategory]);
+
+  const monthlyCategorySeries = useMemo(() => {
+    if (!monthlyCategory.length) return null;
+
+    return [
+      { label: 'Owner verified', color: chartColors.owner, values: monthlyCategory.map((entry) => entry.owner) },
+      {
+        label: 'Community verified',
+        color: chartColors.community,
+        values: monthlyCategory.map((entry) => entry.community),
+      },
+      { label: 'Total places', color: chartColors.total, values: monthlyCategory.map((entry) => entry.total) },
+    ];
+  }, [monthlyCategory]);
 
   return (
     <main className="flex min-h-screen flex-col gap-8 bg-gray-50 px-6 py-8 text-gray-900">
       <header className="max-w-5xl">
         <p className="text-sm uppercase tracking-wide text-sky-700">Stats</p>
-        <h1 className="mt-2 text-3xl font-semibold">Growth trends</h1>
+        <h1 className="mt-2 text-3xl font-semibold">Marketplace dashboard</h1>
         <p className="mt-2 text-gray-600">
-          Weekly and monthly snapshots of places listed on CryptoPayMap, broken down by verification
-          type. Data is currently seeded for development and visualization purposes.
+          Country rankings and category momentum for the CryptoPayMap community. Data below is seeded for
+          development and visualization purposes.
         </p>
       </header>
 
-      {state.loading && <p className="text-gray-700">Loading trends…</p>}
+      {state.loading && <p className="text-gray-700">Loading stats…</p>}
       {state.error && (
         <p className="rounded-md bg-red-50 px-4 py-3 text-red-700">Failed to load data: {state.error}</p>
       )}
 
       {state.data && weeklySeries && monthlySeries && (
         <section className="grid gap-6 md:grid-cols-2">
-          <div className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200">
-            <div className="mb-4 flex items-start justify-between">
-              <div>
-                <p className="text-sm font-medium text-sky-700">Weekly</p>
-                <h2 className="text-xl font-semibold">Verification trend</h2>
-                <p className="text-sm text-gray-600">Owner and community verified places, week by week.</p>
+          <Card
+            eyebrow="Weekly"
+            title="Verification trend"
+            description="Owner and community verified places by week."
+          >
+            <LineChart
+              labels={state.data.verificationTrends.weekly.map((entry) => formatPeriodLabel(entry.date))}
+              series={weeklySeries}
+            />
+          </Card>
+
+          <Card
+            eyebrow="Monthly"
+            title="Verification trend"
+            description="Aggregated monthly progress for owners and community."
+          >
+            <BarChart
+              labels={state.data.verificationTrends.monthly.map((entry) => formatPeriodLabel(entry.month))}
+              series={monthlySeries}
+            />
+          </Card>
+        </section>
+      )}
+
+      {state.data && (
+        <section className="grid gap-6 lg:grid-cols-3">
+          <div className="lg:col-span-2">
+            <Card
+              eyebrow="Leaderboard"
+              title="Country rankings"
+              description="Top countries by number of owner and community verified listings."
+            >
+              <div className="mb-4 flex flex-wrap gap-4">
+                <label className="flex items-center gap-2 text-sm text-gray-700">
+                  Sort by
+                  <select
+                    className="rounded-md border border-gray-300 bg-white px-2 py-1 text-sm"
+                    value={countrySort}
+                    onChange={(event) => setCountrySort(event.target.value as CountrySortKey)}
+                  >
+                    <option value="total">Total</option>
+                    <option value="owner">Owner</option>
+                    <option value="community">Community</option>
+                  </select>
+                </label>
+                <label className="flex items-center gap-2 text-sm text-gray-700">
+                  Show top
+                  <select
+                    className="rounded-md border border-gray-300 bg-white px-2 py-1 text-sm"
+                    value={countryLimit}
+                    onChange={(event) => setCountryLimit(Number(event.target.value))}
+                  >
+                    <option value={4}>4</option>
+                    <option value={6}>6</option>
+                    <option value={8}>8</option>
+                  </select>
+                </label>
               </div>
-            </div>
-            <LineChart labels={state.data.weekly.map((entry) => entry.date)} series={weeklySeries} />
+
+              <BarChart labels={sortedCountries.map((item) => item.country)} series={countrySeries} />
+            </Card>
           </div>
 
-          <div className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200">
-            <div className="mb-4 flex items-start justify-between">
-              <div>
-                <p className="text-sm font-medium text-sky-700">Monthly</p>
-                <h2 className="text-xl font-semibold">Verification trend</h2>
-                <p className="text-sm text-gray-600">Aggregated monthly progress for owners and community.</p>
-              </div>
+          <div className="lg:col-span-1">
+            <div className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200">
+              <p className="text-sm font-medium text-sky-700">Highlights</p>
+              <h2 className="text-xl font-semibold">Current leaderboard</h2>
+              <p className="text-sm text-gray-600">Sorted by total verified listings.</p>
+              <ol className="mt-4 space-y-3 text-sm text-gray-800">
+                {sortCountries(state.data.countries).map((entry, index) => (
+                  <li key={entry.country} className="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2">
+                    <div className="flex items-center gap-3">
+                      <span className="text-xs font-semibold text-gray-500">#{index + 1}</span>
+                      <span className="font-medium">{entry.country}</span>
+                    </div>
+                    <span className="text-gray-600">{entry.total} places</span>
+                  </li>
+                ))}
+              </ol>
             </div>
-            <BarChart labels={state.data.monthly.map((entry) => entry.month)} series={monthlySeries} />
           </div>
+        </section>
+      )}
+
+      {state.data && weeklyCategorySeries && monthlyCategorySeries && (
+        <section className="grid gap-6 md:grid-cols-2">
+          <Card
+            eyebrow="Category focus"
+            title="Weekly category trend"
+            description="Compare how each category is growing week over week."
+          >
+            <div className="mb-4">
+              <label className="flex items-center gap-2 text-sm text-gray-700">
+                Select category
+                <select
+                  className="rounded-md border border-gray-300 bg-white px-2 py-1 text-sm"
+                  value={selectedCategory}
+                  onChange={(event) => setSelectedCategory(event.target.value)}
+                >
+                  {categoryNames.map((name) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <LineChart
+              labels={weeklyCategory.map((entry) => formatPeriodLabel(entry.period))}
+              series={weeklyCategorySeries}
+            />
+          </Card>
+
+          <Card
+            eyebrow="Category focus"
+            title="Monthly category trend"
+            description="Owner and community verified totals for the chosen category."
+          >
+            <BarChart
+              labels={monthlyCategory.map((entry) => formatPeriodLabel(entry.period))}
+              series={monthlyCategorySeries}
+            />
+          </Card>
         </section>
       )}
     </main>

--- a/lib/stats/dashboard.ts
+++ b/lib/stats/dashboard.ts
@@ -1,0 +1,81 @@
+export type CountryRanking = {
+  country: string;
+  owner: number;
+  community: number;
+  total: number;
+};
+
+export type CategoryTrendPoint = {
+  period: string;
+  category: string;
+  owner: number;
+  community: number;
+  total: number;
+};
+
+export const countryRankings: CountryRanking[] = [
+  { country: 'United States', owner: 72, community: 46, total: 118 },
+  { country: 'Canada', owner: 38, community: 29, total: 67 },
+  { country: 'Germany', owner: 34, community: 26, total: 60 },
+  { country: 'Argentina', owner: 29, community: 18, total: 47 },
+  { country: 'Philippines', owner: 26, community: 22, total: 48 },
+  { country: 'Nigeria', owner: 19, community: 15, total: 34 },
+  { country: 'Australia', owner: 24, community: 16, total: 40 },
+  { country: 'Portugal', owner: 15, community: 12, total: 27 },
+];
+
+export const categoryTrends: {
+  weekly: CategoryTrendPoint[];
+  monthly: CategoryTrendPoint[];
+} = {
+  weekly: [
+    { period: '2024-09-09', category: 'Dining', owner: 35, community: 18, total: 53 },
+    { period: '2024-09-09', category: 'Retail', owner: 21, community: 14, total: 35 },
+    { period: '2024-09-09', category: 'Services', owner: 18, community: 12, total: 30 },
+
+    { period: '2024-09-16', category: 'Dining', owner: 38, community: 19, total: 57 },
+    { period: '2024-09-16', category: 'Retail', owner: 22, community: 15, total: 37 },
+    { period: '2024-09-16', category: 'Services', owner: 19, community: 13, total: 32 },
+
+    { period: '2024-09-23', category: 'Dining', owner: 40, community: 21, total: 61 },
+    { period: '2024-09-23', category: 'Retail', owner: 24, community: 15, total: 39 },
+    { period: '2024-09-23', category: 'Services', owner: 20, community: 14, total: 34 },
+
+    { period: '2024-09-30', category: 'Dining', owner: 42, community: 22, total: 64 },
+    { period: '2024-09-30', category: 'Retail', owner: 26, community: 16, total: 42 },
+    { period: '2024-09-30', category: 'Services', owner: 21, community: 15, total: 36 },
+
+    { period: '2024-10-07', category: 'Dining', owner: 44, community: 24, total: 68 },
+    { period: '2024-10-07', category: 'Retail', owner: 27, community: 18, total: 45 },
+    { period: '2024-10-07', category: 'Services', owner: 23, community: 16, total: 39 },
+
+    { period: '2024-10-14', category: 'Dining', owner: 46, community: 25, total: 71 },
+    { period: '2024-10-14', category: 'Retail', owner: 29, community: 19, total: 48 },
+    { period: '2024-10-14', category: 'Services', owner: 24, community: 17, total: 41 },
+
+    { period: '2024-10-21', category: 'Dining', owner: 48, community: 26, total: 74 },
+    { period: '2024-10-21', category: 'Retail', owner: 31, community: 20, total: 51 },
+    { period: '2024-10-21', category: 'Services', owner: 25, community: 18, total: 43 },
+  ],
+  monthly: [
+    { period: '2024-06', category: 'Dining', owner: 28, community: 14, total: 42 },
+    { period: '2024-06', category: 'Retail', owner: 17, community: 11, total: 28 },
+    { period: '2024-06', category: 'Services', owner: 14, community: 10, total: 24 },
+
+    { period: '2024-07', category: 'Dining', owner: 31, community: 16, total: 47 },
+    { period: '2024-07', category: 'Retail', owner: 18, community: 12, total: 30 },
+    { period: '2024-07', category: 'Services', owner: 15, community: 11, total: 26 },
+
+    { period: '2024-08', category: 'Dining', owner: 33, community: 17, total: 50 },
+    { period: '2024-08', category: 'Retail', owner: 20, community: 13, total: 33 },
+    { period: '2024-08', category: 'Services', owner: 16, community: 12, total: 28 },
+
+    { period: '2024-09', category: 'Dining', owner: 36, community: 18, total: 54 },
+    { period: '2024-09', category: 'Retail', owner: 22, community: 14, total: 36 },
+    { period: '2024-09', category: 'Services', owner: 17, community: 13, total: 30 },
+
+    { period: '2024-10', category: 'Dining', owner: 39, community: 20, total: 59 },
+    { period: '2024-10', category: 'Retail', owner: 24, community: 15, total: 39 },
+    { period: '2024-10', category: 'Services', owner: 19, community: 14, total: 33 },
+  ],
+};

--- a/lib/stats/utils.ts
+++ b/lib/stats/utils.ts
@@ -1,0 +1,31 @@
+import type { CategoryTrendPoint, CountryRanking } from "./dashboard";
+
+export type CountrySortKey = "total" | "owner" | "community";
+
+export function sortCountries(
+  countries: CountryRanking[],
+  sortBy: CountrySortKey = "total",
+  limit = countries.length,
+): CountryRanking[] {
+  const sorted = [...countries].sort((a, b) => b[sortBy] - a[sortBy]);
+  return sorted.slice(0, Math.max(0, limit));
+}
+
+export function getCategoryNames(trends: CategoryTrendPoint[]): string[] {
+  return Array.from(new Set(trends.map((entry) => entry.category)));
+}
+
+export function filterCategoryTrends(trends: CategoryTrendPoint[], category: string): CategoryTrendPoint[] {
+  return trends.filter((entry) => entry.category === category);
+}
+
+export function formatPeriodLabel(period: string): string {
+  if (period.length === 7) {
+    const [year, month] = period.split("-");
+    const date = new Date(Date.UTC(Number(year), Number(month) - 1));
+    return date.toLocaleDateString("en-US", { month: "short", year: "numeric", timeZone: "UTC" });
+  }
+
+  const parsedDate = new Date(`${period}T00:00:00Z`);
+  return parsedDate.toLocaleDateString("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "npm run test:stats",
+    "test:stats": "tsc --project tsconfig.test.json && node --test .tmp-tests/tests/*.js && rm -rf .tmp-tests"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/tests/stats-utils.test.ts
+++ b/tests/stats-utils.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { categoryTrends, countryRankings } from "../lib/stats/dashboard";
+import { filterCategoryTrends, formatPeriodLabel, getCategoryNames, sortCountries } from "../lib/stats/utils";
+
+describe("sortCountries", () => {
+  it("sorts by the chosen metric and limits results", () => {
+    const topTwo = sortCountries(countryRankings, "owner", 2);
+
+    assert.equal(topTwo.length, 2);
+    assert.ok(topTwo[0].owner >= topTwo[1].owner);
+    assert.equal(topTwo[0].country, "United States");
+  });
+
+  it("defaults to total count when no sort key is provided", () => {
+    const sorted = sortCountries(countryRankings);
+    const totals = sorted.map((item) => item.total);
+
+    assert.deepEqual([...totals].sort((a, b) => b - a), totals);
+  });
+});
+
+describe("category trends helpers", () => {
+  it("lists unique category names", () => {
+    const categories = getCategoryNames(categoryTrends.weekly);
+
+    assert.ok(categories.includes("Dining"));
+    assert.ok(categories.includes("Retail"));
+    assert.ok(categories.includes("Services"));
+  });
+
+  it("filters weekly and monthly entries for a category", () => {
+    const diningWeekly = filterCategoryTrends(categoryTrends.weekly, "Dining");
+    const diningMonthly = filterCategoryTrends(categoryTrends.monthly, "Dining");
+
+    assert.equal(diningWeekly.length, 7);
+    assert.equal(diningMonthly.length, 5);
+    assert.ok(diningWeekly.every((entry) => entry.category === "Dining"));
+    assert.ok(diningMonthly.every((entry) => entry.category === "Dining"));
+  });
+});
+
+describe("formatPeriodLabel", () => {
+  it("formats monthly periods", () => {
+    assert.equal(formatPeriodLabel("2024-10"), "Oct 2024");
+  });
+
+  it("formats weekly date labels", () => {
+    assert.equal(formatPeriodLabel("2024-10-07"), "Oct 7");
+  });
+});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": ".tmp-tests",
+    "module": "CommonJS"
+  },
+  "include": ["tests/**/*.ts", "lib/stats/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- expand the stats API to return verification, country ranking, and category trend datasets
- replace the stats page with interactive charts for verification growth, country rankings, and category trends
- add reusable stats utilities, tests, and lint configuration for the dashboard

## Testing
- npm run lint
- npm run test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938464aa9e083289ed7c50f4127737f)