### PR TITLE
Make map the homepage, add global header and temporary brand assets

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,32 @@
 import './globals.css';
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
+import GlobalHeader from '@/components/GlobalHeader';
+
+const description = 'CryptoPayMap — discover places that accept cryptocurrency payments.';
 
 export const metadata: Metadata = {
-  title: 'CryptoPayMap v2',
-  description: 'Cryptocurrency payments map scaffold'
+  title: 'CryptoPayMap',
+  description,
+  icons: {
+    icon: '/favicon.svg',
+  },
+  openGraph: {
+    title: 'CryptoPayMap',
+    description,
+    images: ['/og.svg'],
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className="min-h-screen bg-white text-gray-900">
+        <div className="flex min-h-screen flex-col">
+          <GlobalHeader />
+          <main className="flex-1">{children}</main>
+        </div>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import MapClient from '../components/map/MapClient';
+
 export default function HomePage() {
-  return <div>CryptoPayMap v2 scaffold</div>;
+  return <MapClient />;
 }

--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const NAV_LINKS = [
+  { label: 'Map', href: '/' },
+  { label: 'Discover', href: '/discover' },
+  { label: 'Stats', href: '/stats' },
+  { label: 'Submit', href: '/submit' },
+  { label: 'Donate', href: '/donate' },
+  { label: 'Disclaimer/About', href: '/about' },
+];
+
+const isActivePath = (pathname: string, href: string) => {
+  if (href === '/') {
+    return pathname === '/' || pathname.startsWith('/map');
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+};
+
+export default function GlobalHeader() {
+  const pathname = usePathname();
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur">
+      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6">
+        <Link href="/" className="flex items-center gap-3 font-semibold text-gray-900">
+          <img
+            src="/brand/logo.svg"
+            alt="CryptoPayMap logo"
+            className="h-9 w-9"
+          />
+          <span className="text-base sm:text-lg">CryptoPayMap</span>
+        </Link>
+        <nav className="hidden items-center gap-4 text-sm font-medium text-gray-600 md:flex">
+          {NAV_LINKS.map((link) => {
+            const isActive = isActivePath(pathname, link.href);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={
+                  isActive
+                    ? 'rounded-full bg-gray-900 px-3 py-1.5 text-white'
+                    : 'rounded-full px-3 py-1.5 text-gray-600 transition hover:text-gray-900'
+                }
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+        <div className="md:hidden">
+          <Link
+            href="/"
+            className="rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700"
+          >
+            Menu
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/lib/filters";
 import DbStatusIndicator from "@/components/status/DbStatusIndicator";
 
-const HEADER_HEIGHT = 0;
+const HEADER_HEIGHT = 64;
 
 const DEFAULT_COORDINATES: [number, number] = [20, 0];
 const DEFAULT_ZOOM = 2;

--- a/public/brand/logo.svg
+++ b/public/brand/logo.svg
@@ -1,0 +1,8 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="4" width="120" height="120" rx="24" fill="#111827" />
+  <rect x="4" y="4" width="120" height="120" rx="24" stroke="#F97316" stroke-width="8" />
+  <path d="M42 64C42 51.297 52.297 41 65 41H86" stroke="#F97316" stroke-width="10" stroke-linecap="round" />
+  <path d="M86 64C86 76.703 75.703 87 63 87H42" stroke="#F97316" stroke-width="10" stroke-linecap="round" />
+  <circle cx="42" cy="64" r="6" fill="#F97316" />
+  <circle cx="86" cy="64" r="6" fill="#F97316" />
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="8" y="8" width="112" height="112" rx="24" fill="#111827" />
+  <rect x="8" y="8" width="112" height="112" rx="24" stroke="#F97316" stroke-width="8" />
+  <path d="M44 64C44 52.402 53.402 43 65 43H84" stroke="#F97316" stroke-width="10" stroke-linecap="round" />
+  <path d="M84 64C84 75.598 74.598 85 63 85H44" stroke="#F97316" stroke-width="10" stroke-linecap="round" />
+  <circle cx="44" cy="64" r="6" fill="#F97316" />
+  <circle cx="84" cy="64" r="6" fill="#F97316" />
+</svg>

--- a/public/og.svg
+++ b/public/og.svg
@@ -1,0 +1,10 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1200" height="630" rx="48" fill="#0F172A" />
+  <rect x="80" y="80" width="470" height="470" rx="64" fill="#111827" stroke="#F97316" stroke-width="16" />
+  <path d="M240 315C240 250.964 291.964 199 356 199H452" stroke="#F97316" stroke-width="36" stroke-linecap="round" />
+  <path d="M452 315C452 379.036 400.036 431 336 431H240" stroke="#F97316" stroke-width="36" stroke-linecap="round" />
+  <circle cx="240" cy="315" r="18" fill="#F97316" />
+  <circle cx="452" cy="315" r="18" fill="#F97316" />
+  <text x="600" y="320" fill="#F8FAFC" font-family="'Inter', 'Segoe UI', sans-serif" font-size="72" font-weight="700">CryptoPayMap</text>
+  <text x="600" y="395" fill="#CBD5F5" font-family="'Inter', 'Segoe UI', sans-serif" font-size="32">Find places that accept crypto worldwide</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Replace the v2 scaffold with the interactive map as the primary homepage to meet UX expectations.
- Add a persistent global header with logo and navigation so the site has a consistent top-level chrome.
- Provide single-source, replaceable brand assets and wire them into Next metadata for favicon and OG previews.
- Ensure the map layout accounts for the header height so map UI does not get obscured.

### Description
- Render the map on `/` by updating `app/page.tsx` to return `MapClient` instead of scaffold text.
- Add a new client component `components/GlobalHeader.tsx` that shows the square SVG logo and nav links and highlights the active route.
- Update `app/layout.tsx` to include `GlobalHeader`, configure metadata icons/OG image, and wrap app content in a main layout.
- Add temporary SVG assets at `public/brand/logo.svg`, `public/favicon.svg`, and `public/og.svg`, and adjust `components/map/MapClient.tsx` to use a `HEADER_HEIGHT` of `64` to account for the header.

### Testing
- Started the dev server with `npm run dev` and verified compilation succeeded for pages and API routes.
- Automated Playwright script visited `/` and captured a screenshot of the homepage with the header and map, which completed successfully.
- Manual verification during the dev run confirmed the header, nav active state, and that `/map` routes render the same map view as `/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586826fac483288b30c1586ae93e17)