### PR TITLE
Add DB-backed submissions intake with validation

### DIFF
--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -27,9 +27,10 @@ type FormState = {
 };
 
 type SubmissionResponse = {
-  ok: boolean;
-  submissionId?: string;
+  id?: string;
+  status?: string;
   suggestedPlaceId?: string;
+  errors?: Record<string, string>;
   error?: string;
 };
 

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -1,6 +1,8 @@
 import { promises as fs } from "fs";
 import path from "path";
 
+import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+
 export type SubmissionKind = "owner" | "community";
 
 export type SubmissionPayload = {
@@ -27,6 +29,8 @@ export type SubmissionPayload = {
   termsAccepted?: boolean;
 };
 
+type SubmissionErrors = Record<string, string>;
+
 const submissionsDir = path.join(process.cwd(), "data", "submissions");
 
 const writeSubmissionToDisk = async (record: StoredSubmission) => {
@@ -36,7 +40,11 @@ const writeSubmissionToDisk = async (record: StoredSubmission) => {
 };
 
 export const saveSubmission = async (record: StoredSubmission): Promise<StoredSubmission> => {
-  await writeSubmissionToDisk(record);
+  try {
+    await writeSubmissionToDisk(record);
+  } catch (error) {
+    console.error("[submissions] failed to write to disk", error);
+  }
   return record;
 };
 
@@ -56,7 +64,32 @@ export type StoredSubmission = {
 
 type NormalizationResult =
   | { ok: true; payload: SubmissionPayload }
-  | { ok: false; error: string };
+  | { ok: false; errors: SubmissionErrors };
+
+const MAX_LENGTHS = {
+  name: 160,
+  country: 3,
+  city: 120,
+  address: 200,
+  category: 60,
+  contactEmail: 200,
+  contactName: 120,
+  role: 40,
+  about: 600,
+  paymentNote: 150,
+  website: 200,
+  twitter: 200,
+  instagram: 200,
+  facebook: 200,
+  notesForAdmin: 300,
+  chain: 40,
+  amenity: 40,
+};
+
+const MAX_ACCEPTED_CHAINS = 12;
+const MAX_AMENITIES = 20;
+
+const emailRegex = /[^@]+@[^.]+\..+/;
 
 const ensureString = (value: unknown): string | undefined => {
   if (typeof value === "string") {
@@ -107,64 +140,249 @@ const generateSuggestedPlaceId = (payload: SubmissionPayload) => {
   return `cpm:${country}-${citySlug}-${payload.verificationRequest}-${categorySlug}-${nameSlug}-${suffix}`;
 };
 
+const validateLength = (
+  errors: SubmissionErrors,
+  field: keyof SubmissionPayload,
+  value: string | undefined,
+  max: number,
+) => {
+  if (!value) return;
+  if (value.length > max) {
+    errors[field] = `Must be ${max} characters or fewer`;
+  }
+};
+
+const normalizeStringArray = (
+  value: unknown,
+  maxItemLength: number,
+  maxItems: number,
+  field: keyof SubmissionPayload,
+  errors: SubmissionErrors,
+) => {
+  const cleaned = ensureStringArray(value);
+  if (!cleaned) return undefined;
+  if (cleaned.length > maxItems) {
+    errors[field] = `Must include ${maxItems} items or fewer`;
+    return cleaned.slice(0, maxItems);
+  }
+  const tooLong = cleaned.find((entry) => entry.length > maxItemLength);
+  if (tooLong) {
+    errors[field] = `Entries must be ${maxItemLength} characters or fewer`;
+  }
+  return cleaned;
+};
+
 export const normalizeSubmission = (raw: unknown): NormalizationResult => {
   if (!raw || typeof raw !== "object") {
-    return { ok: false, error: "Invalid JSON" };
+    return { ok: false, errors: { body: "Invalid JSON" } };
   }
 
   const obj = raw as Record<string, unknown>;
-  const requiredFields: Array<[keyof SubmissionPayload, string | undefined]> = [
-    ["name", ensureString(obj.name)],
-    ["country", ensureString(obj.country)],
-    ["city", ensureString(obj.city)],
-    ["address", ensureString(obj.address)],
-    ["category", ensureString(obj.category)],
-  ];
+  const errors: SubmissionErrors = {};
+  const name = ensureString(obj.name);
+  const country = ensureString(obj.country);
+  const city = ensureString(obj.city);
+  const address = ensureString(obj.address);
+  const category = ensureString(obj.category);
+  const contactEmail = ensureString(obj.contactEmail);
+  const contactName = ensureString(obj.contactName);
+  const role = ensureString(obj.role);
+  const about = ensureString(obj.about);
+  const paymentNote = ensureString(obj.paymentNote);
+  const website = ensureString(obj.website);
+  const twitter = ensureString(obj.twitter);
+  const instagram = ensureString(obj.instagram);
+  const facebook = ensureString(obj.facebook);
+  const notesForAdmin = ensureString(obj.notesForAdmin);
+  const rawLat = obj.lat;
+  const rawLng = obj.lng;
+  const parsedLat = ensureNumber(rawLat);
+  const parsedLng = ensureNumber(rawLng);
 
-  const missing = requiredFields.filter(([, value]) => !value).map(([key]) => key);
+  if (!name) errors.name = "Required";
+  if (!country) errors.country = "Required";
+  if (!city) errors.city = "Required";
+  if (!address) errors.address = "Required";
+  if (!category) errors.category = "Required";
+  if (!contactEmail) errors.contactEmail = "Required";
 
-  const verificationRequest = obj.verificationRequest === "owner" || obj.verificationRequest === "community"
-    ? obj.verificationRequest
-    : undefined;
+  const verificationRequest =
+    obj.verificationRequest === "owner" || obj.verificationRequest === "community"
+      ? obj.verificationRequest
+      : undefined;
 
-  const acceptedChains = ensureStringArray(obj.acceptedChains);
-
-  if (!verificationRequest) missing.push("verificationRequest");
-  if (!acceptedChains?.length) missing.push("acceptedChains");
-
-  if (missing.length) {
-    return { ok: false, error: `Missing required fields: ${missing.join(", ")}` };
+  if (!verificationRequest) {
+    errors.verificationRequest = "Must be owner or community";
   }
 
+  const acceptedChains = normalizeStringArray(
+    obj.acceptedChains,
+    MAX_LENGTHS.chain,
+    MAX_ACCEPTED_CHAINS,
+    "acceptedChains",
+    errors,
+  );
+  if (!acceptedChains?.length) {
+    errors.acceptedChains = "Select at least one";
+  }
+
+  if (contactEmail && (!emailRegex.test(contactEmail) || contactEmail.length > MAX_LENGTHS.contactEmail)) {
+    errors.contactEmail = "Invalid email";
+  }
+
+  validateLength(errors, "name", name, MAX_LENGTHS.name);
+  validateLength(errors, "country", country, MAX_LENGTHS.country);
+  validateLength(errors, "city", city, MAX_LENGTHS.city);
+  validateLength(errors, "address", address, MAX_LENGTHS.address);
+  validateLength(errors, "category", category, MAX_LENGTHS.category);
+  validateLength(errors, "contactName", contactName, MAX_LENGTHS.contactName);
+  validateLength(errors, "role", role, MAX_LENGTHS.role);
+  validateLength(errors, "about", about, MAX_LENGTHS.about);
+  validateLength(errors, "paymentNote", paymentNote, MAX_LENGTHS.paymentNote);
+  validateLength(errors, "website", website, MAX_LENGTHS.website);
+  validateLength(errors, "twitter", twitter, MAX_LENGTHS.twitter);
+  validateLength(errors, "instagram", instagram, MAX_LENGTHS.instagram);
+  validateLength(errors, "facebook", facebook, MAX_LENGTHS.facebook);
+  validateLength(errors, "notesForAdmin", notesForAdmin, MAX_LENGTHS.notesForAdmin);
+
   const payload: SubmissionPayload = {
-    name: requiredFields[0][1]!,
-    country: requiredFields[1][1]!,
-    city: requiredFields[2][1]!,
-    address: requiredFields[3][1]!,
-    category: requiredFields[4][1]!,
+    name: name ?? "",
+    country: country ?? "",
+    city: city ?? "",
+    address: address ?? "",
+    category: category ?? "",
     verificationRequest: verificationRequest as SubmissionKind,
     acceptedChains: acceptedChains as string[],
-    contactEmail: ensureString(obj.contactEmail),
-    contactName: ensureString(obj.contactName),
-    role: ensureString(obj.role),
-    about: ensureString(obj.about),
-    paymentNote: ensureString(obj.paymentNote),
-    website: ensureString(obj.website),
-    twitter: ensureString(obj.twitter),
-    instagram: ensureString(obj.instagram),
-    facebook: ensureString(obj.facebook),
-    lat: ensureNumber(obj.lat),
-    lng: ensureNumber(obj.lng),
-    amenities: ensureStringArray(obj.amenities),
-    notesForAdmin: ensureString(obj.notesForAdmin),
+    contactEmail,
+    contactName,
+    role,
+    about,
+    paymentNote,
+    website,
+    twitter,
+    instagram,
+    facebook,
+    lat: parsedLat,
+    lng: parsedLng,
+    amenities: normalizeStringArray(
+      obj.amenities,
+      MAX_LENGTHS.amenity,
+      MAX_AMENITIES,
+      "amenities",
+      errors,
+    ),
+    notesForAdmin,
     termsAccepted: typeof obj.termsAccepted === "boolean" ? obj.termsAccepted : undefined,
   };
 
+  if (rawLat !== null && rawLat !== undefined && rawLat !== "" && parsedLat === undefined) {
+    errors.lat = "Invalid latitude";
+  }
+  if (rawLng !== null && rawLng !== undefined && rawLng !== "" && parsedLng === undefined) {
+    errors.lng = "Invalid longitude";
+  }
+
+  if ((payload.lat !== undefined && payload.lng === undefined) || (payload.lat === undefined && payload.lng !== undefined)) {
+    errors.lat = "Lat/Lng must be provided together";
+    errors.lng = "Lat/Lng must be provided together";
+  }
+
+  if (payload.lat !== undefined && (payload.lat < -90 || payload.lat > 90)) {
+    errors.lat = "Latitude out of range";
+  }
+  if (payload.lng !== undefined && (payload.lng < -180 || payload.lng > 180)) {
+    errors.lng = "Longitude out of range";
+  }
+
   if (payload.termsAccepted === false) {
-    return { ok: false, error: "Terms must be accepted" };
+    errors.termsAccepted = "Terms must be accepted";
+  }
+
+  if (Object.keys(errors).length) {
+    return { ok: false, errors };
   }
 
   return { ok: true, payload };
+};
+
+const insertSubmissionToDb = async (record: StoredSubmission) => {
+  if (!hasDatabaseUrl()) {
+    throw new DbUnavailableError("DB_UNAVAILABLE");
+  }
+  const route = "api_submissions_create";
+
+  const { rows } = await dbQuery<{ present: string | null }>(
+    "SELECT to_regclass('public.submissions') AS present",
+    [],
+    { route },
+  );
+  if (!rows[0]?.present) {
+    throw new Error("SUBMISSIONS_TABLE_MISSING");
+  }
+
+  const payload = record.payload;
+
+  await dbQuery(
+    `INSERT INTO submissions (
+      id,
+      status,
+      kind,
+      suggested_place_id,
+      name,
+      country,
+      city,
+      address,
+      category,
+      accepted_chains,
+      contact_email,
+      contact_name,
+      role,
+      about,
+      payment_note,
+      website,
+      twitter,
+      instagram,
+      facebook,
+      lat,
+      lng,
+      amenities,
+      notes_for_admin,
+      terms_accepted,
+      payload
+    )
+    VALUES (
+      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15,
+      $16, $17, $18, $19, $20, $21, $22, $23, $24, $25
+    )`,
+    [
+      record.submissionId,
+      record.status,
+      record.payload.verificationRequest,
+      record.suggestedPlaceId,
+      payload.name,
+      payload.country,
+      payload.city,
+      payload.address,
+      payload.category,
+      payload.acceptedChains,
+      payload.contactEmail,
+      payload.contactName ?? null,
+      payload.role ?? null,
+      payload.about ?? null,
+      payload.paymentNote ?? null,
+      payload.website ?? null,
+      payload.twitter ?? null,
+      payload.instagram ?? null,
+      payload.facebook ?? null,
+      payload.lat ?? null,
+      payload.lng ?? null,
+      payload.amenities ?? null,
+      payload.notesForAdmin ?? null,
+      payload.termsAccepted ?? null,
+      JSON.stringify(payload),
+    ],
+    { route },
+  );
 };
 
 export const persistSubmission = async (payload: SubmissionPayload): Promise<StoredSubmission> => {
@@ -178,6 +396,7 @@ export const persistSubmission = async (payload: SubmissionPayload): Promise<Sto
     payload,
   };
 
+  await insertSubmissionToDb(stored);
   await saveSubmission(stored);
 
   return stored;
@@ -225,7 +444,7 @@ export const handleUnifiedSubmission = async (request: Request) => {
     const normalized = normalizeSubmission(body);
 
     if (!normalized.ok) {
-      return new Response(JSON.stringify({ ok: false, error: normalized.error }), {
+      return new Response(JSON.stringify({ errors: normalized.errors }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -234,10 +453,26 @@ export const handleUnifiedSubmission = async (request: Request) => {
     const record = await persistSubmission(normalized.payload);
 
     return new Response(
-      JSON.stringify({ ok: true, submissionId: record.submissionId, suggestedPlaceId: record.suggestedPlaceId }),
+      JSON.stringify({
+        id: record.submissionId,
+        status: record.status,
+        suggestedPlaceId: record.suggestedPlaceId,
+      }),
       { status: 201, headers: { "Content-Type": "application/json" } },
     );
   } catch (error) {
+    if (error instanceof DbUnavailableError || (error as Error).message?.includes("DATABASE_URL")) {
+      return new Response(JSON.stringify({ error: "DB_UNAVAILABLE" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (error instanceof Error && error.message === "SUBMISSIONS_TABLE_MISSING") {
+      return new Response(JSON.stringify({ error: "Submissions table missing" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
     console.error("[submissions] unexpected", error);
     return new Response(JSON.stringify({ ok: false, error: "Failed to process submission" }), {
       status: 500,
@@ -273,7 +508,7 @@ export const handleLegacySubmission = async (request: Request, expectedKind: Sub
 
     const normalized = normalizeSubmission(normalizedBody);
     if (!normalized.ok) {
-      return new Response(JSON.stringify({ ok: false, error: normalized.error }), {
+      return new Response(JSON.stringify({ errors: normalized.errors }), {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
@@ -282,10 +517,26 @@ export const handleLegacySubmission = async (request: Request, expectedKind: Sub
     const record = await persistSubmission(normalized.payload);
 
     return new Response(
-      JSON.stringify({ ok: true, submissionId: record.submissionId, suggestedPlaceId: record.suggestedPlaceId }),
+      JSON.stringify({
+        id: record.submissionId,
+        status: record.status,
+        suggestedPlaceId: record.suggestedPlaceId,
+      }),
       { status: 201, headers: { "Content-Type": "application/json" } },
     );
   } catch (error) {
+    if (error instanceof DbUnavailableError || (error as Error).message?.includes("DATABASE_URL")) {
+      return new Response(JSON.stringify({ error: "DB_UNAVAILABLE" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (error instanceof Error && error.message === "SUBMISSIONS_TABLE_MISSING") {
+      return new Response(JSON.stringify({ error: "Submissions table missing" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
     console.error("[submissions] legacy", error);
     return new Response(JSON.stringify({ ok: false, error: "Invalid submission" }), {
       status: 400,

--- a/migrations/compat_v3_min.sql
+++ b/migrations/compat_v3_min.sql
@@ -81,3 +81,33 @@ BEGIN
     WHERE last_verified IS NULL;
   END IF;
 END$$;
+
+-- Submissions table for owner/community intake
+CREATE TABLE IF NOT EXISTS public.submissions (
+  id TEXT PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  status TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  suggested_place_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  country TEXT NOT NULL,
+  city TEXT NOT NULL,
+  address TEXT NOT NULL,
+  category TEXT NOT NULL,
+  accepted_chains TEXT[] NOT NULL,
+  contact_email TEXT NOT NULL,
+  contact_name TEXT,
+  role TEXT,
+  about TEXT,
+  payment_note TEXT,
+  website TEXT,
+  twitter TEXT,
+  instagram TEXT,
+  facebook TEXT,
+  lat DOUBLE PRECISION,
+  lng DOUBLE PRECISION,
+  amenities TEXT[],
+  notes_for_admin TEXT,
+  terms_accepted BOOLEAN,
+  payload JSONB NOT NULL
+);


### PR DESCRIPTION
### Motivation
- Enable owner/community submission intake to be persisted as pending records in a DB-ready way.
- Provide server-side validation to reject malformed or spammy submissions early.
- Keep disk-based JSON files as a best-effort backup while moving primary persistence to Postgres when configured.
- Prepare the groundwork for a moderation flow (approve/reject/promote) implemented in later tasks.

### Description
- Implemented comprehensive validation in `lib/submissions.ts` with required fields, email/coordinate checks, string length caps, and array size limits, returning field-level `errors` on 400 responses.
- Added DB persistence path `insertSubmissionToDb` that writes new submissions into a `public.submissions` table when `DATABASE_URL` is present, and returns 503 (`DB_UNAVAILABLE`) if DB is not configured.
- Made disk writes via `saveSubmission` best-effort (errors logged but not fatal), and adjusted API responses to return 201 with `{ id, status, suggestedPlaceId }` on success and `{ errors: {...} }` for validation errors.
- Added a compatibility migration (`migrations/compat_v3_min.sql`) to create the `public.submissions` table, and updated the `/submit` frontend response type to accept the new response shape and errors.

### Testing
- Ran `npm run build` which completed successfully (type checking and compilation passed) with non-critical warnings about image usage and page deoptimization.
- No automated DB writes were executed during CI because DB writes are gated by `DATABASE_URL` and the code returns `DB_UNAVAILABLE` when not configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695409ff94e483288705376d7f390c7c)