### PR TITLE
Task 68 - Document DB connection contract + add /api/health + extend smoke

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+
+export async function GET() {
+  if (!hasDatabaseUrl()) {
+    return NextResponse.json({ ok: false, db: { ok: false } }, { status: 503 });
+  }
+
+  const start = Date.now();
+
+  try {
+    await dbQuery("SELECT 1", [], { route: "api_health" });
+    const latencyMs = Date.now() - start;
+    return NextResponse.json({ ok: true, db: { ok: true, latencyMs } });
+  } catch (error) {
+    if (error instanceof DbUnavailableError) {
+      return NextResponse.json({ ok: false, db: { ok: false } }, { status: 503 });
+    }
+
+    console.error("[health] db query failed", error);
+    return NextResponse.json({ ok: false, db: { ok: false } }, { status: 503 });
+  }
+}

--- a/docs/db-connection.md
+++ b/docs/db-connection.md
@@ -1,0 +1,59 @@
+# Database connection contract
+
+This document is the source of truth for how the application connects to Postgres and how
+database failures map to API responses.
+
+## Required environment variables
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `DATABASE_URL` | Yes | Postgres connection string used by API routes, scripts, and smoke checks. |
+
+Notes:
+- Connection strings may include `ssl=true` or `sslmode=require`/`verify-ca`/`verify-full` to force SSL.
+- If `DATABASE_URL` is missing, DB-backed routes fail fast and smoke/API checks are skipped.
+
+## Pool settings
+
+The shared pool is created in `lib/db.ts` and reused across routes.
+
+- `max`: **4** connections
+- `idleTimeoutMillis`: **20000** (20s)
+- `connectionTimeoutMillis`: **7000** (7s)
+- `ssl`: enabled when the connection string includes `ssl=true` or `sslmode=require|verify-ca|verify-full`
+
+## Timeout strategy
+
+- Connection acquisition is capped by `connectionTimeoutMillis` (7s).
+- No `statement_timeout` or per-query timeout is set in code; Postgres defaults apply.
+- If timeouts are needed, update the connection string or add server-side defaults.
+
+## Retry strategy
+
+Retries are implemented in `lib/db.ts` for both `dbQuery` and `getDbClient`.
+
+- Max attempts: **3** (initial try + 2 retries).
+- Backoff: **200ms**, then **400ms** for subsequent retries.
+- Retries only occur on transient errors, including:
+  - Postgres `XX000`
+  - Network/driver codes (`ECONNRESET`, `ETIMEDOUT`, `EPIPE`, `ECONNREFUSED`)
+  - Messages containing `connection terminated`, `connection reset`, `timeout`,
+    or `control plane request failed`
+- After exhausting retries on transient errors, a `DbUnavailableError` is thrown.
+- Callers may disable retries by passing `{ retry: false }` (used for transactional flows).
+
+## API error mapping policy
+
+The API uses a consistent mapping for database-related failures:
+
+- **503 Service Unavailable**: returned when a `DbUnavailableError` is raised
+  (e.g., `/api/places`, `/api/places/[id]`, `/api/submissions/[id]/promote`,
+  `/api/health`).
+- **404 Not Found**: returned when a specific record is missing
+  (e.g., `/api/places/[id]`, `/api/submissions/[id]/promote`).
+- **400 Bad Request**: returned when input is invalid or a submission is in an
+  invalid state (e.g., `/api/submissions/[id]/status`, `/api/submissions/[id]/promote`).
+- **500 Internal Server Error**: returned for unexpected failures, including
+  schema mismatches or unhandled database errors.
+
+For other endpoints, unhandled exceptions follow Next.js defaults (500).

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -145,6 +145,24 @@ const checkList = async () => {
   log("ok list country=AQ");
 };
 
+const checkHealth = async () => {
+  const response = await fetchWithRetry(`${BASE_URL}/api/health`, {}, { label: "health" });
+  if (!response.ok) throw new Error(`health returned ${response.status}`);
+
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error("health returned invalid JSON");
+  }
+
+  if (!body || typeof body !== "object") throw new Error("health returned non-object JSON");
+  if (!body.ok) throw new Error("health ok flag is false");
+  if (!body.db?.ok) throw new Error("health db ok flag is false");
+
+  log("ok health");
+};
+
 const expectations = [
   ["antarctica-owner-1", { verification: "owner", accepted: ["BTC", "Lightning", "ETH", "USDT"] }],
   ["antarctica-community-1", { verification: "community", accepted: ["BTC", "ETH"] }],
@@ -190,6 +208,7 @@ const runApiChecks = async () => {
     }
 
     await checkList();
+    await checkHealth();
     log("ok api");
   } finally {
     cleanup();


### PR DESCRIPTION
### Motivation

- Provide a single source of truth describing DB connection, pool, timeout and retry behavior for the app.
- Expose a lightweight `/api/health` endpoint that probes the DB and reports availability and latency for quick diagnostics.
- Ensure smoke checks include the health endpoint so regressions in DB connectivity are caught early in CI.
- Keep changes minimal and avoid altering existing endpoint behavior.

### Description

- Add `docs/db-connection.md` documenting required env vars, pool settings (`max`, `idleTimeoutMillis`, `connectionTimeoutMillis`), timeout strategy, retry policy, and API error mapping.
- Add `app/api/health/route.ts` which runs a minimal `SELECT 1` via `dbQuery`, measures latency, returns `{ ok, db: { ok, latencyMs? } }`, and maps DB failures to HTTP `503` when appropriate.
- Extend `scripts/smoke.mjs` with a `checkHealth` function that calls `/api/health` and asserts `ok` and `db.ok`, and invoke it during API smoke checks.
- No other endpoint behavior was changed; DB-unavailable handling continues to surface as `503` via `DbUnavailableError`.

### Testing

- Ran `npm run build` which completed successfully and included the new `/api/health` route in the build.
- Ran `npm run smoke` which executed unit checks and exited `PASS` with API checks skipped because `DATABASE_URL` was not set.
- In CI (with `DATABASE_URL` present) the updated smoke will perform runtime API checks including `/api/health` (not executed locally due to missing env).
- No automated test failures were observed for the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535a5dba8083289628d1c10ac082a6)