### PR TITLE
Add public square SVG logo and use it in global header

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -27,7 +27,7 @@ export default function GlobalHeader() {
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6">
         <Link href="/" className="flex items-center gap-3 font-semibold text-gray-900">
           <img
-            src="/brand/logo.svg"
+            src="/logo.svg"
             alt="CryptoPayMap logo"
             className="h-9 w-9"
           />

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,11 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="16" width="480" height="480" rx="96" fill="#0F172A" />
+  <rect x="16" y="16" width="480" height="480" rx="96" stroke="#F97316" stroke-width="20" />
+  <rect x="72" y="140" width="160" height="160" rx="36" fill="#111827" stroke="#F97316" stroke-width="12" />
+  <path d="M112 220C112 199.909 128.909 183 149 183H198" stroke="#F97316" stroke-width="16" stroke-linecap="round" />
+  <path d="M198 220C198 240.091 181.091 257 161 257H112" stroke="#F97316" stroke-width="16" stroke-linecap="round" />
+  <circle cx="112" cy="220" r="8" fill="#F97316" />
+  <circle cx="198" cy="220" r="8" fill="#F97316" />
+  <text x="260" y="230" fill="#F8FAFC" font-family="'Inter', 'Segoe UI', sans-serif" font-size="48" font-weight="700">CryptoPayMap</text>
+  <text x="260" y="278" fill="#CBD5F5" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20">Crypto-friendly places</text>
+</svg>


### PR DESCRIPTION
### Motivation

- Provide a single, replaceable square logo asset in `public` so the site can reference an easily-swappable SVG. 
- Ensure the global header uses the public-facing logo path for consistent branding across pages. 
- Keep icon/OG resources as SVGs for crisp rendering and easy updates. 

### Description

- Add a new SVG logo at `public/logo.svg` containing the square icon plus text. 
- Update `components/GlobalHeader.tsx` to load the logo from `/logo.svg` instead of `/brand/logo.svg`. 
- No other UI or routing changes were made in this PR. 

### Testing

- Started the dev server with `npm run dev` and the Next.js app compiled successfully. 
- The homepage and pages compiled without errors and the server served at `http://localhost:3000`. 
- Ran an automated Playwright script to load the homepage and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a09d920bc832880aeca62839df109)