### PR TITLE
Normalize payment accepts chains for place detail API

### DIFF
--- a/app/api/places/[id]/route.ts
+++ b/app/api/places/[id]/route.ts
@@ -96,8 +96,8 @@ const normalizeAccepted = (payments: PaymentAccept[], fallback?: string[]): stri
   const seen = new Set<string>();
 
   for (const payment of payments) {
-    const asset = payment.asset?.toUpperCase() ?? null;
-    const chain = payment.chain?.toUpperCase() ?? null;
+    const asset = payment.asset?.trim().toUpperCase() ?? null;
+    const chain = payment.chain?.trim().toUpperCase() ?? null;
     let label: string | null = null;
 
     if (chain === "LIGHTNING" || (asset === "BTC" && chain === "LIGHTNING")) {


### PR DESCRIPTION
## Summary
- trim asset and chain values from payment_accepts before building accepted assets for place detail responses, preventing empty or whitespace-only entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949690c4950832892226e15f3f2cd40)