### PR TITLE
Add submit page and dummy submission endpoints

### DIFF
--- a/app/api/submissions/community/route.ts
+++ b/app/api/submissions/community/route.ts
@@ -1,0 +1,5 @@
+import { handleSubmission } from "@/lib/submissions";
+
+export async function POST(request: Request) {
+  return handleSubmission(request, "community");
+}

--- a/app/api/submissions/owner/route.ts
+++ b/app/api/submissions/owner/route.ts
@@ -1,0 +1,5 @@
+import { handleSubmission } from "@/lib/submissions";
+
+export async function POST(request: Request) {
+  return handleSubmission(request, "owner");
+}

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -1,0 +1,534 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+import type { NormalizedPlace, SubmissionKind } from "@/lib/submissions";
+import type { FilterMeta } from "@/lib/filters";
+
+type FormState = {
+  name: string;
+  country: string;
+  city: string;
+  address: string;
+  category: string;
+  accepted: string[];
+  about: string;
+  paymentNote: string;
+  website: string;
+  twitter: string;
+  instagram: string;
+  facebook: string;
+  lat: string;
+  lng: string;
+  submitterName: string;
+  submitterEmail: string;
+  role: string;
+  notesForAdmin: string;
+};
+
+type SubmissionResponse = {
+  status: string;
+  normalizedPlace: NormalizedPlace;
+};
+
+const initialFormState: FormState = {
+  name: "",
+  country: "",
+  city: "",
+  address: "",
+  category: "",
+  accepted: [],
+  about: "",
+  paymentNote: "",
+  website: "",
+  twitter: "",
+  instagram: "",
+  facebook: "",
+  lat: "",
+  lng: "",
+  submitterName: "",
+  submitterEmail: "",
+  role: "owner",
+  notesForAdmin: "",
+};
+
+const emailRegex = /[^@]+@[^.]+\..+/;
+
+const fieldLabel = (label: string) => <span className="text-sm font-medium text-gray-800">{label}</span>;
+
+export default function SubmitPage() {
+  const [mode, setMode] = useState<SubmissionKind>("owner");
+  const [formState, setFormState] = useState<FormState>(initialFormState);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [preview, setPreview] = useState<NormalizedPlace | null>(null);
+  const [meta, setMeta] = useState<FilterMeta | null>(null);
+
+  useEffect(() => {
+    const loadMeta = async () => {
+      try {
+        const res = await fetch("/api/filters/meta");
+        if (!res.ok) throw new Error("Failed to load meta");
+        const data = (await res.json()) as FilterMeta;
+        setMeta(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    loadMeta();
+  }, []);
+
+  const citiesForCountry = useMemo(() => {
+    if (!meta) return [];
+    return meta.citiesByCountry[formState.country] ?? [];
+  }, [meta, formState.country]);
+
+  const handleInputChange = (
+    field: keyof FormState,
+    value: string | string[] | ((prev: FormState) => FormState),
+  ) => {
+    setFormState((prev) => {
+      if (typeof value === "function") {
+        return (value as (p: FormState) => FormState)(prev);
+      }
+      return { ...prev, [field]: value } as FormState;
+    });
+  };
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {};
+    if (!formState.name.trim()) newErrors.name = "Required / 必須";
+    if (!formState.country.trim()) newErrors.country = "Required / 必須";
+    if (!formState.city.trim()) newErrors.city = "Required / 必須";
+    if (!formState.address.trim()) newErrors.address = "Required / 必須";
+    if (!formState.category.trim()) newErrors.category = "Required / 必須";
+    if (!formState.accepted.length) newErrors.accepted = "Select at least one / 1つ以上選択";
+    if (!formState.submitterName.trim()) newErrors.submitterName = "Required / 必須";
+    if (!formState.submitterEmail.trim()) {
+      newErrors.submitterEmail = "Required / 必須";
+    } else if (!emailRegex.test(formState.submitterEmail)) {
+      newErrors.submitterEmail = "Invalid email";
+    }
+    if (formState.lat && Number.isNaN(Number(formState.lat))) newErrors.lat = "Invalid number";
+    if (formState.lng && Number.isNaN(Number(formState.lng))) newErrors.lng = "Invalid number";
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setServerError(null);
+    setSuccessMessage(null);
+
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+
+    const payload = {
+      kind: mode,
+      place: {
+        name: formState.name,
+        country: formState.country,
+        city: formState.city,
+        address: formState.address,
+        category: formState.category,
+        accepted: formState.accepted,
+        about: formState.about || undefined,
+        paymentNote: formState.paymentNote || undefined,
+        website: formState.website || undefined,
+        twitter: formState.twitter || undefined,
+        instagram: formState.instagram || undefined,
+        facebook: formState.facebook || undefined,
+        lat: formState.lat ? Number(formState.lat) : undefined,
+        lng: formState.lng ? Number(formState.lng) : undefined,
+      },
+      submitter: {
+        name: formState.submitterName,
+        email: formState.submitterEmail,
+        role: formState.role,
+        notesForAdmin: formState.notesForAdmin || undefined,
+      },
+    };
+
+    try {
+      const endpoint = mode === "owner" ? "/api/submissions/owner" : "/api/submissions/community";
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({}));
+        throw new Error(error?.error || "Submission failed");
+      }
+
+      const data = (await res.json()) as SubmissionResponse;
+      setSuccessMessage("Submission received / 送信しました");
+      setPreview(data.normalizedPlace);
+    } catch (error) {
+      console.error(error);
+      setServerError("Submission failed. Please try again / 送信に失敗しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const resetForm = () => {
+    setFormState(initialFormState);
+    setPreview(null);
+    setSuccessMessage(null);
+    setServerError(null);
+    setErrors({});
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold text-gray-900">Submit a crypto-friendly place</h1>
+          <p className="text-gray-600">店舗情報の登録 / 更新リクエスト</p>
+        </div>
+
+        <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-2">
+          <p className="text-gray-800 font-semibold">Choose submitter type / 投稿者を選択</p>
+          <div className="flex space-x-2">
+            <button
+              type="button"
+              onClick={() => setMode("owner")}
+              className={`px-4 py-2 rounded-md border ${
+                mode === "owner" ? "bg-blue-600 text-white border-blue-600" : "bg-white text-gray-800"
+              }`}
+            >
+              Owner / 店舗オーナー
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("community")}
+              className={`px-4 py-2 rounded-md border ${
+                mode === "community" ? "bg-blue-600 text-white border-blue-600" : "bg-white text-gray-800"
+              }`}
+            >
+              Community / コミュニティ
+            </button>
+          </div>
+          <p className="text-sm text-gray-700">
+            {mode === "owner"
+              ? "For store owners / staff to request verification or updates. 店舗オーナー・スタッフ向けの申請フォーム"
+              : "For customers and fans to recommend a place. 常連客・ファン向けの推薦フォーム"}
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-4">
+            <div className="space-y-1">
+              {fieldLabel("Store name / 店舗名 (required)")}
+              <input
+                type="text"
+                className="w-full rounded-md border px-3 py-2"
+                value={formState.name}
+                onChange={(e) => handleInputChange("name", e.target.value)}
+              />
+              {errors.name && <p className="text-red-600 text-sm">{errors.name}</p>}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                {fieldLabel("Country / 国 (required)")}
+                <select
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.country}
+                  onChange={(e) => handleInputChange("country", e.target.value)}
+                >
+                  <option value="">Select / 選択</option>
+                  {meta?.countries.map((c) => (
+                    <option key={c.code} value={c.code}>
+                      {c.name} ({c.code})
+                    </option>
+                  ))}
+                </select>
+                {errors.country && <p className="text-red-600 text-sm">{errors.country}</p>}
+              </div>
+
+              <div className="space-y-1">
+                {fieldLabel("City / 市区町村 (required)")}
+                {citiesForCountry.length ? (
+                  <select
+                    className="w-full rounded-md border px-3 py-2"
+                    value={formState.city}
+                    onChange={(e) => handleInputChange("city", e.target.value)}
+                  >
+                    <option value="">Select / 選択</option>
+                    {citiesForCountry.map((city) => (
+                      <option key={city} value={city}>
+                        {city}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    type="text"
+                    className="w-full rounded-md border px-3 py-2"
+                    value={formState.city}
+                    onChange={(e) => handleInputChange("city", e.target.value)}
+                  />
+                )}
+                {errors.city && <p className="text-red-600 text-sm">{errors.city}</p>}
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              {fieldLabel("Address / 住所 (required)")}
+              <input
+                type="text"
+                className="w-full rounded-md border px-3 py-2"
+                value={formState.address}
+                onChange={(e) => handleInputChange("address", e.target.value)}
+              />
+              {errors.address && <p className="text-red-600 text-sm">{errors.address}</p>}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                {fieldLabel("Category / カテゴリー (required)")}
+                <select
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.category}
+                  onChange={(e) => handleInputChange("category", e.target.value)}
+                >
+                  <option value="">Select / 選択</option>
+                  {meta?.categories.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {cat}
+                    </option>
+                  ))}
+                </select>
+                {errors.category && <p className="text-red-600 text-sm">{errors.category}</p>}
+              </div>
+
+              <div className="space-y-1">
+                {fieldLabel("Accepted crypto / 受け入れ (required)")}
+                <div className="flex flex-wrap gap-2">
+                  {meta?.chains.map((chain) => (
+                    <label key={chain} className="flex items-center space-x-2 border rounded px-2 py-1">
+                      <input
+                        type="checkbox"
+                        checked={formState.accepted.includes(chain)}
+                        onChange={(e) => {
+                          const checked = e.target.checked;
+                          handleInputChange("accepted", (prev) => ({
+                            ...prev,
+                            accepted: checked
+                              ? [...prev.accepted, chain]
+                              : prev.accepted.filter((c) => c !== chain),
+                          }));
+                        }}
+                      />
+                      <span>{chain}</span>
+                    </label>
+                  ))}
+                </div>
+                {errors.accepted && <p className="text-red-600 text-sm">{errors.accepted}</p>}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                {fieldLabel("Latitude (optional)")}
+                <input
+                  type="text"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.lat}
+                  onChange={(e) => handleInputChange("lat", e.target.value)}
+                  placeholder="35.680"
+                />
+                {errors.lat && <p className="text-red-600 text-sm">{errors.lat}</p>}
+              </div>
+              <div className="space-y-1">
+                {fieldLabel("Longitude (optional)")}
+                <input
+                  type="text"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.lng}
+                  onChange={(e) => handleInputChange("lng", e.target.value)}
+                  placeholder="139.760"
+                />
+                {errors.lng && <p className="text-red-600 text-sm">{errors.lng}</p>}
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              {fieldLabel("About / 店舗紹介 (optional)")}
+              <textarea
+                className="w-full rounded-md border px-3 py-2"
+                rows={3}
+                value={formState.about}
+                onChange={(e) => handleInputChange("about", e.target.value)}
+                maxLength={600}
+              />
+            </div>
+
+            <div className="space-y-1">
+              {fieldLabel("Payment note / 支払いメモ (optional)")}
+              <input
+                type="text"
+                className="w-full rounded-md border px-3 py-2"
+                value={formState.paymentNote}
+                onChange={(e) => handleInputChange("paymentNote", e.target.value)}
+                maxLength={150}
+              />
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                {fieldLabel("Website")}
+                <input
+                  type="text"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.website}
+                  onChange={(e) => handleInputChange("website", e.target.value)}
+                  placeholder="https://..."
+                />
+              </div>
+              <div className="space-y-1">
+                {fieldLabel("Twitter / X")}
+                <input
+                  type="text"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.twitter}
+                  onChange={(e) => handleInputChange("twitter", e.target.value)}
+                  placeholder="@handle"
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                {fieldLabel("Instagram")}
+                <input
+                  type="text"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.instagram}
+                  onChange={(e) => handleInputChange("instagram", e.target.value)}
+                  placeholder="@handle"
+                />
+              </div>
+              <div className="space-y-1">
+                {fieldLabel("Facebook")}
+                <input
+                  type="text"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.facebook}
+                  onChange={(e) => handleInputChange("facebook", e.target.value)}
+                  placeholder="https://facebook.com/..."
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-4">
+            <h2 className="text-lg font-semibold text-gray-900">Submitter info / 申請者情報</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                {fieldLabel("Name / お名前 (required)")}
+                <input
+                  type="text"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.submitterName}
+                  onChange={(e) => handleInputChange("submitterName", e.target.value)}
+                />
+                {errors.submitterName && <p className="text-red-600 text-sm">{errors.submitterName}</p>}
+              </div>
+              <div className="space-y-1">
+                {fieldLabel("Email (required)")}
+                <input
+                  type="email"
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.submitterEmail}
+                  onChange={(e) => handleInputChange("submitterEmail", e.target.value)}
+                />
+                {errors.submitterEmail && <p className="text-red-600 text-sm">{errors.submitterEmail}</p>}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-1">
+                {fieldLabel("Role / 役割")}
+                <select
+                  className="w-full rounded-md border px-3 py-2"
+                  value={formState.role}
+                  onChange={(e) => handleInputChange("role", e.target.value)}
+                >
+                  <option value="owner">Owner / オーナー</option>
+                  <option value="staff">Staff / スタッフ</option>
+                  <option value="customer">Customer / 常連</option>
+                  <option value="other">Other / その他</option>
+                </select>
+              </div>
+              <div className="space-y-1">
+                {fieldLabel("Notes for admin / 補足")}
+                <textarea
+                  className="w-full rounded-md border px-3 py-2"
+                  rows={2}
+                  maxLength={300}
+                  value={formState.notesForAdmin}
+                  onChange={(e) => handleInputChange("notesForAdmin", e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+
+          {serverError && (
+            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-red-800">
+              {serverError}
+            </div>
+          )}
+          {successMessage && (
+            <div className="rounded-md border border-green-200 bg-green-50 p-3 text-green-800">
+              {successMessage}
+            </div>
+          )}
+
+          <div className="flex items-center space-x-3">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-blue-600 text-white px-4 py-2 font-semibold disabled:opacity-60"
+            >
+              {isSubmitting ? "Submitting..." : "Submit / 送信"}
+            </button>
+            <button type="button" onClick={resetForm} className="text-sm text-gray-600 underline">
+              Send another / もう一度入力
+            </button>
+          </div>
+        </form>
+
+        {preview && (
+          <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-2">
+            <h3 className="text-lg font-semibold text-gray-900">Preview (normalized)</h3>
+            <p className="text-sm text-gray-700">Verification: {preview.verification}</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-gray-800">
+              <div>
+                <p className="font-semibold">{preview.name}</p>
+                <p className="text-sm text-gray-700">
+                  {preview.city}, {preview.country}
+                </p>
+                <p className="text-sm text-gray-700">{preview.address}</p>
+                <p className="text-sm text-gray-700">Category: {preview.category}</p>
+              </div>
+              <div className="space-y-1 text-sm text-gray-700">
+                <p>Accepted: {preview.accepted.join(", ")}</p>
+                {preview.about && <p>About: {preview.about}</p>}
+                {preview.paymentNote && <p>Payment note: {preview.paymentNote}</p>}
+                <p>Submitter: {preview.submitterName}</p>
+                <p>Email: {preview.submitterEmail}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from "next/server";
+
+export type SubmissionKind = "owner" | "community";
+
+export type SubmissionPlaceInput = {
+  name?: string;
+  country?: string;
+  city?: string;
+  address?: string;
+  category?: string;
+  lat?: unknown;
+  lng?: unknown;
+  accepted?: unknown;
+  about?: string;
+  paymentNote?: string;
+  website?: string;
+  twitter?: string;
+  instagram?: string;
+  facebook?: string;
+};
+
+export type SubmitterInput = {
+  name?: string;
+  email?: string;
+  role?: string;
+  notesForAdmin?: string;
+};
+
+export type SubmissionPayload = {
+  kind?: SubmissionKind;
+  place?: SubmissionPlaceInput;
+  submitter?: SubmitterInput;
+};
+
+export type NormalizedPlace = {
+  name: string;
+  country: string;
+  city: string;
+  address: string;
+  category: string;
+  accepted: string[];
+  verification: SubmissionKind;
+  updatedAt: string;
+  lat?: number;
+  lng?: number;
+  about?: string;
+  paymentNote?: string;
+  website?: string;
+  twitter?: string;
+  instagram?: string;
+  facebook?: string;
+  submitterName?: string;
+  submitterEmail?: string;
+};
+
+const ensureString = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value.trim();
+  return undefined;
+};
+
+const ensureStringArray = (value: unknown): string[] | undefined => {
+  if (Array.isArray(value)) {
+    const cleaned = value
+      .map((v) => (typeof v === "string" ? v.trim() : ""))
+      .filter(Boolean);
+    return cleaned.length ? cleaned : undefined;
+  }
+  return undefined;
+};
+
+const ensureNumber = (value: unknown): number | undefined => {
+  if (value === null || value === undefined || value === "") return undefined;
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : undefined;
+};
+
+export const validateAndNormalizeSubmission = (
+  payload: SubmissionPayload,
+  expectedKind: SubmissionKind,
+): { normalizedPlace: NormalizedPlace } | { error: string } => {
+  if (!payload || payload.kind !== expectedKind) {
+    return { error: "Invalid submission" };
+  }
+
+  const { place = {}, submitter = {} } = payload;
+
+  const name = ensureString(place.name);
+  const country = ensureString(place.country);
+  const city = ensureString(place.city);
+  const address = ensureString(place.address);
+  const category = ensureString(place.category);
+  const accepted = ensureStringArray(place.accepted);
+  const submitterName = ensureString(submitter.name);
+  const submitterEmail = ensureString(submitter.email);
+
+  if (!name || !country || !city || !address || !category || !accepted?.length || !submitterName || !submitterEmail) {
+    return { error: "Invalid submission" };
+  }
+
+  const normalizedPlace: NormalizedPlace = {
+    name,
+    country,
+    city,
+    address,
+    category,
+    accepted,
+    verification: expectedKind,
+    updatedAt: new Date().toISOString(),
+    about: ensureString(place.about),
+    paymentNote: ensureString(place.paymentNote),
+    website: ensureString(place.website),
+    twitter: ensureString(place.twitter),
+    instagram: ensureString(place.instagram),
+    facebook: ensureString(place.facebook),
+    lat: ensureNumber(place.lat),
+    lng: ensureNumber(place.lng),
+    submitterName,
+    submitterEmail,
+  };
+
+  return { normalizedPlace };
+};
+
+export const handleSubmission = async (request: Request, expectedKind: SubmissionKind) => {
+  try {
+    const payload = (await request.json()) as SubmissionPayload;
+    const result = validateAndNormalizeSubmission(payload, expectedKind);
+
+    if ("error" in result) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    console.log(`[submission] ${expectedKind}`, { normalizedPlace: result.normalizedPlace, submitter: payload.submitter });
+
+    return NextResponse.json({ status: "received", normalizedPlace: result.normalizedPlace });
+  } catch (error) {
+    console.error("[submission] error", error);
+    return NextResponse.json({ error: "Invalid submission" }, { status: 400 });
+  }
+};


### PR DESCRIPTION
## Summary
- add a new /submit client page with owner/community toggle, client validation, and preview
- add shared submission normalization helper and dummy owner/community API handlers
- use filter meta to populate form options and return normalized preview data

## Testing
- npm run lint
- CI=1 npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694027ef37048328bb7474e4fdc3266a)