### PR TITLE
Add directory and unverified trends to stats charts

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -33,6 +33,8 @@ type ChartSeries = {
 const chartColors = {
   owner: '#0ea5e9',
   community: '#f97316',
+  directory: '#8b5cf6',
+  unverified: '#f43f5e',
   total: '#22c55e',
 };
 
@@ -227,7 +229,16 @@ export default function StatsPage() {
         color: chartColors.community,
         values: state.data.verificationTrends.weekly.map((entry) => entry.community),
       },
-      { label: 'Total places', color: chartColors.total, values: state.data.verificationTrends.weekly.map((entry) => entry.total) },
+      {
+        label: 'Directory verified',
+        color: chartColors.directory,
+        values: state.data.verificationTrends.weekly.map((entry) => entry.directory),
+      },
+      {
+        label: 'Unverified listings',
+        color: chartColors.unverified,
+        values: state.data.verificationTrends.weekly.map((entry) => entry.unverified),
+      },
     ];
   }, [state.data]);
 
@@ -245,7 +256,16 @@ export default function StatsPage() {
         color: chartColors.community,
         values: state.data.verificationTrends.monthly.map((entry) => entry.community),
       },
-      { label: 'Total places', color: chartColors.total, values: state.data.verificationTrends.monthly.map((entry) => entry.total) },
+      {
+        label: 'Directory verified',
+        color: chartColors.directory,
+        values: state.data.verificationTrends.monthly.map((entry) => entry.directory),
+      },
+      {
+        label: 'Unverified listings',
+        color: chartColors.unverified,
+        values: state.data.verificationTrends.monthly.map((entry) => entry.unverified),
+      },
     ];
   }, [state.data]);
 
@@ -323,7 +343,7 @@ export default function StatsPage() {
           <Card
             eyebrow="Weekly"
             title="Verification trend"
-            description="Owner and community verified places by week."
+            description="Owner, community, directory, and unverified places by week."
           >
             <LineChart
               labels={state.data.verificationTrends.weekly.map((entry) => formatPeriodLabel(entry.date))}
@@ -334,7 +354,7 @@ export default function StatsPage() {
           <Card
             eyebrow="Monthly"
             title="Verification trend"
-            description="Aggregated monthly progress for owners and community."
+            description="Aggregated monthly progress across all verification types."
           >
             <BarChart
               labels={state.data.verificationTrends.monthly.map((entry) => formatPeriodLabel(entry.month))}

--- a/lib/stats/trends.ts
+++ b/lib/stats/trends.ts
@@ -2,6 +2,8 @@ export type WeeklyTrendPoint = {
   date: string;
   owner: number;
   community: number;
+  directory: number;
+  unverified: number;
   total: number;
 };
 
@@ -9,25 +11,27 @@ export type MonthlyTrendPoint = {
   month: string;
   owner: number;
   community: number;
+  directory: number;
+  unverified: number;
   total: number;
 };
 
 export const weeklyTrends: WeeklyTrendPoint[] = [
-  { date: '2024-09-02', owner: 120, community: 68, total: 188 },
-  { date: '2024-09-09', owner: 128, community: 70, total: 198 },
-  { date: '2024-09-16', owner: 133, community: 72, total: 205 },
-  { date: '2024-09-23', owner: 138, community: 75, total: 213 },
-  { date: '2024-09-30', owner: 145, community: 79, total: 224 },
-  { date: '2024-10-07', owner: 152, community: 82, total: 234 },
-  { date: '2024-10-14', owner: 158, community: 86, total: 244 },
-  { date: '2024-10-21', owner: 164, community: 89, total: 253 },
+  { date: '2024-09-02', owner: 120, community: 68, directory: 42, unverified: 25, total: 255 },
+  { date: '2024-09-09', owner: 128, community: 70, directory: 45, unverified: 24, total: 267 },
+  { date: '2024-09-16', owner: 133, community: 72, directory: 48, unverified: 23, total: 276 },
+  { date: '2024-09-23', owner: 138, community: 75, directory: 52, unverified: 22, total: 287 },
+  { date: '2024-09-30', owner: 145, community: 79, directory: 55, unverified: 21, total: 300 },
+  { date: '2024-10-07', owner: 152, community: 82, directory: 59, unverified: 20, total: 313 },
+  { date: '2024-10-14', owner: 158, community: 86, directory: 63, unverified: 18, total: 325 },
+  { date: '2024-10-21', owner: 164, community: 89, directory: 67, unverified: 17, total: 337 },
 ];
 
 export const monthlyTrends: MonthlyTrendPoint[] = [
-  { month: '2024-05', owner: 96, community: 52, total: 148 },
-  { month: '2024-06', owner: 110, community: 58, total: 168 },
-  { month: '2024-07', owner: 123, community: 64, total: 187 },
-  { month: '2024-08', owner: 135, community: 71, total: 206 },
-  { month: '2024-09', owner: 148, community: 78, total: 226 },
-  { month: '2024-10', owner: 160, community: 84, total: 244 },
+  { month: '2024-05', owner: 96, community: 52, directory: 35, unverified: 28, total: 211 },
+  { month: '2024-06', owner: 110, community: 58, directory: 38, unverified: 26, total: 232 },
+  { month: '2024-07', owner: 123, community: 64, directory: 42, unverified: 25, total: 254 },
+  { month: '2024-08', owner: 135, community: 71, directory: 47, unverified: 24, total: 277 },
+  { month: '2024-09', owner: 148, community: 78, directory: 52, unverified: 23, total: 301 },
+  { month: '2024-10', owner: 160, community: 84, directory: 56, unverified: 22, total: 322 },
 ];


### PR DESCRIPTION
## Summary
- extend stats trends data with directory and unverified verification counts
- update stats page charts to display all four verification types with new legend colors
- refresh chart descriptions to cover the added verification types

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384b499260832898a571817ef62ff7)