### PR TITLE
Add Discover, Donate, and About pages with copy-to-clipboard donation buttons

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+
+export default function AboutPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 sm:py-12">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">About &amp; Disclaimer</p>
+        <h1 className="text-3xl font-semibold text-gray-900 sm:text-4xl">About CryptoPayMap</h1>
+        <p className="max-w-2xl text-base text-gray-600">
+          CryptoPayMap is a community-driven directory that helps travelers and locals discover places accepting
+          cryptocurrency payments.
+        </p>
+      </header>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">Data sources</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Listings come from verified owner submissions, community contributions, and publicly available directories.
+          We periodically review and update entries as new information arrives.
+        </p>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">Accuracy disclaimer</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Information on this site is provided as-is and may change without notice. Always confirm payment methods and
+          availability directly with each venue before relying on it.
+        </p>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">Contact &amp; issues</h2>
+        <p className="mt-2 text-sm text-gray-600">
+          Found an incorrect listing or want to request a feature? Please open an issue on GitHub.
+        </p>
+        <Link
+          href="https://github.com/badjoke-lab/cryptopaymap-v2/issues"
+          target="_blank"
+          rel="noreferrer"
+          className="mt-4 inline-flex rounded-full border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700"
+        >
+          Visit GitHub Issues
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/app/discover/page.tsx
+++ b/app/discover/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+
+export default function DiscoverPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 sm:py-12">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">Discover</p>
+        <h1 className="text-3xl font-semibold text-gray-900 sm:text-4xl">Find crypto-friendly destinations</h1>
+        <p className="max-w-2xl text-base text-gray-600">
+          We are building a curated directory of neighborhoods and travel clusters that accept cryptocurrency.
+          This space will soon feature themed collections and guides.
+        </p>
+      </header>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">Directory highlights (coming soon)</h2>
+        <ul className="mt-4 space-y-3 text-sm text-gray-600">
+          <li>• City hubs with the highest concentration of crypto-friendly venues.</li>
+          <li>• Merchants verified by owners and the community.</li>
+          <li>• Suggested routes and trip planning tips.</li>
+        </ul>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <Link
+            href="/"
+            className="rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white"
+          >
+            Explore the map
+          </Link>
+          <Link
+            href="/submit"
+            className="rounded-full border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700"
+          >
+            Submit a place
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/donate/page.tsx
+++ b/app/donate/page.tsx
@@ -1,0 +1,118 @@
+import CopyButton from '@/components/CopyButton';
+
+const DONATION_ADDRESSES = [
+  {
+    label: 'BTC',
+    address: 'bc1qhg2a9yp6nwdlfuzvm70dpzfun0xzrctn4cyzlt',
+    network: 'Bitcoin',
+  },
+  {
+    label: 'ETH',
+    address: '0xc0c79cacdcb6e152800c8e1c1d73ab647a1132f9',
+    network: 'Ethereum (ERC-20)',
+  },
+  {
+    label: 'USDT',
+    address: '0xc0c79cacdcb6e152800c8e1c1d73ab647a1132f9',
+    network: 'ERC-20 / BEP-20',
+  },
+  {
+    label: 'USDC',
+    address: '0xc0c79cacdcb6e152800c8e1c1d73ab647a1132f9',
+    network: 'ERC-20 / BEP-20',
+  },
+  {
+    label: 'SOL',
+    address: '7aqoEHgKniBoUbgyJLBEsGKZG2K3seTsbCwQrxAi9DMR',
+    network: 'Solana',
+  },
+  {
+    label: 'BNB',
+    address: '0xc0c79cacdcb6e152800c8e1c1d73ab647a1132f9',
+    network: 'BEP-20',
+  },
+  {
+    label: 'DOGE',
+    address: 'DBcD6vrY1KWZGxzohaADF2LYKkZbL1qD8q',
+    network: 'Dogecoin',
+  },
+  {
+    label: 'AVAX',
+    address: '0xc0c79cacdcb6e152800c8e1c1d73ab647a1132f9',
+    network: 'Avalanche C-Chain',
+  },
+  {
+    label: 'XRP',
+    address: 'rHFpSj15qmruSpptrVZxGZxDPGVjNRu95S',
+    network: 'Ripple',
+  },
+];
+
+const SUPPORT_LINKS = [
+  {
+    label: 'Donate with Stripe',
+    href: 'https://buy.stripe.com/cNi8wI7oPcvS4x528zcIE00',
+  },
+  {
+    label: 'Support on Ko-fi',
+    href: 'https://ko-fi.com/badjoke_lab',
+  },
+];
+
+export default function DonatePage() {
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 sm:py-12">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">Donate</p>
+        <h1 className="text-3xl font-semibold text-gray-900 sm:text-4xl">Support the CryptoPayMap project</h1>
+        <p className="max-w-2xl text-base text-gray-600">
+          Your contributions help us maintain the directory, verify submissions, and build new discovery tools for the
+          crypto community.
+        </p>
+      </header>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">Crypto addresses</h2>
+        <p className="mt-2 text-sm text-gray-600">Tap the copy button to save any address.</p>
+
+        <div className="mt-6 space-y-4">
+          {DONATION_ADDRESSES.map((item) => (
+            <div
+              key={`${item.label}-${item.network}`}
+              className="flex flex-col gap-3 rounded-lg border border-gray-100 bg-gray-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-base font-semibold text-gray-900">{item.label}</span>
+                  <span className="rounded-full bg-white px-2.5 py-0.5 text-xs font-medium text-gray-500">
+                    {item.network}
+                  </span>
+                </div>
+                <p className="mt-2 break-all font-mono text-sm text-gray-700">{item.address}</p>
+              </div>
+              <CopyButton text={item.address} ariaLabel={`Copy ${item.label} address`} />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-xl font-semibold text-gray-900">Card &amp; hosted donations</h2>
+        <p className="mt-2 text-sm text-gray-600">Prefer a traditional checkout? Use one of the hosted options.</p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          {SUPPORT_LINKS.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white"
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { copyText } from '@/lib/clipboard';
+
+type CopyStatus = 'idle' | 'copied' | 'error';
+
+type CopyButtonProps = {
+  text: string;
+  ariaLabel?: string;
+  className?: string;
+};
+
+const statusLabel: Record<CopyStatus, string> = {
+  idle: 'Copy',
+  copied: 'Copied',
+  error: 'Copy failed',
+};
+
+export default function CopyButton({ text, ariaLabel, className }: CopyButtonProps) {
+  const [status, setStatus] = useState<CopyStatus>('idle');
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetStatus = useCallback(() => {
+    setStatus('idle');
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await copyText(text);
+      setStatus('copied');
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => {
+        setStatus('idle');
+        timeoutRef.current = null;
+      }, 2000);
+    } catch (error) {
+      console.error(error);
+      setStatus('error');
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(resetStatus, 2000);
+    }
+  }, [resetStatus, text]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={
+        className ??
+        'inline-flex items-center justify-center rounded-full border border-gray-200 px-3 py-1.5 text-xs font-semibold text-gray-700 transition hover:border-gray-300 hover:text-gray-900'
+      }
+      aria-label={ariaLabel ?? `Copy ${text} to clipboard`}
+    >
+      {statusLabel[status]}
+    </button>
+  );
+}

--- a/lib/clipboard.ts
+++ b/lib/clipboard.ts
@@ -1,0 +1,25 @@
+export async function copyText(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  if (typeof document === 'undefined') {
+    throw new Error('Clipboard not available');
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+  const success = document.execCommand('copy');
+  textarea.remove();
+
+  if (!success) {
+    throw new Error('Copy failed');
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide the missing core pages linked from the global header so navigation paths are not dead.
- Add a working `Donate` page that exposes all required crypto addresses and hosted donation links.
- Surface an `About / Disclaimer` page with data source and accuracy notes and a GitHub issues contact link.
- Include a minimal `Discover` directory placeholder so the route renders and is not empty.

### Description
- Added `app/discover/page.tsx`, `app/donate/page.tsx`, and `app/about/page.tsx` to implement the new routes and content.
- Implemented a reusable copy helper `lib/clipboard.ts` and a client component `components/CopyButton.tsx` to copy addresses with status feedback.
- Populated `Donate` with the exact required addresses for BTC/ETH/USDT/USDC/SOL/BNB/DOGE/AVAX/XRP and hosted links for Stripe and Ko-fi.
- Pages reuse the existing global header from `app/layout.tsx` so navigation behaves consistently.

### Testing
- Started the dev server with `npm run dev` and Next compiled the new `/donate/page` successfully.
- Ran a Playwright script to visit `http://127.0.0.1:3000/donate` which loaded and produced a screenshot artifact (donate-page.png), indicating the page renders.
- No unit or integration test suites were modified or added for this UI-only change.
- Manual smoke check verified copy button component mounts and the UI shows the provided addresses (no automated clipboard assertions were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69586c85d64483289c663b28d78566f7)