### PR TITLE
Task 02: DB connection stability — retry/backoff and safe 503 responses

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,6 +1,113 @@
-import { Pool } from "pg";
+import { Pool, type PoolClient } from "pg";
+
+const MAX_ATTEMPTS = 3;
+const RETRY_BACKOFF_MS = [200, 400];
 
 let pool: Pool | null = null;
+
+type Queryable = Pool | PoolClient;
+
+type DbQueryOptions = {
+  route: string;
+  client?: PoolClient;
+  retry?: boolean;
+};
+
+export class DbUnavailableError extends Error {
+  code: string;
+
+  constructor(message = "DB_UNAVAILABLE", options?: { cause?: unknown }) {
+    super(message);
+    this.name = "DbUnavailableError";
+    this.code = "DB_UNAVAILABLE";
+    if (options?.cause) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+const getErrorDetails = (error: unknown) => {
+  if (error && typeof error === "object") {
+    const err = error as { code?: string; message?: string; stack?: string };
+    return {
+      code: err.code,
+      message: err.message,
+      stack: err.stack,
+    };
+  }
+  return {
+    code: undefined,
+    message: String(error),
+    stack: undefined,
+  };
+};
+
+const sanitizeMessage = (message: string) =>
+  message
+    .replace(/postgres(?:ql)?:\/\/\S+/gi, "[redacted]")
+    .replace(/password=([^&\s]+)/gi, "password=***");
+
+const logDbFailure = (route: string, attempt: number, error: unknown) => {
+  const { code, message, stack } = getErrorDetails(error);
+  const payload = {
+    route,
+    attempt,
+    code,
+    message: message ? sanitizeMessage(message) : "Unknown database error",
+  };
+
+  if (process.env.NODE_ENV === "production") {
+    console.error("[db] query failed", payload);
+  } else {
+    console.error("[db] query failed", {
+      ...payload,
+      stack,
+    });
+  }
+};
+
+const isTransientDbError = (error: unknown) => {
+  const { code, message } = getErrorDetails(error);
+  if (code === "XX000") return true;
+
+  const normalized = (message ?? "").toLowerCase();
+  if (normalized.includes("control plane request failed")) return true;
+
+  if (code && ["ECONNRESET", "ETIMEDOUT", "EPIPE", "ECONNREFUSED"].includes(code)) {
+    return true;
+  }
+
+  return Boolean(
+    normalized.includes("connection terminated") ||
+      normalized.includes("connection reset") ||
+      normalized.includes("timeout"),
+  );
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const getPoolConfig = (connectionString: string) => {
+  const sslRequired = (() => {
+    try {
+      const url = new URL(connectionString);
+      const sslMode = url.searchParams.get("sslmode")?.toLowerCase();
+      const sslFlag = url.searchParams.get("ssl")?.toLowerCase();
+      if (sslFlag === "true") return true;
+      return Boolean(sslMode && ["require", "verify-ca", "verify-full"].includes(sslMode));
+    } catch {
+      return /sslmode=require|ssl=true/i.test(connectionString);
+    }
+  })();
+
+  return {
+    connectionString,
+    max: 4,
+    connectionTimeoutMillis: 7000,
+    idleTimeoutMillis: 20000,
+    ssl: sslRequired ? true : undefined,
+  };
+};
 
 export const hasDatabaseUrl = () => Boolean(process.env.DATABASE_URL);
 
@@ -12,9 +119,70 @@ export const getDbPool = () => {
   }
 
   if (!pool) {
-    pool = new Pool({ connectionString });
+    pool = new Pool(getPoolConfig(connectionString));
   }
 
   return pool;
 };
 
+export const isDbUnavailableError = (error: unknown): error is DbUnavailableError =>
+  error instanceof DbUnavailableError;
+
+export const getDbClient = async (route: string) => {
+  const poolInstance = getDbPool();
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      return await poolInstance.connect();
+    } catch (error) {
+      logDbFailure(route, attempt, error);
+
+      if (attempt < MAX_ATTEMPTS && isTransientDbError(error)) {
+        const backoff = RETRY_BACKOFF_MS[attempt - 1] ?? RETRY_BACKOFF_MS.at(-1) ?? 0;
+        await sleep(backoff);
+        continue;
+      }
+
+      if (isTransientDbError(error)) {
+        throw new DbUnavailableError("DB_UNAVAILABLE", { cause: error });
+      }
+
+      throw error;
+    }
+  }
+
+  throw new DbUnavailableError("DB_UNAVAILABLE");
+};
+
+export const dbQuery = async <T>(
+  text: string,
+  params: unknown[] = [],
+  options?: DbQueryOptions,
+) => {
+  const route = options?.route ?? "unknown";
+  const queryable: Queryable = options?.client ?? getDbPool();
+  const shouldRetry = options?.retry ?? true;
+  const attempts = shouldRetry ? MAX_ATTEMPTS : 1;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await queryable.query<T>(text, params);
+    } catch (error) {
+      logDbFailure(route, attempt, error);
+
+      if (attempt < attempts && isTransientDbError(error)) {
+        const backoff = RETRY_BACKOFF_MS[attempt - 1] ?? RETRY_BACKOFF_MS.at(-1) ?? 0;
+        await sleep(backoff);
+        continue;
+      }
+
+      if (isTransientDbError(error)) {
+        throw new DbUnavailableError("DB_UNAVAILABLE", { cause: error });
+      }
+
+      throw error;
+    }
+  }
+
+  throw new DbUnavailableError("DB_UNAVAILABLE");
+};

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,4 @@
-import { Pool, type PoolClient } from "pg";
+import { Pool, type PoolClient, type QueryResultRow } from "pg";
 
 const MAX_ATTEMPTS = 3;
 const RETRY_BACKOFF_MS = [200, 400];
