### PR TITLE
Normalize accepted assets for places list

### DIFF
--- a/lib/places/normalizeAccepted.ts
+++ b/lib/places/normalizeAccepted.ts
@@ -1,0 +1,46 @@
+export type PaymentAccept = {
+  asset: string | null;
+  chain: string | null;
+};
+
+export const normalizeAccepted = (
+  payments: PaymentAccept[],
+  fallback?: string[],
+): string[] => {
+  if (payments.length === 0) {
+    return fallback ?? [];
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+
+  for (const payment of payments) {
+    const asset = payment.asset?.trim().toUpperCase() ?? null;
+    const chain = payment.chain?.trim().toUpperCase() ?? null;
+    let label: string | null = null;
+
+    if (
+      chain === "LIGHTNING" ||
+      chain === "LN" ||
+      asset === "LIGHTNING" ||
+      (asset === "BTC" && chain === "LIGHTNING")
+    ) {
+      label = "Lightning";
+    } else if (asset) {
+      label = asset;
+    } else if (chain) {
+      label = chain;
+    }
+
+    if (label && !seen.has(label)) {
+      seen.add(label);
+      normalized.push(label);
+    }
+  }
+
+  if (normalized.length === 0 && fallback?.length) {
+    return fallback;
+  }
+
+  return normalized;
+};


### PR DESCRIPTION
## Summary
- add a shared helper to normalize accepted assets from payment_accepts rows
- reuse the helper in the place detail endpoint
- compute list endpoint accepted assets from payment_accepts data so Lightning is included

## Testing
- npm run lint *(fails: `next` command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a9e6b9fb48328ba4ff54545daabaa)