### PR TITLE
Task 69 Add status page and DB health indicators

### DIFF
--- a/app/internal/submissions/page.tsx
+++ b/app/internal/submissions/page.tsx
@@ -4,6 +4,7 @@ import path from "path";
 import SubmissionsClient from "./SubmissionsClient";
 import { LoadedSubmission } from "./types";
 import { StoredSubmission } from "@/lib/submissions";
+import DbStatusIndicator from "@/components/status/DbStatusIndicator";
 
 export const runtime = "nodejs";
 
@@ -56,9 +57,12 @@ export default async function SubmissionsPage() {
 
   return (
     <main className="mx-auto max-w-6xl space-y-6 p-6">
-      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
-        <p className="text-sm font-semibold">Internal only / 暫定レビュー画面</p>
-        <p className="text-sm">直リンクのみ。外部には公開しないでください。</p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
+          <p className="text-sm font-semibold">Internal only / 暫定レビュー画面</p>
+          <p className="text-sm">直リンクのみ。外部には公開しないでください。</p>
+        </div>
+        <DbStatusIndicator showBanner />
       </div>
 
       {warnings.length > 0 && (
@@ -82,4 +86,3 @@ export default async function SubmissionsPage() {
     </main>
   );
 }
-

--- a/app/status/StatusClient.tsx
+++ b/app/status/StatusClient.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useHealthStatus } from "@/components/status/useHealthStatus";
+
+type StatusClientProps = {
+  buildSha: string | null;
+};
+
+const formatTimestamp = (value: Date | null) => {
+  if (!value) return "Checking…";
+  return value.toLocaleString();
+};
+
+export default function StatusClient({ buildSha }: StatusClientProps) {
+  const { status, lastUpdated } = useHealthStatus();
+
+  const overall = useMemo(() => {
+    if (!status) {
+      return {
+        label: "CHECKING",
+        className: "border-gray-200 bg-gray-50 text-gray-600",
+      };
+    }
+
+    if (status.ok && status.db.ok) {
+      return {
+        label: "OK",
+        className: "border-emerald-200 bg-emerald-50 text-emerald-700",
+      };
+    }
+
+    return {
+      label: "DEGRADED",
+      className: "border-amber-200 bg-amber-50 text-amber-800",
+    };
+  }, [status]);
+
+  const dbLabel = status?.db.ok ? "OK" : "DOWN";
+  const latency = status?.db.latencyMs;
+  const shortSha = buildSha ? buildSha.slice(0, 7) : null;
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-gray-900">System Status</h1>
+        <p className="text-sm text-gray-600">
+          Live health checks for API and database availability.
+        </p>
+      </header>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-gray-600">Overall</p>
+            <div
+              className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${overall.className}`}
+            >
+              <span className="h-2 w-2 rounded-full bg-current" aria-hidden />
+              {overall.label}
+            </div>
+          </div>
+          <div className="text-right text-xs text-gray-500">
+            <p>Last checked</p>
+            <p className="font-medium text-gray-700">
+              {formatTimestamp(lastUpdated)}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <p className="text-xs uppercase tracking-wide text-gray-500">API</p>
+            <p className="mt-2 text-sm font-semibold text-gray-900">
+              {status?.ok ? "OK" : "DOWN"}
+            </p>
+            {!status?.ok && (
+              <p className="mt-1 text-xs text-gray-600">
+                Temporary data issue. Please try again shortly.
+              </p>
+            )}
+          </div>
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <p className="text-xs uppercase tracking-wide text-gray-500">Database</p>
+            <p className="mt-2 text-sm font-semibold text-gray-900">{dbLabel}</p>
+            <p className="mt-1 text-xs text-gray-600">
+              {status?.db.ok
+                ? `Latency: ${latency ?? "-"} ms`
+                : "Temporary data issue. Data may be delayed."}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 border-t border-gray-100 pt-4 text-xs text-gray-500">
+          <p>
+            Timestamp: <span className="text-gray-700">{formatTimestamp(lastUpdated)}</span>
+          </p>
+          <p>
+            Build:{" "}
+            <span className="text-gray-700">
+              {shortSha ? `commit ${shortSha}` : "unknown"}
+            </span>
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,0 +1,10 @@
+import StatusClient from "./StatusClient";
+
+const buildSha =
+  process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ??
+  process.env.VERCEL_GIT_COMMIT_SHA ??
+  null;
+
+export default function StatusPage() {
+  return <StatusClient buildSha={buildSha} />;
+}

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -26,6 +26,7 @@ import {
   FilterState,
   parseFiltersFromSearchParams,
 } from "@/lib/filters";
+import DbStatusIndicator from "@/components/status/DbStatusIndicator";
 
 const HEADER_HEIGHT = 0;
 
@@ -533,6 +534,10 @@ export default function MapClient() {
         </div>
       </aside>
       <div className="relative flex-1 bg-gray-50">
+        <DbStatusIndicator
+          className="pointer-events-none absolute right-4 top-4 z-50 flex flex-col items-end gap-2 text-right"
+          showBanner
+        />
         {placesStatus === "loading" && (
           <div className="absolute inset-0 z-40 flex flex-col items-center justify-center bg-gray-100/90 text-gray-700">
             <div className="h-10 w-10 animate-spin rounded-full border-4 border-blue-200 border-t-blue-500" />

--- a/components/status/DbStatusIndicator.tsx
+++ b/components/status/DbStatusIndicator.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useHealthStatus } from "./useHealthStatus";
+
+type DbStatusIndicatorProps = {
+  className?: string;
+  showBanner?: boolean;
+};
+
+export default function DbStatusIndicator({
+  className,
+  showBanner = false,
+}: DbStatusIndicatorProps) {
+  const { status } = useHealthStatus();
+  const { label, badgeClass, dotClass, isDown } = useMemo(() => {
+    if (!status) {
+      return {
+        label: "CHECKING",
+        badgeClass: "border-gray-200 bg-gray-50 text-gray-600",
+        dotClass: "bg-gray-400",
+        isDown: false,
+      };
+    }
+
+    if (status.db.ok) {
+      return {
+        label: "OK",
+        badgeClass: "border-emerald-200 bg-emerald-50 text-emerald-700",
+        dotClass: "bg-emerald-500",
+        isDown: false,
+      };
+    }
+
+    return {
+      label: "DOWN",
+      badgeClass: "border-rose-200 bg-rose-50 text-rose-700",
+      dotClass: "bg-rose-500",
+      isDown: true,
+    };
+  }, [status]);
+
+  return (
+    <div className={className}>
+      <div
+        className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${badgeClass}`}
+      >
+        <span className={`h-2 w-2 rounded-full ${dotClass}`} aria-hidden />
+        DB: {label}
+      </div>
+      {showBanner && isDown && (
+        <div className="mt-2 w-full max-w-sm rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 shadow-sm">
+          <p className="font-semibold">Temporary data issue</p>
+          <p>Some data may not load while the database is unavailable. Please try again shortly.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/status/useHealthStatus.ts
+++ b/components/status/useHealthStatus.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getHealthStatus, HealthStatus } from "@/lib/healthStatus";
+
+const REFRESH_INTERVAL_MS = 20000;
+
+export function useHealthStatus() {
+  const [status, setStatus] = useState<HealthStatus | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const update = async () => {
+      const data = await getHealthStatus();
+      if (!isMounted) return;
+      setStatus(data);
+      setLastUpdated(new Date());
+    };
+
+    update();
+    const interval = window.setInterval(update, REFRESH_INTERVAL_MS);
+
+    return () => {
+      isMounted = false;
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  return { status, lastUpdated };
+}

--- a/lib/healthStatus.ts
+++ b/lib/healthStatus.ts
@@ -1,0 +1,63 @@
+export type HealthStatus = {
+  ok: boolean;
+  db: {
+    ok: boolean;
+    latencyMs?: number;
+  };
+};
+
+const CACHE_TTL_MS = 20000;
+
+const fallbackStatus: HealthStatus = {
+  ok: false,
+  db: { ok: false },
+};
+
+let cachedStatus: HealthStatus | null = null;
+let cachedAt = 0;
+let inFlight: Promise<HealthStatus> | null = null;
+
+const fetchHealthStatus = async (): Promise<HealthStatus> => {
+  try {
+    const response = await fetch("/api/health", { cache: "no-store" });
+    if (!response.ok) {
+      return fallbackStatus;
+    }
+
+    const data = (await response.json()) as Partial<HealthStatus>;
+    return {
+      ok: Boolean(data?.ok),
+      db: {
+        ok: Boolean(data?.db?.ok),
+        latencyMs: data?.db?.latencyMs,
+      },
+    };
+  } catch {
+    return fallbackStatus;
+  }
+};
+
+export const getHealthStatus = async (): Promise<HealthStatus> => {
+  const now = Date.now();
+  if (cachedStatus && now - cachedAt < CACHE_TTL_MS) {
+    return cachedStatus;
+  }
+
+  if (!inFlight) {
+    inFlight = fetchHealthStatus()
+      .then((data) => {
+        cachedStatus = data;
+        cachedAt = Date.now();
+        inFlight = null;
+        return data;
+      })
+      .catch(() => {
+        cachedStatus = fallbackStatus;
+        cachedAt = Date.now();
+        inFlight = null;
+        return fallbackStatus;
+      });
+  }
+
+  return inFlight;
+};


### PR DESCRIPTION
### Motivation
- Provide a single public `/status` page that surfaces API and DB health and a simple OK/DEGRADED indicator for ops and users.
- Surface database availability and a short explanatory UX in the main UI so pages don’t look broken when the DB is down.
- Keep changes minimal and dependency-free while reusing existing UI primitives and health check API (`GET /api/health`).
- Cache client-side health checks to avoid spamming the API during normal use.

### Description
- Add a cached health helper `lib/healthStatus.ts` that fetches `/api/health` and caches results for `CACHE_TTL_MS` (20s) with in-flight deduplication.
- Add a client hook `components/status/useHealthStatus.ts` to poll the cached health helper every 20s for UI consumption.
- Add a reusable `DbStatusIndicator` component that shows a small DB badge and an optional non-blocking outage banner when DB is down. 
- Add a public status page at `app/status/page.tsx` (with `StatusClient`) and surface the `DbStatusIndicator` on `/map` and `/internal/submissions` to show DB status and the warning banner.

### Testing
- Started the dev server (`next dev`) and the app compiled the new `/status/page` and `app/api/health/route` successfully. (compile succeeded)
- Captured a screenshot of the `/status` page via an automated Playwright script and the navigation/screenshot completed successfully. (succeeded)
- No unit tests or CI smoke/build were run in this rollout; `npm run build` and CI smoke were not executed here. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535db7180c8328a2997c071c91e213)