### PR TITLE
Add minimal v3 DB compatibility migration

### DIFF
--- a/docs/internal/db-compat-check.md
+++ b/docs/internal/db-compat-check.md
@@ -35,3 +35,11 @@ npm run db:compat-check
 ## Next steps
 - If failures persist, compare against `docs/db-v3.0.md`
 - After fixes, re-run the command until it passes
+
+## If the check reports missing tables/columns
+If `pnpm db:compat-check` fails because tables or columns are missing, run the minimal compatibility migration and re-check:
+
+```bash
+pnpm db:migrate:compat
+pnpm db:compat-check
+```

--- a/migrations/compat_v3_min.sql
+++ b/migrations/compat_v3_min.sql
@@ -1,0 +1,60 @@
+-- Minimal compatibility migration for v3 schema expectations
+
+CREATE TABLE IF NOT EXISTS public.categories (
+  id TEXT PRIMARY KEY,
+  label TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Ensure places.lat/lng exist
+ALTER TABLE IF EXISTS public.places
+  ADD COLUMN IF NOT EXISTS lat DOUBLE PRECISION;
+
+ALTER TABLE IF EXISTS public.places
+  ADD COLUMN IF NOT EXISTS lng DOUBLE PRECISION;
+
+-- Backfill lat/lng from geom when missing
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'places'
+  ) THEN
+    UPDATE public.places
+    SET lat = ST_Y(geom::geometry)
+    WHERE lat IS NULL AND geom IS NOT NULL;
+
+    UPDATE public.places
+    SET lng = ST_X(geom::geometry)
+    WHERE lng IS NULL AND geom IS NOT NULL;
+  END IF;
+END$$;
+
+-- Ensure verification timestamps exist
+ALTER TABLE IF EXISTS public.verifications
+  ADD COLUMN IF NOT EXISTS last_checked TIMESTAMPTZ;
+
+ALTER TABLE IF EXISTS public.verifications
+  ADD COLUMN IF NOT EXISTS last_verified TIMESTAMPTZ;
+
+-- Optionally backfill last_checked/last_verified using updated_at when present
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'verifications'
+  ) AND EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'verifications'
+      AND column_name = 'updated_at'
+  ) THEN
+    UPDATE public.verifications
+    SET last_checked = updated_at
+    WHERE last_checked IS NULL;
+
+    UPDATE public.verifications
+    SET last_verified = updated_at
+    WHERE last_verified IS NULL;
+  END IF;
+END$$;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "npm run test:stats",
     "test:stats": "tsc --project tsconfig.test.json && node --test .tmp-tests/tests/*.js && rm -rf .tmp-tests",
-    "db:compat-check": "tsx scripts/db_compat_check.ts"
+    "db:compat-check": "tsx scripts/db_compat_check.ts",
+    "db:migrate:compat": "tsx scripts/db_apply_sql.ts migrations/compat_v3_min.sql"
   },
   "dependencies": {
     "leaflet": "^1.9.4",

--- a/scripts/db_apply_sql.ts
+++ b/scripts/db_apply_sql.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { Client } from 'pg';
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    console.error('Missing DATABASE_URL environment variable');
+    process.exit(1);
+  }
+
+  const fileArg = process.argv[2];
+  const sqlPath = fileArg ? path.resolve(fileArg) : path.join(process.cwd(), 'migrations/compat_v3_min.sql');
+  const sql = readFileSync(sqlPath, 'utf8');
+
+  const client = new Client({ connectionString });
+  await client.connect();
+
+  try {
+    await client.query('BEGIN');
+    await client.query(sql);
+    await client.query('COMMIT');
+    console.log(`Migration applied from ${sqlPath}`);
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    console.error('Migration failed:', error);
+    process.exitCode = 1;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error('Unexpected migration error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an idempotent SQL migration to create missing v3 schema pieces and backfill coordinates and verification timestamps safely
- add a lightweight TypeScript runner and package script to apply the compatibility migration
- document how to rerun the migration when db compatibility checks fail

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c193e27c83288687e4caea616c44)