### PR TITLE
Ensure mobile filters toggle remains visible on mobile map

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -486,11 +486,12 @@ export default function MapClient() {
             </button>
           </div>
         )}
-        <div className="absolute inset-x-0 top-2 z-[60] flex justify-center lg:hidden">
-          <div className="flex items-center gap-2">
+        <div className="pointer-events-none fixed inset-x-0 top-2 z-[60] flex justify-center lg:hidden">
+          <div className="flex items-center gap-2 pointer-events-auto">
             <button
               type="button"
               onClick={toggleFilters}
+              data-testid="map-filters-toggle"
               className="flex items-center gap-2 rounded-full border border-gray-200 bg-white/95 px-4 py-2 text-sm font-semibold text-gray-800 shadow-sm backdrop-blur"
             >
               <span>Filters</span>


### PR DESCRIPTION
## Summary
- keep the map filters toggle fixed and always rendered on mobile breakpoints
- add a data-testid to the mobile filters toggle for easier debugging

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ed72c5de8832897bec445ebee79ac)