### PR TITLE
Map: add geolocation, external navigation links, and client-side bbox cache to reduce pin flicker

### DIFF
--- a/components/map/Drawer.css
+++ b/components/map/Drawer.css
@@ -244,6 +244,33 @@
   font-weight: 500;
 }
 
+.cpm-drawer__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.cpm-drawer__nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  color: #111827;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.cpm-drawer__nav-link:hover {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
 @media (max-width: 1023px) {
   .cpm-drawer {
     width: 380px;

--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -76,6 +76,23 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
       return entries;
     }, [place]);
 
+    const navigationLinks = useMemo(() => {
+      if (!place) return [] as { label: string; href: string; key: string }[];
+      const destination = `${place.lat},${place.lng}`;
+      return [
+        {
+          key: "google-maps",
+          label: "Google Maps",
+          href: `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(destination)}`,
+        },
+        {
+          key: "apple-maps",
+          label: "Apple Maps",
+          href: `https://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
+        },
+      ];
+    }, [place]);
+
     const supportedCrypto = useMemo(() => {
       if (!place) return [] as string[];
       const preferredOrder = ["BTC", "BTC@Lightning", "Lightning", "ETH", "USDT"];
@@ -204,6 +221,25 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
                       rel="noreferrer"
                     >
                       {social.label}
+                    </a>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {navigationLinks.length > 0 && (
+              <section className="cpm-drawer__section">
+                <h3 className="cpm-drawer__section-title">Navigate</h3>
+                <div className="cpm-drawer__nav">
+                  {navigationLinks.map((link) => (
+                    <a
+                      key={link.key}
+                      className="cpm-drawer__nav-link"
+                      href={link.href}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {link.label}
                     </a>
                   ))}
                 </div>

--- a/components/map/MobileBottomSheet.css
+++ b/components/map/MobileBottomSheet.css
@@ -233,6 +233,33 @@
   text-decoration: underline;
 }
 
+.cpm-bottom-sheet__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.cpm-bottom-sheet__nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  color: #0f172a;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-decoration: none;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.cpm-bottom-sheet__nav-link:hover {
+  border-color: #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cpm-bottom-sheet__panel {
     transition: none;

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -73,6 +73,23 @@ const buildSocialLinks = (place: Place | null) => {
   return entries;
 };
 
+const buildNavigationLinks = (place: Place | null) => {
+  if (!place) return [] as { label: string; href: string; key: string }[];
+  const destination = `${place.lat},${place.lng}`;
+  return [
+    {
+      key: "google-maps",
+      label: "Google Maps",
+      href: `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(destination)}`,
+    },
+    {
+      key: "apple-maps",
+      label: "Apple Maps",
+      href: `https://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
+    },
+  ];
+};
+
 const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(({ place, isOpen, onClose }, ref) => {
   const [stage, setStage] = useState<SheetStage>("peek");
   const [renderedPlace, setRenderedPlace] = useState<Place | null>(null);
@@ -96,6 +113,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(({ place, isOpen, on
 
   const supportedCrypto = useMemo(() => formatSupportedCrypto(renderedPlace), [renderedPlace]);
   const socialLinks = useMemo(() => buildSocialLinks(renderedPlace), [renderedPlace]);
+  const navigationLinks = useMemo(() => buildNavigationLinks(renderedPlace), [renderedPlace]);
   const photos = useMemo(() => {
     if (!renderedPlace) return [] as string[];
     return renderedPlace.photos?.length ? renderedPlace.photos : renderedPlace.images ?? [];
@@ -263,6 +281,27 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(({ place, isOpen, on
                     rel="noreferrer"
                   >
                     {social.label}
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {showDetails && navigationLinks.length > 0 && (
+            <section className="cpm-bottom-sheet__section">
+              <div className="cpm-bottom-sheet__section-head">
+                <h3 className="cpm-bottom-sheet__section-title">Navigate</h3>
+              </div>
+              <div className="cpm-bottom-sheet__nav">
+                {navigationLinks.map((link) => (
+                  <a
+                    key={link.key}
+                    className="cpm-bottom-sheet__nav-link"
+                    href={link.href}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {link.label}
                   </a>
                 ))}
               </div>

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -41,3 +41,128 @@
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
   border: 3px solid rgba(255, 255, 255, 0.9);
 }
+
+.cpm-map-controls {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: auto;
+}
+
+.cpm-map-button {
+  appearance: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 999px;
+  padding: 8px 14px;
+  background: #ffffff;
+  color: #111827;
+  font-size: 0.875rem;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.cpm-map-button:disabled {
+  cursor: progress;
+  color: #6b7280;
+  border-color: #e5e7eb;
+  background: #f9fafb;
+}
+
+.cpm-map-button:not(:disabled):hover {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+}
+
+.cpm-map-toast {
+  max-width: 220px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #f8fafc;
+  padding: 8px 10px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
+}
+
+.cpm-map-loading {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 60;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #e5e7eb;
+  color: #475569;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+  pointer-events: none;
+}
+
+.cpm-map-loading__spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 2px solid #c7d2fe;
+  border-top-color: #6366f1;
+  animation: cpm-spin 0.9s linear infinite;
+}
+
+.cpm-user-marker-icon {
+  background: transparent;
+  border: none;
+}
+
+.cpm-user-marker {
+  position: relative;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+}
+
+.cpm-user-marker__pulse {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.3);
+  animation: cpm-pulse 1.8s ease-out infinite;
+}
+
+.cpm-user-marker__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #2563eb;
+  border: 2px solid #ffffff;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.4);
+  position: relative;
+}
+
+@keyframes cpm-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes cpm-pulse {
+  0% {
+    transform: scale(0.4);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(1.6);
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a convenient “Locate me” control so users can center the map on their current position with clear error messaging when geolocation fails.  
- Offer external navigation links (Google Maps and Apple Maps) from place detail UI so users can open directions in map apps.  
- Prevent marker flicker / blank-state during quick pans/zooms by keeping existing markers visible while fetching and avoid unnecessary re-renders.  

### Description

- Added a Locate control and geolocation handling in `components/map/MapClient.tsx` including a user marker, `userLocation` state, `handleLocateMe`, and geolocation error messages.  
- Added external navigation links (Google Maps and Apple Maps) to both desktop drawer (`components/map/Drawer.tsx`, `Drawer.css`) and mobile bottom sheet (`components/map/MobileBottomSheet.tsx`, `MobileBottomSheet.css`).  
- Implemented debounced requests and a client-side cache keyed by `bbox@zoom|filters` in `MapClient` (`placesCacheRef`) with a small LRU-like eviction, and changed fetch/scheduling logic to reuse cached results to avoid wiping markers mid-pan.  
- Replaced the full-screen loading wipe with a subtle inline loading indicator and added CSS for map controls, user marker, loading spinner, and navigation buttons (`components/map/map.css`, updated CSS files).  

### Testing

- Launched the dev server with `npm run dev` and confirmed the app compiled and served (dev startup succeeded).  
- Ran an automated Playwright script that opened the app at `http://127.0.0.1:3000` and captured a screenshot of the map UI, which completed successfully.  
- No unit tests were added; changes were validated via the dev build and the screenshot smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587234e19883289dd7d1894e1d5181)