### PR TITLE
Implement submissions API and wire submit form

### DIFF
--- a/app/api/submissions/community/route.ts
+++ b/app/api/submissions/community/route.ts
@@ -1,5 +1,5 @@
-import { handleSubmission } from "@/lib/submissions";
+import { handleLegacySubmission } from "@/lib/submissions";
 
 export async function POST(request: Request) {
-  return handleSubmission(request, "community");
+  return handleLegacySubmission(request, "community");
 }

--- a/app/api/submissions/owner/route.ts
+++ b/app/api/submissions/owner/route.ts
@@ -1,5 +1,5 @@
-import { handleSubmission } from "@/lib/submissions";
+import { handleLegacySubmission } from "@/lib/submissions";
 
 export async function POST(request: Request) {
-  return handleSubmission(request, "owner");
+  return handleLegacySubmission(request, "owner");
 }

--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -1,0 +1,5 @@
+import { handleUnifiedSubmission } from "@/lib/submissions";
+
+export async function POST(request: Request) {
+  return handleUnifiedSubmission(request);
+}


### PR DESCRIPTION
## Summary
- add unified /api/submissions endpoint that validates and stores submissions as JSON files with suggested IDs
- introduce submission normalization helpers and legacy handler reuse
- connect the /submit form to the new API and show clearer success/error feedback

## Testing
- npm run lint
- CI=1 npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694037fc11f4832882d4c90553f74d21)