### PR TITLE
Use http scheme for Apple Maps navigation links

### DIFF
--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -88,7 +88,7 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
         {
           key: "apple-maps",
           label: "Apple Maps",
-          href: `https://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
+          href: `http://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
         },
       ];
     }, [place]);

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -85,7 +85,7 @@ const buildNavigationLinks = (place: Place | null) => {
     {
       key: "apple-maps",
       label: "Apple Maps",
-      href: `https://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
+      href: `http://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
     },
   ];
 };


### PR DESCRIPTION
### Motivation
- Ensure Apple Maps navigation links open correctly by using the `http://maps.apple.com` scheme as required by some platforms.
- Provide a reliable “Navigate” action in place detail views alongside existing Google Maps links.
- Make a minimal change scoped to the UI link generation without altering map or geolocation behavior.

### Description
- Update `components/map/Drawer.tsx` to use `http://maps.apple.com/?daddr=lat,lng` for the Apple Maps navigation link.
- Update `components/map/MobileBottomSheet.tsx` to use `http://maps.apple.com/?daddr=lat,lng` for the Apple Maps navigation link.
- Keep Google Maps links unchanged and leave geolocation (`Locate me`) logic untouched.

### Testing
- No automated tests were run for this change.
- The change is limited to static link generation in two components and should be safe for review and deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a08e249688328885291171688f762)