### PR TITLE
Implement map filters API and UI

### DIFF
--- a/app/api/filters/meta/route.ts
+++ b/app/api/filters/meta/route.ts
@@ -1,3 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { places } from "@/lib/data/places";
+import { deriveFilterMeta } from "@/lib/filters";
+
 export async function GET() {
-  return Response.json({ message: 'Filters meta API placeholder' });
+  const meta = deriveFilterMeta(places);
+  return NextResponse.json(meta);
 }

--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -1,7 +1,50 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 import { places } from "@/lib/data/places";
+import { normalizeCommaParams } from "@/lib/filters";
+import type { Place } from "@/types/places";
 
-export async function GET() {
-  return NextResponse.json(places);
+const getPlaceChains = (place: Place) =>
+  place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? [];
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+
+  const category = searchParams.get("category");
+  const country = searchParams.get("country");
+  const city = searchParams.get("city");
+  const chainFilters = normalizeCommaParams(searchParams.getAll("chain")).map((chain) => chain.toLowerCase());
+  const verificationFilters = normalizeCommaParams(searchParams.getAll("verification")) as Place["verification"][];
+
+  const hasChainFilters = chainFilters.length > 0;
+  const hasVerificationFilters = verificationFilters.length > 0;
+
+  const filtered = places.filter((place) => {
+    if (category && place.category !== category) {
+      return false;
+    }
+
+    if (country && place.country !== country) {
+      return false;
+    }
+
+    if (city && place.city !== city) {
+      return false;
+    }
+
+    if (hasChainFilters) {
+      const placeChains = getPlaceChains(place).map((chain) => chain.toLowerCase());
+      if (!chainFilters.some((chain) => placeChains.includes(chain))) {
+        return false;
+      }
+    }
+
+    if (hasVerificationFilters && !verificationFilters.includes(place.verification)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return NextResponse.json(filtered);
 }

--- a/components/map/FiltersPanel.tsx
+++ b/components/map/FiltersPanel.tsx
@@ -37,7 +37,10 @@ export function FiltersPanel({ filters, meta, onChange, onClear, disabled, showH
   };
 
   const isCityDisabled = !filters.country;
-  const cityOptions = filters.country && meta?.citiesByCountry[filters.country];
+  const cityOptions: string[] =
+    filters.country && meta?.citiesByCountry[filters.country]
+      ? meta.citiesByCountry[filters.country]
+      : [];
 
   return (
     <div className="flex flex-col gap-4">
@@ -128,17 +131,17 @@ export function FiltersPanel({ filters, meta, onChange, onClear, disabled, showH
             className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-50"
             value={filters.city ?? ""}
             onChange={(event) =>
-              onChange({ ...filters, city: event.target.value ? event.target.value : null })
-            }
-            disabled={disabled || isCityDisabled}
-          >
-            <option value="">All cities</option>
-            {cityOptions?.map((city) => (
-              <option key={city} value={city}>
-                {city}
-              </option>
-            ))}
-          </select>
+            onChange({ ...filters, city: event.target.value ? event.target.value : null })
+          }
+          disabled={disabled || isCityDisabled}
+        >
+          <option value="">All cities</option>
+          {cityOptions.map((city) => (
+            <option key={city} value={city}>
+              {city}
+            </option>
+          ))}
+        </select>
         </label>
       </div>
 

--- a/components/map/FiltersPanel.tsx
+++ b/components/map/FiltersPanel.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import type { ChangeEvent } from "react";
+
+import type { FilterMeta, FilterState } from "@/lib/filters";
+
+export type FiltersPanelProps = {
+  filters: FilterState;
+  meta: FilterMeta | null;
+  onChange: (next: FilterState) => void;
+  onClear: () => void;
+  disabled?: boolean;
+  showHeading?: boolean;
+};
+
+const VERIFICATION_LABELS: Record<string, string> = {
+  owner: "Owner",
+  community: "Community",
+  directory: "Directory",
+  unverified: "Unverified",
+};
+
+export function FiltersPanel({ filters, meta, onChange, onClear, disabled, showHeading = true }: FiltersPanelProps) {
+  const handleCheckboxChange = (
+    event: ChangeEvent<HTMLInputElement>,
+    key: "chains" | "verifications",
+    value: string,
+  ) => {
+    const current = new Set(filters[key]);
+    if (event.target.checked) {
+      current.add(value);
+    } else {
+      current.delete(value);
+    }
+
+    onChange({ ...filters, [key]: Array.from(current) });
+  };
+
+  const isCityDisabled = !filters.country;
+  const cityOptions = filters.country && meta?.citiesByCountry[filters.country];
+
+  return (
+    <div className="flex flex-col gap-4">
+      {showHeading && <h3 className="text-sm font-semibold text-gray-900">Filters</h3>}
+      <div className="grid grid-cols-1 gap-4 text-sm">
+        <label className="space-y-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">Category</span>
+          <select
+            className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={filters.category ?? ""}
+            onChange={(event) =>
+              onChange({ ...filters, category: event.target.value ? event.target.value : null })
+            }
+            disabled={disabled || !meta}
+          >
+            <option value="">All categories</option>
+            {meta?.categories.map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <fieldset className="space-y-2">
+          <legend className="text-xs font-semibold uppercase tracking-wide text-gray-600">Chain</legend>
+          <div className="grid max-h-32 grid-cols-2 gap-2 overflow-y-auto rounded-md border border-gray-200 bg-white p-3 text-sm shadow-inner">
+            {meta?.chains.map((chain) => (
+              <label key={chain} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  checked={filters.chains.includes(chain)}
+                  onChange={(event) => handleCheckboxChange(event, "chains", chain)}
+                  disabled={disabled}
+                />
+                <span>{chain}</span>
+              </label>
+            ))}
+            {!meta && <span className="text-xs text-gray-500">Loading options…</span>}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="text-xs font-semibold uppercase tracking-wide text-gray-600">Verification</legend>
+          <div className="grid grid-cols-1 gap-2 rounded-md border border-gray-200 bg-white p-3 shadow-inner">
+            {(meta?.verificationStatuses ?? Object.keys(VERIFICATION_LABELS)).map((status) => (
+              <label key={status} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  checked={filters.verifications.includes(status as FilterState["verifications"][number])}
+                  onChange={(event) => handleCheckboxChange(event, "verifications", status)}
+                  disabled={disabled}
+                />
+                <span className="capitalize">{VERIFICATION_LABELS[status] ?? status}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <label className="space-y-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">Country</span>
+          <select
+            className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={filters.country ?? ""}
+            onChange={(event) =>
+              onChange({
+                ...filters,
+                country: event.target.value ? event.target.value : null,
+                city: null,
+              })
+            }
+            disabled={disabled || !meta}
+          >
+            <option value="">All countries</option>
+            {meta?.countries.map((country) => (
+              <option key={country.code} value={country.code}>
+                {country.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="space-y-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">City</span>
+          <select
+            className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-gray-50"
+            value={filters.city ?? ""}
+            onChange={(event) =>
+              onChange({ ...filters, city: event.target.value ? event.target.value : null })
+            }
+            disabled={disabled || isCityDisabled}
+          >
+            <option value="">All cities</option>
+            {cityOptions?.map((city) => (
+              <option key={city} value={city}>
+                {city}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-gray-500">{meta ? "Options loaded" : "Loading filters…"}</span>
+        <button
+          type="button"
+          className="text-sm font-medium text-blue-600 underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:text-gray-400"
+          onClick={onClear}
+          disabled={disabled}
+        >
+          Clear filters
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default FiltersPanel;

--- a/lib/filters.ts
+++ b/lib/filters.ts
@@ -1,0 +1,143 @@
+import type { Place } from "@/types/places";
+
+type CountryNameMap = Record<string, string>;
+
+const COUNTRY_NAMES: CountryNameMap = {
+  JP: "Japan",
+  US: "United States",
+  FR: "France",
+  AU: "Australia",
+  CA: "Canada",
+};
+
+export type FilterMeta = {
+  categories: string[];
+  chains: string[];
+  countries: { code: string; name: string }[];
+  citiesByCountry: Record<string, string[]>;
+  verificationStatuses: Place["verification"][];
+};
+
+export const deriveFilterMeta = (places: Place[]): FilterMeta => {
+  const categorySet = new Set<string>();
+  const chainSet = new Set<string>();
+  const countrySet = new Set<string>();
+  const citiesMap = new Map<string, Set<string>>();
+  const verificationSet = new Set<Place["verification"]>();
+
+  places.forEach((place) => {
+    if (place.category) categorySet.add(place.category);
+    (place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? []).forEach((chain) => {
+      chainSet.add(chain);
+    });
+    if (place.country) {
+      countrySet.add(place.country);
+      if (!citiesMap.has(place.country)) {
+        citiesMap.set(place.country, new Set());
+      }
+      if (place.city) {
+        citiesMap.get(place.country)?.add(place.city);
+      }
+    }
+    verificationSet.add(place.verification);
+  });
+
+  const countries = Array.from(countrySet)
+    .sort()
+    .map((code) => ({ code, name: COUNTRY_NAMES[code] ?? code }));
+
+  const citiesByCountry: Record<string, string[]> = {};
+  citiesMap.forEach((cities, code) => {
+    citiesByCountry[code] = Array.from(cities).sort((a, b) => a.localeCompare(b));
+  });
+
+  return {
+    categories: Array.from(categorySet).sort((a, b) => a.localeCompare(b)),
+    chains: Array.from(chainSet).sort((a, b) => a.localeCompare(b)),
+    countries,
+    citiesByCountry,
+    verificationStatuses: Array.from(verificationSet).sort(),
+  };
+};
+
+export type FilterState = {
+  category: string | null;
+  chains: string[];
+  verifications: Place["verification"][];
+  country: string | null;
+  city: string | null;
+};
+
+export const defaultFilterState: FilterState = {
+  category: null,
+  chains: [],
+  verifications: [],
+  country: null,
+  city: null,
+};
+
+export const normalizeCommaParams = (values: string[]): string[] =>
+  values
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+export const buildQueryFromFilters = (filters: FilterState): string => {
+  const params = new URLSearchParams();
+
+  if (filters.category) {
+    params.set("category", filters.category);
+  }
+  if (filters.chains.length) {
+    params.set("chain", filters.chains.join(","));
+  }
+  if (filters.verifications.length) {
+    params.set("verification", filters.verifications.join(","));
+  }
+  if (filters.country) {
+    params.set("country", filters.country);
+  }
+  if (filters.city) {
+    params.set("city", filters.city);
+  }
+
+  const queryString = params.toString();
+  return queryString ? `?${queryString}` : "";
+};
+
+export const parseFiltersFromSearchParams = (
+  searchParams: URLSearchParams,
+  meta?: FilterMeta,
+): FilterState => {
+  const availableCategories = new Set(meta?.categories ?? []);
+  const availableChains = new Set(meta?.chains ?? []);
+  const availableVerifications = new Set(meta?.verificationStatuses ?? []);
+  const availableCountries = new Set((meta?.countries ?? []).map((c) => c.code));
+
+  const category = searchParams.get("category");
+  const country = searchParams.get("country");
+  const city = searchParams.get("city");
+
+  const chains = normalizeCommaParams(searchParams.getAll("chain"));
+  const verifications = normalizeCommaParams(searchParams.getAll("verification")) as FilterState["verifications"];
+
+  const filteredCategory = category && (!availableCategories.size || availableCategories.has(category)) ? category : null;
+  const filteredCountry = country && (!availableCountries.size || availableCountries.has(country)) ? country : null;
+  const filteredChains = chains.filter((chain) => !availableChains.size || availableChains.has(chain));
+  const filteredVerifications = verifications.filter(
+    (verification) => !availableVerifications.size || availableVerifications.has(verification),
+  ) as FilterState["verifications"];
+
+  const filteredCity =
+    city && filteredCountry && (!meta?.citiesByCountry[filteredCountry] || meta.citiesByCountry[filteredCountry].includes(city))
+      ? city
+      : null;
+
+  return {
+    category: filteredCategory,
+    chains: filteredChains,
+    verifications: filteredVerifications,
+    country: filteredCountry,
+    city: filteredCity,
+  };
+};


### PR DESCRIPTION
## Summary
- implement filter metadata endpoint derived from place data and add filtering support to /api/places
- add shared filter utilities and panels for map experience with desktop and mobile controls
- synchronize filter state with URL and refresh map markers, lists, and centering based on selections

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d58f0f5e8832881fc688796bc046a)