### PR TITLE
Fix places verification mapping

### DIFF
--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -8,6 +8,21 @@ import type { Place } from "@/types/places";
 const getPlaceChains = (place: Place) =>
   place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? [];
 
+const allowedVerificationLevels: Place["verification"][] = [
+  "unverified",
+  "owner",
+  "directory",
+  "community",
+];
+
+const sanitizeVerification = (value: string | null): Place["verification"] => {
+  if (value && allowedVerificationLevels.includes(value as Place["verification"])) {
+    return value as Place["verification"];
+  }
+
+  return "unverified";
+};
+
 const loadPlacesFromDb = async (
   filters: {
     category: string | null;
@@ -52,18 +67,47 @@ const loadPlacesFromDb = async (
       where.push(`p.city = $${params.length}`);
     }
 
+    where.push("p.lat IS NOT NULL");
+    where.push("p.lng IS NOT NULL");
+
     const hasVerifications = Boolean(tableChecks[0]?.verifications);
     const hasPayments = Boolean(tableChecks[0]?.payments);
 
-    const verificationSelect = hasVerifications ? ", COALESCE(v.status, 'unverified') AS verification" : ", 'unverified'::text AS verification";
+    const verificationColumns = hasVerifications
+      ? await client.query<{ column_name: string }>(
+          `SELECT column_name
+           FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'verifications' AND column_name IN ('level', 'status')`,
+        )
+      : null;
+
+    const hasVerificationLevel = Boolean(verificationColumns?.rows.some((row) => row.column_name === "level"));
+    const hasVerificationStatus = Boolean(verificationColumns?.rows.some((row) => row.column_name === "status"));
+
+    const verificationField = hasVerifications && hasVerificationLevel ? "v.level" : null;
+    const reviewField = hasVerifications && hasVerificationStatus ? "v.status" : null;
+
+    const verificationSelect = verificationField
+      ? `, COALESCE(${verificationField}, 'unverified') AS verification`
+      : ", 'unverified'::text AS verification";
+
+    const reviewSelect = reviewField ? `, ${reviewField} AS review_status` : ", NULL::text AS review_status";
+
     const paymentsSelect = hasPayments ? ", array_agg(DISTINCT pa.asset) FILTER (WHERE pa.asset IS NOT NULL) AS accepted_chains" : "";
     const joinVerification = hasVerifications ? " LEFT JOIN verifications v ON v.place_id = p.id" : "";
     const joinPayments = hasPayments ? " LEFT JOIN payment_accepts pa ON pa.place_id = p.id" : "";
-    const groupBy = hasPayments
-      ? `GROUP BY p.id, p.name, p.category, p.city, p.country, p.lat, p.lng, p.address, p.about${hasVerifications ? ", v.status" : ""}`
-      : "";
 
-    const query = `SELECT p.id, p.name, p.category, p.city, p.country, p.lat, p.lng, p.address, p.about${verificationSelect}${paymentsSelect}
+    const groupByColumns = ["p.id", "p.name", "p.category", "p.city", "p.country", "p.lat", "p.lng", "p.address", "p.about"];
+    if (verificationField) {
+      groupByColumns.push(verificationField);
+    }
+    if (reviewField) {
+      groupByColumns.push(reviewField);
+    }
+
+    const groupBy = hasPayments ? `GROUP BY ${Array.from(new Set(groupByColumns)).join(", ")}` : "";
+
+    const query = `SELECT p.id, p.name, p.category, p.city, p.country, p.lat, p.lng, p.address, p.about${verificationSelect}${reviewSelect}${paymentsSelect}
       FROM places p${joinVerification}${joinPayments}
       ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
       ${groupBy}`;
@@ -78,7 +122,8 @@ const loadPlacesFromDb = async (
       lng: number;
       address: string | null;
       about: string | null;
-      verification: Place["verification"];
+      verification: string | null;
+      review_status: string | null;
       accepted_chains?: string[] | null;
     }>(query, params);
 
@@ -87,19 +132,26 @@ const loadPlacesFromDb = async (
         id: row.id,
         name: row.name,
         category: row.category ?? "unknown",
-        verification: row.verification ?? "unverified",
+        verification: sanitizeVerification(row.verification),
         lat: Number(row.lat),
         lng: Number(row.lng),
         country: row.country ?? "",
         city: row.city ?? "",
-        address: row.address ?? undefined,
-        address_full: row.address ?? undefined,
-        about: row.about ?? undefined,
+        address: row.address ?? null,
+        address_full: row.address ?? null,
+        about: row.about ?? null,
+        paymentNote: null,
+        accepted: row.accepted_chains ?? [],
+        website: null,
+        phone: null,
+        twitter: null,
+        instagram: null,
+        facebook: null,
+        amenities: [],
+        submitterName: null,
+        images: [],
+        updatedAt: null,
       };
-
-      if (hasPayments) {
-        base.accepted = row.accepted_chains ?? undefined;
-      }
 
       return base;
     });
@@ -138,6 +190,15 @@ export async function GET(request: NextRequest) {
   const hasVerificationFilters = verificationFilters.length > 0;
 
   const filtered = sourcePlaces.filter((place) => {
+    if (
+      place.lat === null ||
+      place.lng === null ||
+      Number.isNaN(place.lat) ||
+      Number.isNaN(place.lng)
+    ) {
+      return false;
+    }
+
     if (category && place.category !== category) {
       return false;
     }

--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -8,36 +8,27 @@ import type { Place } from "@/types/places";
 const getPlaceChains = (place: Place) =>
   place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? [];
 
-const optionalStringKeys = [
-  "address",
-  "address_full",
-  "about",
-  "paymentNote",
-  "website",
-  "phone",
-  "twitter",
-  "instagram",
-  "facebook",
-  "submitterName",
-  "updatedAt",
-  "coverImage",
-  "description",
-  "social_twitter",
-  "social_instagram",
-  "social_website",
-] satisfies (keyof Place)[];
+const u = (v: string | null | undefined): string | undefined => v ?? undefined;
 
-const sanitizeOptionalStrings = (place: Place): Place => {
-  const sanitized = { ...place } as Place;
-
-  for (const key of optionalStringKeys) {
-    if (sanitized[key] === null) {
-      sanitized[key] = undefined as Place[typeof key];
-    }
-  }
-
-  return sanitized;
-};
+const sanitizeOptionalStrings = (place: Place): Place => ({
+  ...place,
+  address: u(place.address),
+  address_full: u(place.address_full),
+  about: u(place.about),
+  paymentNote: u(place.paymentNote),
+  website: u(place.website),
+  phone: u(place.phone),
+  twitter: u(place.twitter),
+  instagram: u(place.instagram),
+  facebook: u(place.facebook),
+  submitterName: u(place.submitterName),
+  updatedAt: u(place.updatedAt),
+  coverImage: u(place.coverImage),
+  description: u(place.description),
+  social_twitter: u(place.social_twitter),
+  social_instagram: u(place.social_instagram),
+  social_website: u(place.social_website),
+});
 
 const allowedVerificationLevels: Place["verification"][] = [
   "unverified",
@@ -163,26 +154,26 @@ const loadPlacesFromDb = async (
         id: row.id,
         name: row.name,
         category: row.category ?? "unknown",
-        verification: sanitizeVerification(row.verification),
-        lat: Number(row.lat),
-        lng: Number(row.lng),
-        country: row.country ?? "",
-        city: row.city ?? "",
-        address: row.address ?? undefined,
-        address_full: row.address ?? undefined,
-        about: row.about ?? undefined,
-        paymentNote: undefined,
-        accepted: row.accepted_chains ?? [],
-        website: undefined,
-        phone: undefined,
-        twitter: undefined,
-        instagram: undefined,
-        facebook: undefined,
-        amenities: [],
-        submitterName: undefined,
-        images: [],
-        updatedAt: undefined,
-      };
+      verification: sanitizeVerification(row.verification),
+      lat: Number(row.lat),
+      lng: Number(row.lng),
+      country: row.country ?? "",
+      city: row.city ?? "",
+      address: u(row.address),
+      address_full: u(row.address),
+      about: u(row.about),
+      paymentNote: undefined,
+      accepted: row.accepted_chains ?? [],
+      website: undefined,
+      phone: undefined,
+      twitter: undefined,
+      instagram: undefined,
+      facebook: undefined,
+      amenities: [],
+      submitterName: undefined,
+      images: [],
+      updatedAt: undefined,
+    };
 
       return base;
     });

--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -8,6 +8,37 @@ import type { Place } from "@/types/places";
 const getPlaceChains = (place: Place) =>
   place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? [];
 
+const optionalStringKeys = [
+  "address",
+  "address_full",
+  "about",
+  "paymentNote",
+  "website",
+  "phone",
+  "twitter",
+  "instagram",
+  "facebook",
+  "submitterName",
+  "updatedAt",
+  "coverImage",
+  "description",
+  "social_twitter",
+  "social_instagram",
+  "social_website",
+] satisfies (keyof Place)[];
+
+const sanitizeOptionalStrings = (place: Place): Place => {
+  const sanitized = { ...place } as Place;
+
+  for (const key of optionalStringKeys) {
+    if (sanitized[key] === null) {
+      sanitized[key] = undefined as Place[typeof key];
+    }
+  }
+
+  return sanitized;
+};
+
 const allowedVerificationLevels: Place["verification"][] = [
   "unverified",
   "owner",
@@ -137,20 +168,20 @@ const loadPlacesFromDb = async (
         lng: Number(row.lng),
         country: row.country ?? "",
         city: row.city ?? "",
-        address: row.address ?? null,
-        address_full: row.address ?? null,
-        about: row.about ?? null,
-        paymentNote: null,
+        address: row.address ?? undefined,
+        address_full: row.address ?? undefined,
+        about: row.about ?? undefined,
+        paymentNote: undefined,
         accepted: row.accepted_chains ?? [],
-        website: null,
-        phone: null,
-        twitter: null,
-        instagram: null,
-        facebook: null,
+        website: undefined,
+        phone: undefined,
+        twitter: undefined,
+        instagram: undefined,
+        facebook: undefined,
         amenities: [],
-        submitterName: null,
+        submitterName: undefined,
         images: [],
-        updatedAt: null,
+        updatedAt: undefined,
       };
 
       return base;
@@ -225,5 +256,5 @@ export async function GET(request: NextRequest) {
     return true;
   });
 
-  return NextResponse.json(filtered);
+  return NextResponse.json(filtered.map(sanitizeOptionalStrings));
 }


### PR DESCRIPTION
## Summary
- derive API verification from database verification level with a fallback to allowed values
- filter out places missing coordinates and return drawer-friendly DTO fields with defaults
- keep payment chain filtering compatible with database data

## Testing
- npm run build *(fails: dependencies unavailable from npm registry — `next` not installed due to 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948146b6d1c8328964a24e6663593e6)