### PR TITLE
Keep existing pins visible and avoid error state on transient map fetch failures

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -368,9 +368,12 @@ export default function MapClient() {
           return;
         }
 
-        setPlacesStatus("loading");
+        const hadPlaces = placesRef.current.length > 0;
+        setPlacesStatus(hadPlaces ? "success" : "loading");
         setPlacesError(null);
-        setLimitNotice(null);
+        if (!hadPlaces) {
+          setLimitNotice(null);
+        }
 
         try {
           const filters = filtersRef.current;
@@ -420,6 +423,10 @@ export default function MapClient() {
           }
           console.error(error);
           if (!isMounted || requestIdRef.current !== requestId) return;
+          if (placesRef.current.length > 0) {
+            setPlacesStatus("success");
+            return;
+          }
           setPlacesError(
             "Failed to load places. Please try again.\nスポット情報の取得に失敗しました。再読み込みしてください。",
           );


### PR DESCRIPTION
### Motivation
- Prevent the map UI from entering a hard `error` state when `/api/places` fetches fail transiently during rapid zoom/pan.
- Keep previously-loaded pins/clusters visible while new fetches are in-flight so the map does not appear empty after zooming.
- Reduce noisy UI state transitions caused by race/abort conditions during zoom/viewport changes.
- Favor recoverability (allow retry) instead of making the UI immediately unusable on a single fetch failure.

### Description
- Changed `components/map/MapClient.tsx` so fetches check `placesRef.current.length` and only set `placesStatus` to `"loading"` if there are no existing places, otherwise keep `"success"` while fetching. 
- Avoid clearing `limitNotice` when there are existing places so the result-limit banner remains until truly reloaded. 
- In the fetch `catch` branch, if there are existing places present, preserve the `success` state and skip setting `placesError` to avoid hiding pins on transient failures. 
- Left existing abort handling and caching logic intact and relied on `AbortController` and the existing debounce/timer (`fetchTimeoutRef`) behavior.

### Testing
- No automated tests were added or run for this change.
- Existing behavior was adjusted to be conservative about showing errors so no test failures were expected from unit suites.
- Manual verification was intended for zoom/rapid-pan scenarios (not part of automated test run).
- No CI results are included because no automated test invocation was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ebe02c78832898f2f69c92a40932)