### PR TITLE
Fix bbox loading & add filter/search URL sync (payments + search)

### DIFF
--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -7,7 +7,7 @@ import { normalizeAccepted, type PaymentAccept } from "@/lib/accepted";
 import type { Place } from "@/types/places";
 
 const DEFAULT_LIMIT = 200;
-const MAX_LIMIT = 1000;
+const MAX_LIMIT = 12000;
 const ALL_MODE_LIMIT = 1000;
 const CACHE_TTL_MS = 20_000;
 

--- a/components/map/FiltersPanel.tsx
+++ b/components/map/FiltersPanel.tsx
@@ -23,7 +23,7 @@ const VERIFICATION_LABELS: Record<string, string> = {
 export function FiltersPanel({ filters, meta, onChange, onClear, disabled, showHeading = true }: FiltersPanelProps) {
   const handleCheckboxChange = (
     event: ChangeEvent<HTMLInputElement>,
-    key: "chains" | "verifications",
+    key: "chains" | "payments" | "verifications",
     value: string,
   ) => {
     const current = new Set(filters[key]);
@@ -46,6 +46,18 @@ export function FiltersPanel({ filters, meta, onChange, onClear, disabled, showH
     <div className="flex flex-col gap-4">
       {showHeading && <h3 className="text-sm font-semibold text-gray-900">Filters</h3>}
       <div className="grid grid-cols-1 gap-4 text-sm">
+        <label className="space-y-1">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">Search</span>
+          <input
+            type="search"
+            className="w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            placeholder="Search by name or address"
+            value={filters.search}
+            onChange={(event) => onChange({ ...filters, search: event.target.value })}
+            disabled={disabled}
+          />
+        </label>
+
         <label className="space-y-1">
           <span className="text-xs font-semibold uppercase tracking-wide text-gray-600">Category</span>
           <select
@@ -81,6 +93,28 @@ export function FiltersPanel({ filters, meta, onChange, onClear, disabled, showH
               </label>
             ))}
             {!meta && <span className="text-xs text-gray-500">Loading options…</span>}
+          </div>
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="text-xs font-semibold uppercase tracking-wide text-gray-600">Payment</legend>
+          <div className="grid max-h-32 grid-cols-2 gap-2 overflow-y-auto rounded-md border border-gray-200 bg-white p-3 text-sm shadow-inner">
+            {meta?.payments.map((payment) => (
+              <label key={payment} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  checked={filters.payments.includes(payment)}
+                  onChange={(event) => handleCheckboxChange(event, "payments", payment)}
+                  disabled={disabled}
+                />
+                <span>{payment}</span>
+              </label>
+            ))}
+            {!meta && <span className="text-xs text-gray-500">Loading options…</span>}
+            {meta?.payments.length === 0 && (
+              <span className="text-xs text-gray-500">No payment options</span>
+            )}
           </div>
         </fieldset>
 

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -32,8 +32,8 @@ const HEADER_HEIGHT = 0;
 
 const DEFAULT_COORDINATES: [number, number] = [20, 0];
 const DEFAULT_ZOOM = 2;
-const MAX_CLIENT_LIMIT = 1000;
-const BBOX_PRECISION = 5;
+const MAX_CLIENT_LIMIT = 12000;
+const BBOX_PRECISION = 6;
 
 const PIN_SVGS: Record<PinType, string> = {
   owner: `<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g><path d="M16 2 C10 2,6 6.5,6 12 C6 20,16 30,16 30 C16 30,26 20,26 12 C26 6.5,22 2,16 2Z" fill="#F59E0B" stroke="white" stroke-width="2"/><circle cx="16" cy="12" r="4" fill="white"/></g></svg>`,
@@ -279,7 +279,7 @@ export default function MapClient() {
 
     const getLimitForZoom = (zoom: number) => {
       const rawLimit =
-        zoom <= 2 ? 600 : zoom <= 4 ? 800 : zoom <= 6 ? 1000 : 1000;
+        zoom <= 2 ? 2000 : zoom <= 4 ? 4000 : zoom <= 6 ? 8000 : 12000;
       return Math.min(rawLimit, MAX_CLIENT_LIMIT);
     };
 
@@ -441,9 +441,11 @@ export default function MapClient() {
       Boolean(
         filters.category ||
           filters.chains.length ||
+          filters.payments.length ||
           filters.verifications.length ||
           filters.country ||
-          filters.city,
+          filters.city ||
+          filters.search.trim(),
       ),
     [filters],
   );
@@ -516,7 +518,7 @@ export default function MapClient() {
     if (!places.length) {
       return (
         <div className="rounded-lg border border-gray-100 bg-gray-50 p-3 text-sm text-gray-600">
-          No places match the current filters.
+          No places found for current filters.
         </div>
       );
     }


### PR DESCRIPTION
### Motivation
- Resolve bbox loading reliability that caused the initial world view to be capped to a tiny dataset and ensure fetches re-run on map ready / moveend / zoomend.
- Make bbox fetch limits zoom-aware to scale results by view and raise server/client caps to allow large world-level responses.
- Expose payment normalization and search in the filtering layer so users can search by name/address and filter by payment methods.
- Persist filter/search state in the URL so refreshes and shared links keep the current map/filter state.

### Description
- Implemented zoom-aware limits and raised caps by updating `getLimitForZoom`, `MAX_CLIENT_LIMIT`, and server `MAX_LIMIT`, and increased `BBOX_PRECISION` in `components/map/MapClient.tsx` and `app/api/places/route.ts`.
- Extended filter model in `lib/filters.ts` to include `payments` and `search`, added parsing/serialization via `parseFiltersFromSearchParams` and `buildQueryFromFilters`, and included normalized payment options in `deriveFilterMeta` using `normalizeAccepted`.
- Added a search input and payment checklist to the filter UI in `components/map/FiltersPanel.tsx`, and wired `MapClient` to include `payments` and `q` in URL sync and active-filter detection, plus improved empty-state copy.
- Ensured fetch logic still uses debounced `moveend/zoomend`, force-fetch on map ready, and unchanged stale-response handling and marker rendering flow.

### Testing
- Ran `npm run build` which completed successfully (type checks and compilation passed; lint warnings about existing `<img>` usage were emitted but do not block the build).
- Started the dev server with `npm run dev` and confirmed the `/map` page compiled and served locally.
- Exercised the mobile filters with an automated Playwright script that loaded `/map`, opened the mobile filter sheet, and produced a screenshot of the mobile filters UI (artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fafe34088328943c267ca46766eb)