### PR TITLE
Simplify mobile filter toggle on map

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -74,7 +74,10 @@ export default function MapClient() {
   const [filtersOpen, setFiltersOpen] = useState(false);
   const hasHydratedFiltersRef = useRef(false);
 
-  const openFilters = useCallback(() => setFiltersOpen(true), []);
+  const toggleFilters = useCallback(
+    () => setFiltersOpen((previous) => !previous),
+    [],
+  );
   const closeFilters = useCallback(() => setFiltersOpen(false), []);
 
   const openDrawerForPlace = useCallback((placeId: string) => {
@@ -487,7 +490,7 @@ export default function MapClient() {
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={openFilters}
+              onClick={toggleFilters}
               className="flex items-center gap-2 rounded-full border border-gray-200 bg-white/95 px-4 py-2 text-sm font-semibold text-gray-800 shadow-sm backdrop-blur"
             >
               <span>Filters</span>


### PR DESCRIPTION
## Summary
- toggle the mobile filters panel directly from the Filters button without viewport detection logic
- keep desktop and mobile filter UIs present with Tailwind visibility only

## Testing
- CI=1 npm run build

## Manual Testing
1. Desktop (width ≥1280px)
   - Open `/map`; Filters sidebar stays visible on the left with map on the right.
   - Reload; sidebar does not disappear or flash mobile UI.
2. Mobile (width ≈360px via DevTools)
   - Open `/map`; map plus Filters button show, sidebar stays hidden.
   - Filters panel stays hidden until the Filters button is tapped; tapping closes/opens it.
   - Reload; no momentary flash of the filters panel.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ec049b7488328b56d56c96d749ffd)