### PR TITLE
Task 07 Run DB smoke checks in CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,5 +21,7 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
+      - name: Build app
+        run: npm run build
       - name: Run smoke
         run: npm run smoke

--- a/docs/dev-smoke.md
+++ b/docs/dev-smoke.md
@@ -19,6 +19,28 @@ Expected highlights:
 - Accepted assets are normalized via the shared helper used by both routes, so the sets match even when falling back to JSON data.
 - DB smoke-check prints the place row, payment_accepts entries, and any verification record for the requested id.
 
+## CI setup (DATABASE_URL secret)
+
+Smoke checks in GitHub Actions read `DATABASE_URL` from repository secrets.
+
+1. Open **Settings → Secrets and variables → Actions**.
+2. Click **New repository secret**.
+3. Name it `DATABASE_URL` and paste a connection string for your read-only DB user.
+
+Recommendations:
+- Use a read-only database user to avoid accidental writes.
+- Point to a stable environment (staging/replica) that matches production schema.
+- Keep the connection string minimal (host, db, user, password, sslmode as needed).
+
+Common failures:
+- **Missing env**: smoke job logs show `DATABASE_URL` is undefined. Add the secret in GitHub and re-run.
+- **Connection refused**: check firewall/IP allowlist, SSL requirements, and that the host is reachable from GitHub Actions.
+- **Schema mismatch**: look for migration-related errors in the smoke job output; update the DB or adjust the API expectations.
+
+Troubleshooting:
+- GitHub Actions logs → **Smoke** job → **Run smoke** step.
+- For local repro, export `DATABASE_URL` before running `npm run smoke`.
+
 ## Accepted assets ordering (DB-backed)
 
 Run dev server, then:
@@ -34,4 +56,3 @@ Expected:
 - community   ['BTC','ETH']
 - directory   ['BTC']
 - unverified  ['BTC']
-


### PR DESCRIPTION
### Motivation

- Run DB-backed smoke checks in CI so API behavior (especially `/api/places`) is validated against a real database before merging.
- Ensure the app is built in CI prior to running smoke checks to match production artifacts.
- Provide clear docs for adding the `DATABASE_URL` secret and common troubleshooting steps for maintainers.

### Description

- Expose `DATABASE_URL` from repository secrets to the smoke job by adding `env: DATABASE_URL: ${{ secrets.DATABASE_URL }}` in `.github/workflows/smoke.yml`.
- Add a build step (`npm run build`) to the smoke workflow and keep `npm ci` and `npm run smoke` as steps.
- Add `docs/dev-smoke.md` guidance for setting the `DATABASE_URL` Actions secret, recommend using a read-only DB user, and list common failures and where to inspect logs.

### Testing

- No automated tests were run locally; the changes are CI configuration and documentation only.
- The smoke workflow will run automatically on `pull_request` and `push` to `main` and requires the `DATABASE_URL` secret to exercise DB-backed checks.
- Repository linting and unit tests (if any) will continue to run in their respective workflows unaffected by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a00bf97483289d3e47f863da1dbb)