### PR TITLE
Task 73: add repeatable DB check script and docs

### DIFF
--- a/docs/dev/db-check.md
+++ b/docs/dev/db-check.md
@@ -1,0 +1,49 @@
+# DB check (Postgres + PostGIS)
+
+## Purpose
+
+`npm run db:check` verifies that:
+
+- `DATABASE_URL` is available
+- Postgres is reachable
+- PostGIS is installed
+- Core tables for CryptoPayMap v2 exist
+- A tiny read query succeeds (`places` count)
+
+## Command
+
+```bash
+npm run db:check
+```
+
+## Expected output (success)
+
+```text
+[db-check] Database OK
+[db-check] places count: 123
+```
+
+## Common failures
+
+### DATABASE_URL missing
+
+```text
+DATABASE_URL is not set. Add it to .env.local or export it before running this script.
+```
+
+### PostGIS missing
+
+```text
+PostGIS extension is missing. Run: CREATE EXTENSION postgis;
+```
+
+### Missing tables
+
+```text
+Missing required tables: places, verifications
+```
+
+## Notes
+
+- The script reads `.env.local` if `DATABASE_URL` is not already set.
+- Use this for deterministic smoke checks during development or troubleshooting.


### PR DESCRIPTION
### Motivation

- Provide a single deterministic command to verify `DATABASE_URL` connectivity and required DB schema for debugging and smoke checks.
- Surface missing dependencies like PostGIS and core tables early with clear, actionable messages.
- Make the DB check repeatable and discoverable by adding documentation for developers.
- Keep runtime behavior of the app unchanged by limiting this to a dev/debug script and docs.

### Description

- Update `scripts/db-check.mjs` to load `.env.local`, fail when `DATABASE_URL` is missing, and exit with clear messages.
- Add a PostGIS availability check and a required-tables verification loop for `places`, `verifications`, `payments`, `payment_accepts`, `socials`, `media`, `categories`, and `history`.
- Run a lightweight read query `SELECT COUNT(*)::int AS count FROM places` and print `[db-check] Database OK` with the `places` count on success.
- Add `docs/dev/db-check.md` documenting `npm run db:check`, expected outputs, and common failure messages.

### Testing

- No automated tests were run as part of this change.
- Existing CI and test scripts were not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953cac6efc08328b94630f501b03896)