### PR TITLE
DB-backed /api/stats and /api/stats/trends + /stats UI (history-based trends, indexes, caching)

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,36 +1,166 @@
 import { NextResponse } from "next/server";
 
-import { places } from "@/lib/data/places";
-import { categoryTrends } from "@/lib/stats/dashboard";
-import { computeDashboardStats } from "@/lib/stats/aggregate";
-import { monthlyTrends, weeklyTrends } from "@/lib/stats/trends";
-import {
-  normalizeCategoryTrendPoint,
-  normalizeCountryRanking,
-  normalizeTrendPoint,
-} from "@/lib/stats/utils";
+import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+
+type VerificationLevel = "owner" | "community" | "directory" | "unverified";
+
+// Response shape for GET /api/stats.
+export type StatsApiResponse = {
+  total_places: number;
+  by_country: Array<{ country: string; total: number }>;
+  by_verification: Array<{ level: VerificationLevel; total: number }>;
+};
+
+const VERIFICATION_LEVELS: VerificationLevel[] = [
+  "owner",
+  "community",
+  "directory",
+  "unverified",
+];
+
+const CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=60";
+const TOP_COUNTRY_LIMIT = 50;
+
+const tableExists = async (route: string, table: string) => {
+  const { rows } = await dbQuery<{ present: string | null }>(
+    "SELECT to_regclass($1) AS present",
+    [`public.${table}`],
+    { route },
+  );
+
+  return Boolean(rows[0]?.present);
+};
+
+const ensureIndexes = async (route: string, hasVerifications: boolean, verificationColumn: string | null) => {
+  await dbQuery(
+    "CREATE INDEX IF NOT EXISTS places_country_idx ON public.places (country)",
+    [],
+    { route },
+  );
+
+  if (hasVerifications && verificationColumn) {
+    await dbQuery(
+      `CREATE INDEX IF NOT EXISTS verifications_${verificationColumn}_idx ON public.verifications (${verificationColumn})`,
+      [],
+      { route },
+    );
+  }
+};
+
+const normalizeVerificationLevel = (value: string | null): VerificationLevel => {
+  if (value === "owner" || value === "community" || value === "directory" || value === "unverified") {
+    return value;
+  }
+  return "unverified";
+};
 
 export async function GET() {
-  const verificationTrends = {
-    weekly: weeklyTrends.map(normalizeTrendPoint),
-    monthly: monthlyTrends.map(normalizeTrendPoint),
-  };
+  const route = "api_stats";
 
-  const { byCountry, byCategory, byChain, kpi } = computeDashboardStats(places);
-  const countries = byCountry.map(normalizeCountryRanking);
+  if (!hasDatabaseUrl()) {
+    const empty = VERIFICATION_LEVELS.map((level) => ({ level, total: 0 }));
+    return NextResponse.json<StatsApiResponse>(
+      { total_places: 0, by_country: [], by_verification: empty },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
 
-  const categoryTrendsWithTotals = {
-    weekly: categoryTrends.weekly.map(normalizeCategoryTrendPoint),
-    monthly: categoryTrends.monthly.map(normalizeCategoryTrendPoint),
-  };
+  try {
+    const placesTableExists = await tableExists(route, "places");
+    if (!placesTableExists) {
+      const empty = VERIFICATION_LEVELS.map((level) => ({ level, total: 0 }));
+      return NextResponse.json<StatsApiResponse>(
+        { total_places: 0, by_country: [], by_verification: empty },
+        { headers: { "Cache-Control": CACHE_CONTROL } },
+      );
+    }
 
-  return NextResponse.json({
-    verificationTrends,
-    countries,
-    categoryTrends: categoryTrendsWithTotals,
-    byCountry,
-    byCategory,
-    byChain,
-    kpi,
-  });
+    const hasVerifications = await tableExists(route, "verifications");
+    let verificationColumn: string | null = null;
+
+    if (hasVerifications) {
+      const { rows } = await dbQuery<{ column_name: string }>(
+        `SELECT column_name
+         FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name = 'verifications'
+           AND column_name IN ('level', 'status')`,
+        [],
+        { route },
+      );
+      if (rows.some((row) => row.column_name === "level")) {
+        verificationColumn = "level";
+      } else if (rows.some((row) => row.column_name === "status")) {
+        verificationColumn = "status";
+      }
+    }
+
+    await ensureIndexes(route, hasVerifications, verificationColumn);
+
+    const [{ rows: totalRows }, { rows: countryRows }] = await Promise.all([
+      dbQuery<{ total: string }>("SELECT COUNT(*) AS total FROM places", [], { route }),
+      dbQuery<{ country: string | null; total: string }>(
+        `SELECT country, COUNT(*) AS total
+         FROM places
+         WHERE NULLIF(BTRIM(country), '') IS NOT NULL
+         GROUP BY country
+         ORDER BY COUNT(*) DESC
+         LIMIT $1`,
+        [TOP_COUNTRY_LIMIT],
+        { route },
+      ),
+    ]);
+
+    const totalPlaces = Number(totalRows[0]?.total ?? 0);
+
+    const byCountry = countryRows
+      .map((row) => ({
+        country: row.country ?? "Unknown",
+        total: Number(row.total ?? 0),
+      }))
+      .filter((entry) => entry.total > 0);
+
+    let verificationCounts = new Map<VerificationLevel, number>();
+    VERIFICATION_LEVELS.forEach((level) => verificationCounts.set(level, 0));
+
+    if (hasVerifications && verificationColumn) {
+      const { rows } = await dbQuery<{ level: string | null; total: string }>(
+        `SELECT COALESCE(v.${verificationColumn}, 'unverified') AS level, COUNT(*) AS total
+         FROM places p
+         LEFT JOIN verifications v ON v.place_id = p.id
+         GROUP BY level`,
+        [],
+        { route },
+      );
+      verificationCounts = new Map(
+        VERIFICATION_LEVELS.map((level) => [level, 0]),
+      );
+      rows.forEach((row) => {
+        const level = normalizeVerificationLevel(row.level);
+        verificationCounts.set(level, (verificationCounts.get(level) ?? 0) + Number(row.total ?? 0));
+      });
+    } else {
+      verificationCounts.set("unverified", totalPlaces);
+    }
+
+    const byVerification = VERIFICATION_LEVELS.map((level) => ({
+      level,
+      total: verificationCounts.get(level) ?? 0,
+    }));
+
+    return NextResponse.json<StatsApiResponse>(
+      {
+        total_places: totalPlaces,
+        by_country: byCountry,
+        by_verification: byVerification,
+      },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  } catch (error) {
+    if (error instanceof DbUnavailableError || (error as Error).message?.includes("DATABASE_URL")) {
+      return NextResponse.json({ error: "DB_UNAVAILABLE" }, { status: 503 });
+    }
+    console.error("[stats] failed to load stats", error);
+    return NextResponse.json({ error: "Failed to load stats" }, { status: 500 });
+  }
 }

--- a/app/api/stats/trends/route.ts
+++ b/app/api/stats/trends/route.ts
@@ -1,12 +1,103 @@
 import { NextResponse } from "next/server";
 
-import { monthlyTrends, weeklyTrends } from "@/lib/stats/trends";
-import { normalizeTrendPoint } from "@/lib/stats/utils";
+import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+import { ensureHistoryTable } from "@/lib/history";
+
+export type StatsTrendsPoint = {
+  date: string;
+  delta: number;
+  total: number;
+};
+
+export type StatsTrendsResponse = {
+  points: StatsTrendsPoint[];
+  meta?: { reason: "no_history_data" };
+};
+
+const CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=60";
+const TREND_DAYS = 30;
+const HISTORY_ACTIONS = ["approve", "promote"];
+
+const startOfUtcDay = (date: Date) => {
+  const copy = new Date(date);
+  copy.setUTCHours(0, 0, 0, 0);
+  return copy;
+};
+
+const formatDate = (date: Date) => date.toISOString().slice(0, 10);
+
+const buildDateRange = (days: number) => {
+  const today = startOfUtcDay(new Date());
+  const start = new Date(today);
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+  const dates: string[] = [];
+  for (let i = 0; i < days; i += 1) {
+    const current = new Date(start);
+    current.setUTCDate(start.getUTCDate() + i);
+    dates.push(formatDate(current));
+  }
+  return { start, dates };
+};
 
 export async function GET() {
-  const weekly = weeklyTrends.map(normalizeTrendPoint);
+  const route = "api_stats_trends";
 
-  const monthly = monthlyTrends.map(normalizeTrendPoint);
+  if (!hasDatabaseUrl()) {
+    return NextResponse.json<StatsTrendsResponse>(
+      { points: [], meta: { reason: "no_history_data" } },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  }
 
-  return NextResponse.json({ weekly, monthly });
+  try {
+    await ensureHistoryTable(route);
+
+    const { start, dates } = buildDateRange(TREND_DAYS);
+
+    const { rows } = await dbQuery<{ day: string; total: string }>(
+      `SELECT to_char(created_at::date, 'YYYY-MM-DD') AS day, COUNT(*) AS total
+       FROM public.history
+       WHERE action = ANY($1::text[])
+         AND place_id IS NOT NULL
+         AND created_at >= $2
+       GROUP BY day
+       ORDER BY day ASC`,
+      [HISTORY_ACTIONS, start.toISOString()],
+      { route },
+    );
+
+    if (!rows.length) {
+      return NextResponse.json<StatsTrendsResponse>(
+        { points: [], meta: { reason: "no_history_data" } },
+        { headers: { "Cache-Control": CACHE_CONTROL } },
+      );
+    }
+
+    const deltas = new Map<string, number>();
+    rows.forEach((row) => {
+      deltas.set(row.day, Number(row.total ?? 0));
+    });
+
+    let runningTotal = 0;
+    const points = dates.map((date) => {
+      const delta = deltas.get(date) ?? 0;
+      runningTotal += delta;
+      return {
+        date,
+        delta,
+        total: runningTotal,
+      };
+    });
+
+    return NextResponse.json<StatsTrendsResponse>(
+      { points },
+      { headers: { "Cache-Control": CACHE_CONTROL } },
+    );
+  } catch (error) {
+    if (error instanceof DbUnavailableError || (error as Error).message?.includes("DATABASE_URL")) {
+      return NextResponse.json({ error: "DB_UNAVAILABLE" }, { status: 503 });
+    }
+    console.error("[stats] failed to load trends", error);
+    return NextResponse.json({ error: "Failed to load trends" }, { status: 500 });
+  }
 }

--- a/app/internal/submissions/SubmissionDetailClient.tsx
+++ b/app/internal/submissions/SubmissionDetailClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { HistoryEntry } from "@/lib/history";
 import type { InternalSubmission } from "@/lib/internal-submissions";
@@ -69,7 +69,7 @@ export default function SubmissionDetailClient({ submissionId }: { submissionId:
     void load();
   }, [submissionId]);
 
-  const loadHistory = async () => {
+  const loadHistory = useCallback(async () => {
     try {
       setHistoryStatus("loading");
       const response = await fetch(`/api/internal/submissions/${submissionId}/history`);
@@ -84,11 +84,11 @@ export default function SubmissionDetailClient({ submissionId }: { submissionId:
       console.error("Failed to load history", err);
       setHistoryStatus("error");
     }
-  };
+  }, [submissionId]);
 
   useEffect(() => {
     void loadHistory();
-  }, [submissionId]);
+  }, [loadHistory]);
 
   const handleApprove = async () => {
     setMessage(null);

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -2,40 +2,34 @@
 
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { CategoryTrendPoint } from '@/lib/stats/dashboard';
-import type { CategoryStats, ChainStats, CountryStats, StatsKPI } from '@/lib/stats/aggregate';
-import type { MonthlyTrendPoint, WeeklyTrendPoint } from '@/lib/stats/trends';
-import type { VerificationKey } from '@/lib/types/stats';
-import { filterCategoryTrends, formatPeriodLabel, getCategoryNames } from '@/lib/stats/utils';
 import { safeFetch } from '@/lib/safeFetch';
 
+type VerificationLevel = 'owner' | 'community' | 'directory' | 'unverified';
+
 type StatsResponse = {
-  verificationTrends: {
-    weekly: WeeklyTrendPoint[];
-    monthly: MonthlyTrendPoint[];
-  };
-  countries: CountryStats[];
-  categoryTrends: {
-    weekly: CategoryTrendPoint[];
-    monthly: CategoryTrendPoint[];
-  };
-  byCountry: CountryStats[];
-  byCategory: CategoryStats[];
-  byChain: ChainStats[];
-  kpi: StatsKPI;
+  total_places: number;
+  by_country: Array<{ country: string; total: number }>;
+  by_verification: Array<{ level: VerificationLevel; total: number }>;
 };
 
-type FetchStatus = "idle" | "loading" | "success" | "error";
-
-type StatsTrendsResponse = {
-  weekly: WeeklyTrendPoint[];
-  monthly: MonthlyTrendPoint[];
+type TrendPoint = {
+  date: string;
+  delta: number;
+  total: number;
 };
 
-type FetchState = {
+type TrendsResponse = {
+  points: TrendPoint[];
+  meta?: { reason: 'no_history_data' };
+};
+
+type FetchStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type StatsState = {
   status: FetchStatus;
   error?: string;
-  data?: StatsResponse;
+  stats?: StatsResponse;
+  trends?: TrendsResponse;
 };
 
 type ChartSeries = {
@@ -44,21 +38,19 @@ type ChartSeries = {
   values: number[];
 };
 
-const STATS_COLORS: Record<VerificationKey, string> = {
-  total: '#6B7280',
+const VERIFICATION_LABELS: Record<VerificationLevel, string> = {
+  owner: 'Owner verified',
+  community: 'Community verified',
+  directory: 'Directory verified',
+  unverified: 'Unverified',
+};
+
+const VERIFICATION_COLORS: Record<VerificationLevel, string> = {
   owner: '#F59E0B',
   community: '#3B82F6',
   directory: '#14B8A6',
   unverified: '#9CA3AF',
 };
-
-const VERIFICATION_SERIES: { key: VerificationKey; label: string }[] = [
-  { key: 'total', label: 'Total places' },
-  { key: 'owner', label: 'Owner verified' },
-  { key: 'community', label: 'Community verified' },
-  { key: 'directory', label: 'Directory verified' },
-  { key: 'unverified', label: 'Unverified listings' },
-];
 
 const MAX_AXIS_LABELS = 8;
 
@@ -68,7 +60,7 @@ function getLabelStep(labels: string[]) {
 
 function Legend({ series }: { series: ChartSeries[] }) {
   return (
-    <div className="stats-legend mt-4 flex w-full flex-wrap gap-x-4 gap-y-2 text-sm leading-snug text-gray-700">
+    <div className="mt-4 flex w-full flex-wrap gap-x-4 gap-y-2 text-sm leading-snug text-gray-700">
       {series.map((item) => (
         <div key={item.label} className="flex items-center gap-2">
           <span className="h-3 w-3 rounded-sm" style={{ backgroundColor: item.color }} />
@@ -93,7 +85,7 @@ function LineChart({ labels, series }: { labels: string[]; series: ChartSeries[]
   const tickValues = Array.from({ length: tickCount + 1 }, (_, index) => Math.round((maxValue / tickCount) * index));
 
   return (
-    <div className="stats-chart-shell rounded-md bg-gray-50 p-4 sm:p-5">
+    <div className="rounded-md bg-gray-50 p-4 sm:p-5">
       <svg viewBox={`0 0 ${width} ${height}`} className="h-64 min-h-[16rem] w-full sm:h-72 lg:h-80">
         {tickValues.map((tick) => {
           const y = yScale(tick);
@@ -145,186 +137,45 @@ function LineChart({ labels, series }: { labels: string[]; series: ChartSeries[]
   );
 }
 
-function BarChart({ labels, series }: { labels: string[]; series: ChartSeries[] }) {
-  const width = 520;
-  const height = 260;
-  const padding = 32;
-  const groupWidth = (width - padding * 2) / Math.max(labels.length, 1);
-  const barWidth = groupWidth / (series.length + 1);
-  const labelStep = getLabelStep(labels);
-
-  const maxValue = Math.max(...series.flatMap((item) => item.values), 1);
-  const yScale = (value: number) => (value / maxValue) * (height - padding * 2);
-
-  const tickCount = 4;
-  const tickValues = Array.from({ length: tickCount + 1 }, (_, index) => Math.round((maxValue / tickCount) * index));
-
-  return (
-    <div className="stats-chart-shell rounded-md bg-gray-50 p-4 sm:p-5">
-      <svg viewBox={`0 0 ${width} ${height}`} className="h-64 min-h-[16rem] w-full sm:h-72 lg:h-80">
-        {tickValues.map((tick) => {
-          const y = height - padding - yScale(tick);
-          return (
-            <g key={tick}>
-              <line x1={padding} x2={width - padding} y1={y} y2={y} stroke="#e5e7eb" strokeWidth={1} />
-              <text x={8} y={y + 4} className="fill-gray-500 text-xs">
-                {tick}
-              </text>
-            </g>
-          );
-        })}
-
-        <line x1={padding} x2={padding} y1={padding} y2={height - padding} stroke="#9ca3af" strokeWidth={1.5} />
-        <line x1={padding} x2={width - padding} y1={height - padding} y2={height - padding} stroke="#9ca3af" strokeWidth={1.5} />
-
-        {labels.map((label, labelIndex) => {
-          const baseX = padding + labelIndex * groupWidth;
-          const labelY = height - padding + 16;
-          return (
-            <g key={label + labelIndex}>
-              {series.map((item, seriesIndex) => {
-                const value = item.values[labelIndex] ?? 0;
-                const barHeight = yScale(value);
-                const x = baseX + seriesIndex * barWidth + barWidth * 0.3;
-                const y = height - padding - barHeight;
-                return (
-                  <rect
-                    key={`${label}-${item.label}`}
-                    x={x}
-                    y={y}
-                    width={barWidth * 0.7}
-                    height={barHeight}
-                    rx={3}
-                    fill={item.color}
-                  />
-                );
-              })}
-              {labelIndex % labelStep === 0 ? (
-                <text
-                  x={baseX + groupWidth / 2}
-                  y={labelY}
-                  className="fill-gray-500 text-[9px] sm:text-[10px]"
-                  textAnchor="middle"
-                >
-                  {label}
-                </text>
-              ) : null}
-            </g>
-          );
-        })}
-      </svg>
-
-      <Legend series={series} />
-    </div>
-  );
-}
-
-function Card({
-  title,
+function SectionCard({
   eyebrow,
+  title,
   description,
   children,
-  className,
 }: {
-  title: string;
   eyebrow: string;
+  title: string;
   description: string;
   children: ReactNode;
-  className?: string;
 }) {
   return (
-    <div className={`stats-card rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200 sm:p-6 ${className ?? ''}`}>
-      <div className="mb-4 flex items-start justify-between gap-4">
-        <div className="space-y-1">
-          <p className="text-sm font-medium text-sky-700">{eyebrow}</p>
-          <h2 className="text-xl font-semibold leading-snug sm:text-[22px]">{title}</h2>
-          <p className="text-sm leading-relaxed text-gray-600 sm:max-w-2xl">{description}</p>
-        </div>
+    <section className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-gray-200 sm:p-6">
+      <div className="mb-4 space-y-1">
+        <p className="text-sm font-medium text-sky-700">{eyebrow}</p>
+        <h2 className="text-xl font-semibold leading-snug sm:text-[22px]">{title}</h2>
+        <p className="text-sm leading-relaxed text-gray-600 sm:max-w-2xl">{description}</p>
       </div>
       {children}
-    </div>
-  );
-}
-
-function KPICard({
-  title,
-  value,
-  color,
-  helper,
-}: {
-  title: string;
-  value: string;
-  color: string;
-  helper?: string;
-}) {
-  return (
-    <div className="flex flex-col rounded-md bg-white px-4 py-3 shadow-sm ring-1 ring-gray-200 sm:px-5 sm:py-4">
-      <div className="flex items-center gap-2 text-sm font-medium text-gray-600">
-        <span className="inline-block h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
-        {title}
-      </div>
-      <div className="mt-1 text-2xl font-semibold text-gray-900 sm:text-[26px]">{value}</div>
-      {helper ? <div className="text-xs text-gray-500">{helper}</div> : null}
-    </div>
-  );
-}
-
-function StackedBar({
-  owner,
-  community,
-  directory,
-  unverified,
-  total,
-}: {
-  owner: number;
-  community: number;
-  directory: number;
-  unverified: number;
-  total: number;
-}) {
-  const safeTotal = total || 1;
-  const segments = [
-    { color: STATS_COLORS.owner, value: owner },
-    { color: STATS_COLORS.community, value: community },
-    { color: STATS_COLORS.directory, value: directory },
-    { color: STATS_COLORS.unverified, value: unverified },
-  ];
-
-  return (
-    <div className="mt-2 h-2.5 overflow-hidden rounded-full bg-gray-100">
-      {segments.map((segment) => {
-        const width = (segment.value / safeTotal) * 100;
-        if (!width) return null;
-        return <span key={segment.color} className="block h-full" style={{ width: `${width}%`, backgroundColor: segment.color }} />;
-      })}
-    </div>
+    </section>
   );
 }
 
 export default function StatsPage() {
-  const [state, setState] = useState<FetchState>({ status: "loading" });
-  const [selectedCategory, setSelectedCategory] = useState<string>('');
+  const [state, setState] = useState<StatsState>({ status: 'loading' });
 
   const fetchStats = useCallback(async () => {
-    setState({ status: "loading" });
+    setState({ status: 'loading' });
     try {
-      const [statsSnapshot, trendsSnapshot] = await Promise.all([
+      const [stats, trends] = await Promise.all([
         safeFetch<StatsResponse>('/api/stats'),
-        safeFetch<StatsTrendsResponse>('/api/stats/trends'),
+        safeFetch<TrendsResponse>('/api/stats/trends'),
       ]);
-
-      const data: StatsResponse = {
-        ...statsSnapshot,
-        verificationTrends:
-          statsSnapshot.verificationTrends ?? trendsSnapshot,
-      };
-
-      setState({ status: "success", data });
-      const categories = getCategoryNames(data.categoryTrends.weekly);
-      setSelectedCategory(categories[0] ?? '');
+      setState({ status: 'success', stats, trends });
     } catch (error) {
-      setState({ status: "error", error: 'Failed to load stats. Please try again.' });
-      setSelectedCategory('');
+      setState({
+        status: 'error',
+        error: 'Failed to load stats. Please try again.',
+      });
     }
   }, []);
 
@@ -332,212 +183,136 @@ export default function StatsPage() {
     fetchStats();
   }, [fetchStats]);
 
-  const data = state.data;
-
-  const weeklySeries = useMemo<ChartSeries[]>(() => {
-    if (!data) return [];
-
-    return VERIFICATION_SERIES.map((series) => ({
-      label: series.label,
-      color: STATS_COLORS[series.key],
-      values: data.verificationTrends.weekly.map((entry) => entry[series.key]),
-    }));
-  }, [data]);
-
-  const monthlySeries = useMemo<ChartSeries[]>(() => {
-    if (!data) return [];
-
-    return VERIFICATION_SERIES.map((series) => ({
-      label: series.label,
-      color: STATS_COLORS[series.key],
-      values: data.verificationTrends.monthly.map((entry) => entry[series.key]),
-    }));
-  }, [data]);
-
-  const categoryNames = useMemo(() => (data ? getCategoryNames(data.categoryTrends.weekly) : []), [data]);
-
-  const weeklyCategory = useMemo(() => {
-    if (!data || !selectedCategory) return [] as CategoryTrendPoint[];
-    return filterCategoryTrends(data.categoryTrends.weekly, selectedCategory);
-  }, [selectedCategory, data]);
-
-  const monthlyCategory = useMemo(() => {
-    if (!data || !selectedCategory) return [] as CategoryTrendPoint[];
-    return filterCategoryTrends(data.categoryTrends.monthly, selectedCategory);
-  }, [selectedCategory, data]);
-
-  const weeklyCategorySeries = useMemo(() => {
-    if (!weeklyCategory.length) return [] as ChartSeries[];
-
-    return VERIFICATION_SERIES.map((series) => ({
-      label: series.label,
-      color: STATS_COLORS[series.key],
-      values: weeklyCategory.map((entry) => entry[series.key]),
-    }));
-  }, [weeklyCategory]);
-
-  const monthlyCategorySeries = useMemo(() => {
-    if (!monthlyCategory.length) return [] as ChartSeries[];
-
-    return VERIFICATION_SERIES.map((series) => ({
-      label: series.label,
-      color: STATS_COLORS[series.key],
-      values: monthlyCategory.map((entry) => entry[series.key]),
-    }));
-  }, [monthlyCategory]);
-
-  const showLoading = state.status === "loading";
-  const showError = state.status === "error";
-  const errorMessage = state.error ?? 'Failed to load stats. Please try again.';
-
-  if (showLoading) {
+  if (state.status === 'loading') {
     return (
-      <main className="stats-page flex min-h-screen flex-col gap-8 bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 animate-pulse">
-          <header className="max-w-4xl space-y-3">
+      <main className="flex min-h-screen flex-col gap-8 bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 animate-pulse">
+          <header className="space-y-3">
             <div className="h-4 w-16 rounded bg-sky-100" />
             <div className="h-8 w-64 rounded bg-gray-200" />
             <div className="h-4 w-full max-w-2xl rounded bg-gray-200" />
-            <div className="h-4 w-full max-w-xl rounded bg-gray-200" />
           </header>
-
-          <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {[...Array(4)].map((_, index) => (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {[...Array(3)].map((_, index) => (
               <div key={index} className="rounded-lg bg-white p-4 shadow-sm">
                 <div className="h-4 w-24 rounded bg-gray-200" />
                 <div className="mt-3 h-7 w-32 rounded bg-gray-300" />
                 <div className="mt-2 h-3 w-20 rounded bg-gray-200" />
               </div>
             ))}
-          </section>
-
-          <section className="grid gap-6 md:grid-cols-2">
-            {[...Array(2)].map((_, index) => (
-              <div key={index} className="rounded-md bg-gray-100 p-4 sm:p-5">
-                <div className="h-5 w-24 rounded bg-gray-200" />
-                <div className="mt-2 h-6 w-48 rounded bg-gray-200" />
-                <div className="mt-4 h-40 rounded bg-white" />
-              </div>
-            ))}
-          </section>
-
-          <section className="grid gap-6 lg:grid-cols-3">
-            <div className="lg:col-span-2 rounded-md bg-white p-4 shadow-sm">
-              <div className="flex flex-col gap-2">
-                <div className="h-4 w-28 rounded bg-gray-200" />
-                <div className="h-5 w-56 rounded bg-gray-200" />
-              </div>
-              <div className="mt-4 h-48 rounded bg-gray-100" />
-            </div>
-            <div className="rounded-md bg-white p-4 shadow-sm">
-              <div className="h-4 w-24 rounded bg-gray-200" />
-              <div className="mt-2 h-5 w-40 rounded bg-gray-200" />
-              <div className="mt-4 space-y-3">
-                {[...Array(4)].map((_, idx) => (
-                  <div key={idx} className="h-10 rounded bg-gray-100" />
-                ))}
-              </div>
-            </div>
-          </section>
-        </div>
-      </main>
-    );
-  }
-
-  const errorBanner = showError ? (
-    <div className="flex flex-col gap-3 rounded-md border border-red-100 bg-red-50 px-4 py-3 text-red-700">
-      <p className="font-medium">{errorMessage}</p>
-      <p className="text-sm">統計データの取得に失敗しました。再度お試しください。</p>
-      <div className="flex flex-wrap gap-3">
-        <button
-          type="button"
-          onClick={fetchStats}
-          disabled={showLoading}
-          className="inline-flex max-w-fit items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-400"
-        >
-          {showLoading && (
-            <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/60 border-t-white" aria-hidden />
-          )}
-          <span>Retry</span>
-        </button>
-      </div>
-    </div>
-  ) : null;
-
-  if (!data) {
-    return (
-      <main className="stats-page flex min-h-screen flex-col gap-8 bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6">
-          <header className="max-w-4xl space-y-2">
-            <p className="text-sm uppercase tracking-wide text-sky-700">Stats</p>
-            <h1 className="text-3xl font-semibold leading-tight">Marketplace dashboard</h1>
-            <p className="text-sm leading-relaxed text-gray-600 sm:text-base">
-              Country rankings and category momentum for the CryptoPayMap community. Data below is seeded for development and visualization purposes.
-            </p>
-          </header>
-          {errorBanner}
-          <div className="rounded-lg bg-white px-5 py-6 text-center text-gray-700 shadow-sm ring-1 ring-gray-200">
-            <p className="text-base font-semibold text-gray-900">No stats data to display.</p>
-            <p className="mt-1 text-sm text-gray-600">Please retry or refresh the page once connectivity is restored.</p>
+          </div>
+          <div className="rounded-lg bg-white p-6 shadow-sm">
+            <div className="h-4 w-32 rounded bg-gray-200" />
+            <div className="mt-4 h-48 rounded bg-gray-100" />
           </div>
         </div>
       </main>
     );
   }
 
-  const verifiedTotal = data.kpi.ownerCount + data.kpi.communityCount;
-  const verifiedRatio = data.kpi.totalPlaces ? Math.round((verifiedTotal / data.kpi.totalPlaces) * 100) : 0;
-  const maxChainTotal = Math.max(...data.byChain.map((entry) => entry.total), 1);
+  if (state.status === 'error' || !state.stats || !state.trends) {
+    return (
+      <main className="flex min-h-screen flex-col gap-6 bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+          <header className="space-y-2">
+            <p className="text-sm uppercase tracking-wide text-sky-700">Stats</p>
+            <h1 className="text-3xl font-semibold leading-tight">Marketplace snapshot</h1>
+            <p className="text-sm leading-relaxed text-gray-600 sm:text-base">
+              Live counts for places, verification levels, and trend activity.
+            </p>
+          </header>
+          <div className="rounded-md border border-red-100 bg-red-50 px-4 py-3 text-red-700">
+            <p className="font-medium">{state.error ?? 'Failed to load stats.'}</p>
+            <p className="text-sm">統計データの取得に失敗しました。再度お試しください。</p>
+            <button
+              type="button"
+              onClick={fetchStats}
+              className="mt-3 inline-flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700"
+            >
+              Retry
+            </button>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  const { stats, trends } = state;
+  const trendLabels = trends.points.map((point) => point.date);
+  const trendSeries = useMemo<ChartSeries[]>(
+    () => [
+      {
+        label: 'Total published places',
+        color: '#2563EB',
+        values: trends.points.map((point) => point.total),
+      },
+    ],
+    [trends.points],
+  );
 
   return (
-    <main className="stats-page flex min-h-screen flex-col bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
+    <main className="flex min-h-screen flex-col bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
-        <header className="max-w-4xl space-y-2">
+        <header className="space-y-2">
           <p className="text-sm uppercase tracking-wide text-sky-700">Stats</p>
-          <h1 className="text-3xl font-semibold leading-tight">Marketplace dashboard</h1>
+          <h1 className="text-3xl font-semibold leading-tight">Marketplace snapshot</h1>
           <p className="text-sm leading-relaxed text-gray-600 sm:text-base">
-            Country rankings, category momentum, and crypto support for the CryptoPayMap community. Data below is seeded for development and visualization purposes.
+            Live counts for places, verification levels, and growth momentum from moderation history.
           </p>
         </header>
 
-        {errorBanner}
-
-        {weeklySeries && monthlySeries && (
-          <section className="grid gap-6 md:grid-cols-2">
-            <Card eyebrow="Weekly" title="Verification trend" description="Owner, community, directory, and unverified places by week.">
-              <LineChart labels={data.verificationTrends.weekly.map((entry) => formatPeriodLabel(entry.label))} series={weeklySeries} />
-            </Card>
-
-            <Card eyebrow="Monthly" title="Verification trend" description="Aggregated monthly progress across all verification types.">
-              <BarChart labels={data.verificationTrends.monthly.map((entry) => formatPeriodLabel(entry.label))} series={monthlySeries} />
-            </Card>
-          </section>
-        )}
-
-        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-          <KPICard title="Total places" value={data.kpi.totalPlaces.toLocaleString()} color={STATS_COLORS.total} />
-          <KPICard
-            title="Owner places"
-            value={data.kpi.ownerCount.toLocaleString()}
-            color={STATS_COLORS.owner}
-            helper={`${Math.round(data.kpi.ownerRatio * 100)}% of all listings`}
-          />
-          <KPICard
-            title="Community places"
-            value={data.kpi.communityCount.toLocaleString()}
-            color={STATS_COLORS.community}
-            helper={`${Math.round(data.kpi.communityRatio * 100)}% of all listings`}
-          />
-          <KPICard title="Verified ratio" value={`${verifiedRatio}%`} color={STATS_COLORS.total} helper="Owner + community" />
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="flex flex-col rounded-md bg-white px-4 py-3 shadow-sm ring-1 ring-gray-200 sm:px-5 sm:py-4">
+            <span className="text-sm font-medium text-gray-600">Total places</span>
+            <span className="mt-1 text-2xl font-semibold text-gray-900 sm:text-[26px]">
+              {stats.total_places.toLocaleString()}
+            </span>
+            <span className="text-xs text-gray-500">All published listings</span>
+          </div>
+          {stats.by_verification.map((entry) => (
+            <div
+              key={entry.level}
+              className="flex flex-col rounded-md bg-white px-4 py-3 shadow-sm ring-1 ring-gray-200 sm:px-5 sm:py-4"
+            >
+              <span className="text-sm font-medium text-gray-600">{VERIFICATION_LABELS[entry.level]}</span>
+              <span className="mt-1 text-2xl font-semibold text-gray-900 sm:text-[26px]">
+                {entry.total.toLocaleString()}
+              </span>
+              <span className="mt-2 h-2 w-full rounded-full bg-gray-100">
+                <span
+                  className="block h-full rounded-full"
+                  style={{
+                    width: stats.total_places
+                      ? `${Math.round((entry.total / stats.total_places) * 100)}%`
+                      : '0%',
+                    backgroundColor: VERIFICATION_COLORS[entry.level],
+                  }}
+                />
+              </span>
+            </div>
+          ))}
         </section>
 
-        <section className="grid gap-6 lg:grid-cols-3">
-          <Card
-            eyebrow="Top countries"
-            title="Country ranking"
-            description="Top countries by verification mix across owner, community, directory, and unverified listings."
-            className="lg:col-span-2"
-          >
+        <SectionCard
+          eyebrow="Trends"
+          title="Growth over the last 30 days"
+          description="Daily cumulative totals based on moderation history (approve/promote actions)."
+        >
+          {trends.points.length ? (
+            <LineChart labels={trendLabels} series={trendSeries} />
+          ) : (
+            <div className="rounded-md border border-dashed border-gray-200 bg-gray-50 px-4 py-8 text-center text-sm text-gray-600">
+              Not enough trend data yet.
+            </div>
+          )}
+        </SectionCard>
+
+        <SectionCard
+          eyebrow="Top countries"
+          title="Where listings are growing"
+          description="Top countries by total published places."
+        >
+          {stats.by_country.length ? (
             <div className="overflow-hidden rounded-md border border-gray-200">
               <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200 text-sm">
@@ -545,124 +320,25 @@ export default function StatsPage() {
                     <tr>
                       <th className="px-4 py-2 text-left">Country</th>
                       <th className="px-4 py-2 text-right">Total</th>
-                      <th className="px-4 py-2 text-right">Owner</th>
-                      <th className="px-4 py-2 text-right">Community</th>
-                      <th className="px-4 py-2 text-right">Directory</th>
-                      <th className="px-4 py-2 text-right">Unverified</th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-100">
-                    {data.byCountry.slice(0, 10).map((entry) => (
+                    {stats.by_country.slice(0, 10).map((entry) => (
                       <tr key={entry.country} className="bg-white">
                         <td className="whitespace-nowrap px-4 py-2 font-medium text-gray-900">{entry.country}</td>
                         <td className="whitespace-nowrap px-4 py-2 text-right text-gray-800">{entry.total}</td>
-                        <td className="whitespace-nowrap px-4 py-2 text-right text-gray-800">{entry.owner}</td>
-                        <td className="whitespace-nowrap px-4 py-2 text-right text-gray-800">{entry.community}</td>
-                        <td className="whitespace-nowrap px-4 py-2 text-right text-gray-800">{entry.directory}</td>
-                        <td className="whitespace-nowrap px-4 py-2 text-right text-gray-800">{entry.unverified}</td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
             </div>
-          </Card>
-
-          <Card
-            eyebrow="Chains"
-            title="Supported crypto"
-            description="How many places accept each chain or asset."
-            className="h-full"
-          >
-            <ul className="mt-2 space-y-3 text-sm text-gray-800">
-              {data.byChain.map((entry) => (
-                <li key={entry.chain} className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-                  <div className="flex items-center justify-between gap-4">
-                    <span className="font-medium uppercase tracking-wide text-gray-900">{entry.chain}</span>
-                    <span className="text-gray-700">{entry.total} places</span>
-                  </div>
-                  <div className="mt-2 h-2 rounded-full bg-white">
-                    <div
-                      className="h-full rounded-full"
-                      style={{ width: `${(entry.total / maxChainTotal) * 100}%`, backgroundColor: STATS_COLORS.total }}
-                    />
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </Card>
-        </section>
-
-        <section className="grid gap-6 lg:grid-cols-2">
-          <Card
-            eyebrow="Categories"
-            title="Category distribution"
-            description="Verification mix per category. The bars stack owner, community, directory, and unverified counts."
-          >
-            <div className="space-y-3 text-sm text-gray-800">
-              {data.byCategory.map((entry) => (
-                <div key={entry.category} className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-2 font-medium text-gray-900">
-                      <span className="uppercase tracking-wide">{entry.category}</span>
-                    </div>
-                    <div className="text-gray-700">{entry.total} places</div>
-                  </div>
-                  <StackedBar
-                    owner={entry.owner}
-                    community={entry.community}
-                    directory={entry.directory}
-                    unverified={entry.unverified}
-                    total={entry.total}
-                  />
-                  <div className="mt-2 flex flex-wrap gap-4 text-xs text-gray-600">
-                    <span className="flex items-center gap-1"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: STATS_COLORS.owner }} /> Owner {entry.owner}</span>
-                    <span className="flex items-center gap-1"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: STATS_COLORS.community }} /> Community {entry.community}</span>
-                    <span className="flex items-center gap-1"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: STATS_COLORS.directory }} /> Directory {entry.directory}</span>
-                    <span className="flex items-center gap-1"><span className="h-2 w-2 rounded-full" style={{ backgroundColor: STATS_COLORS.unverified }} /> Unverified {entry.unverified}</span>
-                  </div>
-                </div>
-              ))}
+          ) : (
+            <div className="rounded-md border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm text-gray-600">
+              No country data available yet.
             </div>
-          </Card>
-
-          {weeklyCategorySeries && monthlyCategorySeries && (
-            <Card
-              eyebrow="Category focus"
-              title="Weekly category trend"
-              description="Compare how each category is growing week over week."
-            >
-              <div className="mb-4">
-                <label className="flex items-center gap-2 text-sm text-gray-700">
-                  Select category
-                  <select
-                    className="rounded-md border border-gray-300 bg-white px-2 py-1 text-sm"
-                    value={selectedCategory}
-                    onChange={(event) => setSelectedCategory(event.target.value)}
-                  >
-                    {categoryNames.map((name) => (
-                      <option key={name} value={name}>
-                        {name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-
-              <LineChart labels={weeklyCategory.map((entry) => formatPeriodLabel(entry.period))} series={weeklyCategorySeries} />
-            </Card>
           )}
-        </section>
-
-        {weeklyCategorySeries && monthlyCategorySeries && (
-          <Card
-            eyebrow="Category focus"
-            title="Monthly category trend"
-            description="Verification mix across total, owner, community, directory, and unverified listings for the chosen category."
-          >
-            <BarChart labels={monthlyCategory.map((entry) => formatPeriodLabel(entry.period))} series={monthlyCategorySeries} />
-          </Card>
-        )}
+        </SectionCard>
       </div>
     </main>
   );

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -162,6 +162,20 @@ function SectionCard({
 
 export default function StatsPage() {
   const [state, setState] = useState<StatsState>({ status: 'loading' });
+  const stats = state.stats;
+  const trends = state.trends;
+  const trendPoints = useMemo(() => trends?.points ?? [], [trends?.points]);
+  const trendLabels = useMemo(() => trendPoints.map((point) => point.date), [trendPoints]);
+  const trendSeries = useMemo<ChartSeries[]>(
+    () => [
+      {
+        label: 'Total published places',
+        color: '#2563EB',
+        values: trendPoints.map((point) => point.total),
+      },
+    ],
+    [trendPoints],
+  );
 
   const fetchStats = useCallback(async () => {
     setState({ status: 'loading' });
@@ -210,7 +224,7 @@ export default function StatsPage() {
     );
   }
 
-  if (state.status === 'error' || !state.stats || !state.trends) {
+  if (state.status === 'error' || !stats || !trends) {
     return (
       <main className="flex min-h-screen flex-col gap-6 bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
@@ -236,19 +250,6 @@ export default function StatsPage() {
       </main>
     );
   }
-
-  const { stats, trends } = state;
-  const trendLabels = trends.points.map((point) => point.date);
-  const trendSeries = useMemo<ChartSeries[]>(
-    () => [
-      {
-        label: 'Total published places',
-        color: '#2563EB',
-        values: trends.points.map((point) => point.total),
-      },
-    ],
-    [trends.points],
-  );
 
   return (
     <main className="flex min-h-screen flex-col bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">

--- a/lib/history.ts
+++ b/lib/history.ts
@@ -68,6 +68,20 @@ export const ensureHistoryTable = async (route: string, client?: PoolClient) => 
     [],
     { route, client },
   );
+
+  await dbQuery(
+    `CREATE INDEX IF NOT EXISTS history_created_at_idx
+     ON public.history (created_at DESC)`,
+    [],
+    { route, client },
+  );
+
+  await dbQuery(
+    `CREATE INDEX IF NOT EXISTS history_action_idx
+     ON public.history (action)`,
+    [],
+    { route, client },
+  );
 };
 
 export const recordHistoryEntry = async (options: {


### PR DESCRIPTION
### Motivation
- Provide DB-backed aggregates for site statistics (counts by country and verification) so the public stats page shows real data and stays fast.
- Base growth trends on the `history` audit trail (actions like `approve`/`promote`) to avoid relying on partial or unreliable `created_at` fields.
- Ensure the stats endpoints and UI never crash on sparse or missing DB data by returning safe empty shapes and metadata.
- Improve query performance for trend and aggregation hot paths by adding indexes and simple caching headers.

### Description
- Implemented `GET /api/stats` (file `app/api/stats/route.ts`) that returns a typed JSON shape `{ total_places, by_country, by_verification }` using efficient `COUNT` and `GROUP BY` queries and a top-N country limit, and creates optional indexes for `places(country)` and verification columns.
- Implemented `GET /api/stats/trends` (file `app/api/stats/trends/route.ts`) that aggregates `approve`/`promote` rows from `public.history` over the last 30 days and returns `{ points: [{ date, delta, total }] }`, with a graceful fallback `{ points: [], meta: { reason: 'no_history_data' } }` when history is unavailable.
- Rebuilt the stats UI at `app/stats/page.tsx` to use the new endpoints and show total places, verification breakdown, top countries, and a trends chart with an explicit empty-state message "Not enough trend data yet.".
- Added history-related DB indexes in `lib/history.ts` (indexes on `created_at` and `action`) and added cache-control headers (`s-maxage=300`) for the stats endpoints to reduce load.

### Testing
- Launched the dev server with `npm run dev` and the Next.js server compiled the new `/stats` page and `/api/stats` route successfully (dev server ready). 
- Loaded the `/stats` page in a headless browser and captured a screenshot to verify the UI rendered against the new endpoints (Playwright run succeeded). 
- Verified the code was committed (changes staged and committed locally). 
- No automated unit tests or CI runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695519b43a18832881ecb1807140513f)