### PR TITLE
Keep mobile Filters / Locate / DB visible by moving controls into map overlay

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -520,12 +520,12 @@ export default function MapClient() {
     [filters],
   );
 
-  // ▼ モバイル用フィルタ UI（z-index を Leaflet より上にして fixed 配置）
+  // ▼ モバイル用フィルタ UI（z-index を Leaflet より上にして overlay 配置）
   const renderMobileFilters = () => {
     return (
-      <div className="pointer-events-none fixed inset-x-0 top-0 z-[1000] lg:hidden">
+      <div className="cpm-map-mobile-filters lg:hidden">
         {/* 上部の「Filters」ボタン + 件数 */}
-        <div className="pointer-events-auto mt-3 flex items-center justify-center gap-2">
+        <div className="flex items-center justify-center gap-2">
           <button
             type="button"
             onClick={toggleFilters}
@@ -547,7 +547,7 @@ export default function MapClient() {
         {/* 下から出るフィルタシート */}
         {filtersOpen && (
           <div
-            className="pointer-events-auto fixed inset-x-0 bottom-0 z-[1010] mx-auto max-h-[70vh] w-full rounded-t-2xl bg-white shadow-lg lg:hidden"
+            className="cpm-map-mobile-filters__sheet"
             data-testid="mobile-filters-sheet"
           >
             <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
@@ -785,20 +785,27 @@ export default function MapClient() {
         </div>
       </aside>
       <div className="relative flex-1 bg-gray-50">
-        <DbStatusIndicator
-          className="pointer-events-none absolute right-4 top-4 z-50 flex flex-col items-end gap-2 text-right"
-          showBanner
-        />
-        <div className="cpm-map-controls">
-          <button
-            type="button"
-            onClick={handleLocateMe}
-            className="cpm-map-button"
-            disabled={isLocating}
-          >
-            {isLocating ? "Locating…" : "Locate me"}
-          </button>
-          {geolocationError && <div className="cpm-map-toast">{geolocationError}</div>}
+        <div className="cpm-map-overlay">
+          <div className="cpm-map-overlay__top">
+            <div className="cpm-map-controls">
+              <button
+                type="button"
+                onClick={handleLocateMe}
+                className="cpm-map-button"
+                disabled={isLocating}
+              >
+                {isLocating ? "Locating…" : "Locate me"}
+              </button>
+              {geolocationError && (
+                <div className="cpm-map-toast">{geolocationError}</div>
+              )}
+            </div>
+            <DbStatusIndicator
+              className="cpm-map-db-status"
+              showBanner
+            />
+          </div>
+          {renderMobileFilters()}
         </div>
         {placesStatus === "loading" && (
           <div className="cpm-map-loading">
@@ -834,8 +841,6 @@ export default function MapClient() {
             </button>
           </div>
         )}
-        {/* モバイル用フィルタは画面全体に fixed で被せる */}
-        {renderMobileFilters()}
         <div
           id="map"
           ref={mapContainerRef}

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -43,10 +43,6 @@
 }
 
 .cpm-map-controls {
-  position: absolute;
-  top: 16px;
-  left: 16px;
-  z-index: 60;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -148,6 +144,60 @@
   border: 2px solid #ffffff;
   box-shadow: 0 4px 10px rgba(37, 99, 235, 0.4);
   position: relative;
+}
+
+.cpm-map-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: calc(env(safe-area-inset-top) + 16px) 16px calc(env(safe-area-inset-bottom) + 16px);
+  pointer-events: none;
+}
+
+.cpm-map-overlay__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.cpm-map-overlay__top > * {
+  pointer-events: auto;
+}
+
+.cpm-map-db-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  text-align: right;
+  pointer-events: auto;
+}
+
+.cpm-map-mobile-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  pointer-events: auto;
+}
+
+.cpm-map-mobile-filters__sheet {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 80;
+  margin-inline: auto;
+  max-height: 70vh;
+  width: 100%;
+  border-top-left-radius: 1rem;
+  border-top-right-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 -16px 32px rgba(15, 23, 42, 0.2);
+  pointer-events: auto;
 }
 
 @keyframes cpm-spin {


### PR DESCRIPTION
### Motivation
- Mobile Filters button and map controls could be obscured by the sticky header and bottom UI, causing accessibility and audit failures.
- The Locate / DB status indicators must always be within the viewport for mobile audits to pass.
- The bottom-hiding “map-under” UI should be removed in favor of an overlay to avoid controls being hidden behind the map area.

### Description
- Consolidated the Locate button, DB status and mobile Filters into a new overlay container in `MapClient` using a `cpm-map-overlay` wrapper.
- Converted the mobile filters sheet from viewport-fixed positioning to an in-map overlay and replaced previous classes with `cpm-map-mobile-filters` / `cpm-map-mobile-filters__sheet`.
- Added new CSS rules in `components/map/map.css` to provide safe-area padding, proper z-indexing, and pointer-event handling for the overlay and DB status (`.cpm-map-overlay`, `.cpm-map-db-status`, `.cpm-map-mobile-filters`, etc.).
- Removed the previous absolute top/left positioning for the standalone controls and now render them from the overlay so they remain visible above the map and below the header.

### Testing
- Started the Next development server with `npm run dev` and the app compiled and served successfully.
- Ran an automated Playwright script to load the home map in a mobile viewport and captured a screenshot to validate layout (`artifacts/map-mobile-overlay.png`), which completed successfully.
- No unit or integration tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ea10a8548328aba6357ab6ab417e)