### PR TITLE
Task 61: Add smoke command for Places APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "smoke": "node scripts/smoke.mjs",
     "test": "npm run test:stats",
     "test:stats": "tsc --project tsconfig.test.json && node --test .tmp-tests/tests/*.js && rm -rf .tmp-tests",
     "db:compat-check": "tsx scripts/db_compat_check.ts",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const PORT = Number(process.env.PORT ?? 3100);
+const BASE_URL = process.env.SMOKE_BASE_URL ?? `http://localhost:${PORT}`;
+
+const log = (message) => {
+  console.log(`[smoke] ${message}`);
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitForReady = async (url, { timeoutMs = 30000, intervalMs = 500 } = {}) => {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch (_) {
+      // ignore until ready
+    }
+    await sleep(intervalMs);
+  }
+
+  throw new Error(`timed out waiting for ${url}`);
+};
+
+const assertArrayEqual = (actual, expected, label) => {
+  if (!Array.isArray(actual)) {
+    throw new Error(`${label} accepted is not an array`);
+  }
+  if (actual.length !== expected.length) {
+    throw new Error(
+      `${label} accepted mismatch: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+  for (let i = 0; i < expected.length; i += 1) {
+    if (actual[i] !== expected[i]) {
+      throw new Error(
+        `${label} accepted mismatch: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+      );
+    }
+  }
+};
+
+const checkDetail = async (id, { verification, accepted }) => {
+  const response = await fetch(`${BASE_URL}/api/places/${id}`);
+  if (!response.ok) throw new Error(`detail ${id} returned ${response.status}`);
+
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error(`detail ${id} returned invalid JSON`);
+  }
+
+  if (!body || typeof body !== "object") throw new Error(`detail ${id} returned non-object JSON`);
+  if (body.verification !== verification) {
+    throw new Error(
+      `detail ${id} verification mismatch: expected ${verification}, got ${body.verification}`,
+    );
+  }
+
+  assertArrayEqual(body.accepted, accepted, `detail ${id}`);
+  log(`ok detail ${id}`);
+};
+
+const checkList = async () => {
+  const response = await fetch(`${BASE_URL}/api/places?country=AQ`);
+  if (!response.ok) throw new Error(`list country=AQ returned ${response.status}`);
+
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error("list country=AQ returned invalid JSON");
+  }
+
+  if (!Array.isArray(body)) throw new Error("list country=AQ returned non-array JSON");
+
+  const record = body.find((place) => place?.id === "antarctica-owner-1");
+  if (!record) throw new Error("list country=AQ missing antarctica-owner-1");
+
+  assertArrayEqual(record.accepted, ["BTC", "Lightning", "ETH", "USDT"], "list country=AQ");
+  log("ok list country=AQ");
+};
+
+const expectations = [
+  ["antarctica-owner-1", { verification: "owner", accepted: ["BTC", "Lightning", "ETH", "USDT"] }],
+  ["antarctica-community-1", { verification: "community", accepted: ["BTC", "ETH"] }],
+  ["antarctica-directory-1", { verification: "directory", accepted: ["BTC"] }],
+  ["antarctica-unverified-1", { verification: "unverified", accepted: ["BTC"] }],
+];
+
+const npmCmd = process.platform === "win32" ? "npm.cmd" : "npm";
+
+const main = async () => {
+  log(`starting dev server on :${PORT}`);
+
+  const serverProcess = spawn(npmCmd, ["run", "dev", "--", "-p", String(PORT)], {
+    env: { ...process.env, PORT: String(PORT) },
+    stdio: "inherit",
+    detached: true,
+  });
+
+  const cleanup = () => {
+    if (!serverProcess.pid) return;
+    try {
+      process.kill(-serverProcess.pid, "SIGTERM");
+    } catch (_) {
+      // ignore cleanup errors
+    }
+  };
+
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(1);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(1);
+  });
+
+  try {
+    await waitForReady(`${BASE_URL}/api/filters/meta`);
+    log("ready");
+
+    for (const [id, expected] of expectations) {
+      await checkDetail(id, expected);
+    }
+
+    await checkList();
+    log("PASS");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[smoke] FAIL: ${message}`);
+    process.exitCode = 1;
+  } finally {
+    cleanup();
+  }
+};
+
+main();


### PR DESCRIPTION
### Motivation
- Provide a single-command smoke check to validate the Places APIs are healthy and catch regressions in `accepted` normalization and preferred ordering.
- Reduce "it worked locally" mistakes by producing clear PASS/FAIL output from CI or developer machines using `npm run smoke`.
- Automate starting a local Next dev server, running quick API checks, and ensuring the server is stopped after the check.

### Description
- Added a `smoke` script entry to `package.json` as `"smoke": "node scripts/smoke.mjs"`.
- Added `scripts/smoke.mjs` which spawns `npm run dev` with `PORT=3100`, waits for readiness by polling `GET /api/filters/meta`, and then performs the required detail and list assertions.
- The script requests `GET /api/places/<id>` for the four expected IDs and checks JSON validity, `verification`, and ordered `accepted` arrays, and verifies `GET /api/places?country=AQ` contains `antarctica-owner-1` with the expected `accepted` order.
- The runner prints progress logs (e.g. `[smoke] starting dev server on :3100`, `[smoke] ready`, `ok detail ...`, `ok list country=AQ`, `[smoke] PASS`) and ensures cleanup by spawning the server with `detached: true` and killing the process group with `process.kill(-serverProcess.pid, 'SIGTERM')` in `finally`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e15a45e08328a7ddde18ecbf59d6)