@@ -21,8 +21,7 @@ export class DbUnavailableError extends Error {
     this.name = "DbUnavailableError";
     this.code = "DB_UNAVAILABLE";
     if (options?.cause) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      (this as { cause?: unknown }).cause = options.cause;
+      (this as Error & { cause?: unknown }).cause = options.cause;
     }
   }
 }
@@ -154,7 +153,7 @@ export const getDbClient = async (route: string) => {
   throw new DbUnavailableError("DB_UNAVAILABLE");
 };
 
-export const dbQuery = async <T>(
+export const dbQuery = async <T extends QueryResultRow = QueryResultRow>(
   text: string,
   params: unknown[] = [],
   options?: DbQueryOptions,

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
 import process from "node:process";
-import { normalizeAccepted } from "../lib/accepted.ts";
+import acceptedModule from "../lib/accepted.ts";
+
+const { normalizeAccepted } = acceptedModule;
 
 const PORT = Number(process.env.PORT ?? 3100);
 const BASE_URL = process.env.SMOKE_BASE_URL ?? `http://localhost:${PORT}`;

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -11,6 +11,34 @@ const log = (message) => {
 };
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const retryBackoffMs = [200, 400];
+
+const fetchWithRetry = async (url, options = {}, { label = url } = {}) => {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await fetch(url, options);
+      if (response.status !== 503) {
+        return response;
+      }
+
+      if (attempt === 3) {
+        return response;
+      }
+
+      log(`${label} returned 503 (attempt ${attempt}), retrying...`);
+    } catch (error) {
+      if (attempt === 3) {
+        throw error;
+      }
+      log(`${label} failed (attempt ${attempt}), retrying...`);
+    }
+
+    const backoff = retryBackoffMs[attempt - 1] ?? retryBackoffMs.at(-1) ?? 0;
+    await sleep(backoff);
+  }
+
+  throw new Error(`failed to fetch ${label}`);
+};
 
 const waitForReady = async (url, { timeoutMs = 30000, intervalMs = 500 } = {}) => {
   const deadline = Date.now() + timeoutMs;
@@ -74,7 +102,7 @@ const runUnitChecks = () => {
 };
 
 const checkDetail = async (id, { verification, accepted }) => {
-  const response = await fetch(`${BASE_URL}/api/places/${id}`);
+  const response = await fetchWithRetry(`${BASE_URL}/api/places/${id}`, {}, { label: `detail ${id}` });
   if (!response.ok) throw new Error(`detail ${id} returned ${response.status}`);
 
   let body;
@@ -96,7 +124,7 @@ const checkDetail = async (id, { verification, accepted }) => {
 };
 
 const checkList = async () => {
-  const response = await fetch(`${BASE_URL}/api/places?country=AQ`);
+  const response = await fetchWithRetry(`${BASE_URL}/api/places?country=AQ`, {}, { label: "list country=AQ" });
   if (!response.ok) throw new Error(`list country=AQ returned ${response.status}`);
 
   let body;


### PR DESCRIPTION
### Motivation

- Make DB access centralized and more robust so transient DB control-plane/connection errors don't cause unpredictable 500s.
- Surface a consistent, non-leaky error shape when the DB is unavailable (`503` with `{"ok":false,"error":"DB_UNAVAILABLE"}`).
- Add small retry/backoff for known transient DB failures to reduce CI/runtime flakiness.
- Improve debug logs with request/route context while avoiding secret leakage.

### Description

- Replace direct `pg` usage with a centralized helper in `lib/db.ts` providing `getDbPool`, `getDbClient`, and `dbQuery`, with pool config (`max:4`, `connectionTimeoutMillis:7000`, `idleTimeoutMillis:20000`) and automatic SSL detection from the connection string.
- Implement retry/backoff logic (`MAX_ATTEMPTS = 3`, backoffs `200ms` and `400ms`) in `dbQuery` and `getDbClient`, and retry only on detected transient errors (e.g. `err.code === 'XX000'`, messages containing `Control plane request failed`, or connection/timeouts); non-transient SQL errors are not retried.
- Add `DbUnavailableError` and sanitize/logging helpers to emit structured logs with `route` and `attempt`, redact connection strings/passwords, and suppress stack traces in production.
- Update API routes to use the helper: `app/api/places/route.ts`, `app/api/places/[id]/route.ts`, and `app/api/submissions/[id]/promote/route.ts` now call `dbQuery`/`getDbClient`, mark transactional queries with `retry:false`, and return `503` JSON `{ "ok": false, "error": "DB_UNAVAILABLE" }` when retries are exhausted.
- Make the smoke-checker `scripts/smoke.mjs` resilient by adding a client-side `fetchWithRetry` that retries up to 3 times with backoff on `503` or network errors.

### Testing

- No automated tests were executed as part of this PR.
- Changes were limited to behavior and error handling; please run `npm run smoke` locally (with a reachable DB) to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953303203c8832899792b2b9d03f5aa)