### PR TITLE
Add loading and error handling to map and stats pages

### DIFF
--- a/lib/safeFetch.ts
+++ b/lib/safeFetch.ts
@@ -1,0 +1,33 @@
+export type SafeFetchOptions = RequestInit & {
+  retries?: number;
+  retryDelayMs?: number;
+};
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function safeFetch<T>(input: RequestInfo | URL, options: SafeFetchOptions = {}): Promise<T> {
+  const { retries = 2, retryDelayMs = 300, ...init } = options;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(input, init);
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      lastError = error;
+      if (attempt < retries) {
+        await wait(retryDelayMs);
+      }
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new Error("Request failed");
+}


### PR DESCRIPTION
## Summary
- add reusable safeFetch helper with retries for client data loading
- implement loading skeletons and retryable error UI for map and stats pages
- guard map rendering with visible placeholders while places load or fail

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ae09e757083288745dbc74f592ff9)