### PR TITLE
Stabilize map filter layout detection

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -143,16 +143,18 @@ export default function MapClient() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const updateViewport = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-      setViewportReady(true);
+    const measureViewport = () => window.innerWidth < MOBILE_BREAKPOINT;
+    const handleResize = () => {
+      setIsMobile(measureViewport());
     };
 
-    updateViewport();
-    window.addEventListener("resize", updateViewport);
+    setIsMobile(measureViewport());
+    setViewportReady(true);
+
+    window.addEventListener("resize", handleResize);
 
     return () => {
-      window.removeEventListener("resize", updateViewport);
+      window.removeEventListener("resize", handleResize);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- ensure the map page waits for a measured viewport before rendering filter UI
- update viewport detection to set layout mode from the first client measurement and keep it in sync on resize

## Root cause
- `MapClient` set `viewportReady` during the resize handler and also in the initial measurement, allowing an initial render with the default `isMobile` value before measurement completed. This could briefly render the desktop sidebar on mobile before the measurement flipped the layout.

## Fix
- gate `viewportReady` until after the first client-side viewport measurement and track `isMobile` off that measurement and subsequent resizes to avoid mismatched SSR/client layout

## Testing
- CI=1 npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e903ee50c83289cc202bb23fc36da)