### PR TITLE
Add promotion endpoint for approved submissions

### DIFF
--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -1,11 +1,126 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { getDbPool, hasDatabaseUrl } from "@/lib/db";
 import { places } from "@/lib/data/places";
 import { normalizeCommaParams } from "@/lib/filters";
 import type { Place } from "@/types/places";
 
 const getPlaceChains = (place: Place) =>
   place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? [];
+
+const loadPlacesFromDb = async (
+  filters: {
+    category: string | null;
+    country: string | null;
+    city: string | null;
+  },
+  chainFilters: string[],
+): Promise<Place[] | null> => {
+  if (!hasDatabaseUrl()) return null;
+
+  const pool = getDbPool();
+  const client = await pool.connect();
+
+  try {
+    const { rows: tableChecks } = await client.query<{
+      present: string | null;
+      verifications: string | null;
+      payments: string | null;
+    }>(
+      `SELECT
+        to_regclass('public.places') AS present,
+        to_regclass('public.verifications') AS verifications,
+        to_regclass('public.payment_accepts') AS payments`,
+    );
+
+    if (!tableChecks[0]?.present) {
+      return null;
+    }
+
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (filters.category) {
+      params.push(filters.category);
+      where.push(`p.category = $${params.length}`);
+    }
+    if (filters.country) {
+      params.push(filters.country);
+      where.push(`p.country = $${params.length}`);
+    }
+    if (filters.city) {
+      params.push(filters.city);
+      where.push(`p.city = $${params.length}`);
+    }
+
+    const hasVerifications = Boolean(tableChecks[0]?.verifications);
+    const hasPayments = Boolean(tableChecks[0]?.payments);
+
+    const verificationSelect = hasVerifications ? ", COALESCE(v.status, 'unverified') AS verification" : ", 'unverified'::text AS verification";
+    const paymentsSelect = hasPayments ? ", array_agg(DISTINCT pa.asset) FILTER (WHERE pa.asset IS NOT NULL) AS accepted_chains" : "";
+    const joinVerification = hasVerifications ? " LEFT JOIN verifications v ON v.place_id = p.id" : "";
+    const joinPayments = hasPayments ? " LEFT JOIN payment_accepts pa ON pa.place_id = p.id" : "";
+    const groupBy = hasPayments
+      ? `GROUP BY p.id, p.name, p.category, p.city, p.country, p.lat, p.lng, p.address, p.about${hasVerifications ? ", v.status" : ""}`
+      : "";
+
+    const query = `SELECT p.id, p.name, p.category, p.city, p.country, p.lat, p.lng, p.address, p.about${verificationSelect}${paymentsSelect}
+      FROM places p${joinVerification}${joinPayments}
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+      ${groupBy}`;
+
+    const { rows } = await client.query<{
+      id: string;
+      name: string;
+      category: string | null;
+      city: string | null;
+      country: string | null;
+      lat: number;
+      lng: number;
+      address: string | null;
+      about: string | null;
+      verification: Place["verification"];
+      accepted_chains?: string[] | null;
+    }>(query, params);
+
+    const mapped = rows.map((row) => {
+      const base: Place = {
+        id: row.id,
+        name: row.name,
+        category: row.category ?? "unknown",
+        verification: row.verification ?? "unverified",
+        lat: Number(row.lat),
+        lng: Number(row.lng),
+        country: row.country ?? "",
+        city: row.city ?? "",
+        address: row.address ?? undefined,
+        address_full: row.address ?? undefined,
+        about: row.about ?? undefined,
+      };
+
+      if (hasPayments) {
+        base.accepted = row.accepted_chains ?? undefined;
+      }
+
+      return base;
+    });
+
+    if (chainFilters.length === 0 || !hasPayments) {
+      return mapped;
+    }
+
+    const normalizedChains = chainFilters.map((chain) => chain.toLowerCase());
+    return mapped.filter((place) => {
+      const accepted = place.accepted ?? [];
+      const normalized = accepted.map((value) => value.toLowerCase());
+      return normalizedChains.some((chain) => normalized.includes(chain));
+    });
+  } catch (error) {
+    console.error("[places] failed to load from database", error);
+    return null;
+  } finally {
+    client.release();
+  }
+};
 
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
@@ -16,10 +131,13 @@ export async function GET(request: NextRequest) {
   const chainFilters = normalizeCommaParams(searchParams.getAll("chain")).map((chain) => chain.toLowerCase());
   const verificationFilters = normalizeCommaParams(searchParams.getAll("verification")) as Place["verification"][];
 
+  const dbPlaces = await loadPlacesFromDb({ category, country, city }, chainFilters);
+  const sourcePlaces = dbPlaces ?? places;
+
   const hasChainFilters = chainFilters.length > 0;
   const hasVerificationFilters = verificationFilters.length > 0;
 
-  const filtered = places.filter((place) => {
+  const filtered = sourcePlaces.filter((place) => {
     if (category && place.category !== category) {
       return false;
     }

--- a/app/api/submissions/[id]/promote/route.ts
+++ b/app/api/submissions/[id]/promote/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+
+import { getDbPool } from "@/lib/db";
+import { buildPlaceIdPrefix, submissionToPlace } from "@/lib/submission-to-place";
+import { loadSubmissionById, saveSubmission } from "@/lib/submissions";
+
+const tableExists = async (client: import("pg").PoolClient, table: string) => {
+  const { rows } = await client.query<{ present: string | null }>(
+    `SELECT to_regclass($1) AS present`,
+    [`public.${table}`],
+  );
+
+  return Boolean(rows[0]?.present);
+};
+
+const loadExistingIds = async (client: import("pg").PoolClient, prefix: string) => {
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT id FROM places WHERE id LIKE $1`,
+    [`${prefix}%`],
+  );
+
+  return rows.map((row) => row.id);
+};
+
+export async function POST(_request: Request, { params }: { params: { id: string } }) {
+  const { id } = params;
+
+  let submission;
+  try {
+    submission = await loadSubmissionById(id);
+  } catch {
+    return NextResponse.json({ error: "Submission not found" }, { status: 404 });
+  }
+
+  if (submission.status !== "approved") {
+    return NextResponse.json({ error: "Submission must be approved first" }, { status: 400 });
+  }
+
+  if (submission.linkedPlaceId) {
+    return NextResponse.json({ error: "Submission already linked to a place" }, { status: 400 });
+  }
+
+  let pool: ReturnType<typeof getDbPool>;
+  try {
+    pool = getDbPool();
+  } catch (error) {
+    console.error("[submissions] missing DATABASE_URL", error);
+    return NextResponse.json({ error: "Database is not configured" }, { status: 500 });
+  }
+
+  const client = await pool.connect();
+
+  try {
+    const placesTableExists = await tableExists(client, "places");
+    if (!placesTableExists) {
+      return NextResponse.json({ error: "places table is missing" }, { status: 500 });
+    }
+
+    const idPrefix = buildPlaceIdPrefix(submission);
+    const existingIds = await loadExistingIds(client, idPrefix);
+    let place: ReturnType<typeof submissionToPlace>;
+
+    try {
+      place = submissionToPlace(submission, { existingIds });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Invalid submission";
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    await client.query("BEGIN");
+
+    await client.query(
+      `INSERT INTO places (id, name, country, city, category, lat, lng, address, about, amenities)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        place.id,
+        place.name,
+        place.country,
+        place.city,
+        place.category,
+        place.lat,
+        place.lng,
+        place.address_full ?? place.address ?? null,
+        place.about ?? null,
+        place.amenities ? JSON.stringify(place.amenities) : null,
+      ],
+    );
+
+    const verificationsTableExists = await tableExists(client, "verifications");
+    if (verificationsTableExists) {
+      await client.query(
+        `INSERT INTO verifications (place_id, status, last_checked, last_verified)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (place_id) DO UPDATE SET status = EXCLUDED.status, last_checked = EXCLUDED.last_checked, last_verified = EXCLUDED.last_verified`,
+        [place.id, place.verification],
+      );
+    }
+
+    const paymentAcceptsExists = await tableExists(client, "payment_accepts");
+    if (paymentAcceptsExists && place.accepted?.length) {
+      for (const asset of place.accepted) {
+        await client.query(
+          `INSERT INTO payment_accepts (place_id, asset, chain)
+           VALUES ($1, $2, $3)
+           ON CONFLICT (place_id, asset, chain, method) DO NOTHING`,
+          [place.id, asset, asset],
+        );
+      }
+    }
+
+    await client.query("COMMIT");
+
+    const updatedSubmission = await saveSubmission({
+      ...submission,
+      linkedPlaceId: place.id,
+      promotedAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({ place, submission: updatedSubmission });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    console.error("[submissions] failed to promote", error);
+    return NextResponse.json({ error: "Failed to promote submission" }, { status: 500 });
+  } finally {
+    client.release();
+  }
+}
+

--- a/app/api/submissions/[id]/promote/route.ts
+++ b/app/api/submissions/[id]/promote/route.ts
@@ -64,6 +64,12 @@ export async function POST(_request: Request, { params }: { params: { id: string
       place = submissionToPlace(submission, { existingIds });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Invalid submission";
+      if (message.toLowerCase().includes("lat/lng")) {
+        return NextResponse.json(
+          { error: "Cannot promote: missing coordinates (lat/lng)." },
+          { status: 400 },
+        );
+      }
       return NextResponse.json({ error: message }, { status: 400 });
     }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,20 @@
+import { Pool } from "pg";
+
+let pool: Pool | null = null;
+
+export const hasDatabaseUrl = () => Boolean(process.env.DATABASE_URL);
+
+export const getDbPool = () => {
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is not configured");
+  }
+
+  if (!pool) {
+    pool = new Pool({ connectionString });
+  }
+
+  return pool;
+};
+

--- a/lib/submission-to-place.ts
+++ b/lib/submission-to-place.ts
@@ -1,0 +1,77 @@
+import type { Place } from "@/types/places";
+
+import type { StoredSubmission } from "./submissions";
+
+const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const findNextSuffix = (existingIds: string[], prefix: string) => {
+  const matcher = new RegExp(`^${escapeRegExp(prefix)}(\\d{3})$`);
+  const currentMax = existingIds.reduce((max, id) => {
+    const match = matcher.exec(id);
+    if (!match) return max;
+    return Math.max(max, Number.parseInt(match[1], 10));
+  }, 0);
+
+  return String(currentMax + 1).padStart(3, "0");
+};
+
+export const buildPlaceIdPrefix = (submission: StoredSubmission) => {
+  const country = slugify(submission.payload.country || "xx");
+  const citySlug = slugify(submission.payload.city || "city");
+  const placeSlug = slugify(submission.payload.name || "place");
+
+  return `cpm:${country}-${citySlug}-${placeSlug}-`;
+};
+
+export const submissionToPlace = (
+  submission: StoredSubmission,
+  options?: { existingIds?: string[] },
+): Place => {
+  const { payload } = submission;
+
+  if (!Number.isFinite(payload.lat) || !Number.isFinite(payload.lng)) {
+    throw new Error("Submission is missing coordinates");
+  }
+
+  const prefix = buildPlaceIdPrefix(submission);
+  const suffix = findNextSuffix(options?.existingIds ?? [], prefix);
+  const id = `${prefix}${suffix}`;
+
+  const verification: Place["verification"] =
+    payload.verificationRequest === "owner" ? "owner" : "community";
+
+  return {
+    id,
+    name: payload.name,
+    category: payload.category,
+    verification,
+    lat: payload.lat,
+    lng: payload.lng,
+    country: payload.country,
+    city: payload.city,
+    address_full: payload.address,
+    address: payload.address,
+    supported_crypto: payload.acceptedChains,
+    accepted: payload.acceptedChains,
+    about: payload.about ?? null,
+    paymentNote: payload.paymentNote ?? null,
+    social_website: payload.website ?? null,
+    social_twitter: payload.twitter ?? null,
+    social_instagram: payload.instagram ?? null,
+    website: payload.website ?? null,
+    twitter: payload.twitter ?? null,
+    instagram: payload.instagram ?? null,
+    facebook: payload.facebook ?? null,
+    amenities: payload.amenities ?? null,
+    submitterName: payload.contactName ?? null,
+  };
+};
+

--- a/lib/submission-to-place.ts
+++ b/lib/submission-to-place.ts
@@ -37,9 +37,18 @@ export const submissionToPlace = (
 ): Place => {
   const { payload } = submission;
 
-  if (!Number.isFinite(payload.lat) || !Number.isFinite(payload.lng)) {
-    throw new Error("Submission is missing coordinates");
+  const { lat: rawLat, lng: rawLng } = payload;
+  if (
+    typeof rawLat !== "number" ||
+    typeof rawLng !== "number" ||
+    !Number.isFinite(rawLat) ||
+    !Number.isFinite(rawLng)
+  ) {
+    throw new Error("Missing or invalid lat/lng");
   }
+
+  const lat = rawLat;
+  const lng = rawLng;
 
   const prefix = buildPlaceIdPrefix(submission);
   const suffix = findNextSuffix(options?.existingIds ?? [], prefix);
@@ -53,8 +62,8 @@ export const submissionToPlace = (
     name: payload.name,
     category: payload.category,
     verification,
-    lat: payload.lat,
-    lng: payload.lng,
+    lat,
+    lng,
     country: payload.country,
     city: payload.city,
     address_full: payload.address,


### PR DESCRIPTION
## Summary
- add submission-to-place converter that generates CPM-style place IDs and place payloads
- add API endpoint to promote approved submissions into the places table and persist linkage metadata
- fetch places from the database for map data and expose a Create Place action in the submissions UI

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942ccae3f1c8328be8153439f188a2a)