### PR TITLE
Hotfix: normalize/split bbox + mobile header offset to fix /api/places 400 and filter overlap

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
 
 const NAV_LINKS = [
   { label: 'Map', href: '/' },
@@ -21,9 +22,33 @@ const isActivePath = (pathname: string, href: string) => {
 
 export default function GlobalHeader() {
   const pathname = usePathname();
+  const headerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const header = headerRef.current;
+    if (!header) return;
+
+    const setHeaderHeight = () => {
+      const height = header.getBoundingClientRect().height;
+      document.documentElement.style.setProperty('--cpm-header-h', `${height}px`);
+    };
+
+    setHeaderHeight();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(() => setHeaderHeight());
+    observer.observe(header);
+    return () => observer.disconnect();
+  }, []);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur">
+    <header
+      ref={headerRef}
+      className="sticky top-0 z-50 border-b border-gray-200 bg-white/95 backdrop-blur"
+    >
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6">
         <Link href="/" className="flex items-center gap-3 font-semibold text-gray-900">
           <img

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -771,8 +771,8 @@ export default function MapClient() {
     <div
       className="relative flex w-full"
       style={{
-        height: `calc(100vh - ${HEADER_HEIGHT}px)`,
-        ["--header-height" as string]: `${HEADER_HEIGHT}px`,
+        height: `calc(100vh - var(--cpm-header-h, ${HEADER_HEIGHT}px))`,
+        ["--header-height" as string]: `var(--cpm-header-h, ${HEADER_HEIGHT}px)`,
       }}
     >
       <aside className="hidden h-full w-80 flex-col border-r border-gray-200 bg-white lg:flex">

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -153,7 +153,8 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: calc(env(safe-area-inset-top) + 16px) 16px calc(env(safe-area-inset-bottom) + 16px);
+  padding: calc(env(safe-area-inset-top) + 16px + var(--cpm-header-h, 0px)) 16px
+    calc(env(safe-area-inset-bottom) + 16px);
   pointer-events: none;
 }
 

--- a/lib/geo/bbox.ts
+++ b/lib/geo/bbox.ts
@@ -1,0 +1,42 @@
+export type ParsedBbox = {
+  minLng: number;
+  minLat: number;
+  maxLng: number;
+  maxLat: number;
+};
+
+const wrapLng = (value: number) => ((((value + 180) % 360) + 360) % 360) - 180;
+
+export const parseBbox = (
+  value: string | null,
+): { bbox: ParsedBbox[] | null; error?: string } => {
+  if (!value) return { bbox: null };
+  const parts = value.split(",").map((part) => part.trim());
+  if (parts.length !== 4) {
+    return { bbox: null, error: "bbox must be four comma-separated numbers" };
+  }
+  const [rawMinLng, rawMinLat, rawMaxLng, rawMaxLat] = parts.map((part) => Number.parseFloat(part));
+  if (![rawMinLng, rawMinLat, rawMaxLng, rawMaxLat].every((num) => Number.isFinite(num))) {
+    return { bbox: null, error: "bbox must contain valid numbers" };
+  }
+
+  const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+  const minLatCandidate = clamp(rawMinLat, -90, 90);
+  const maxLatCandidate = clamp(rawMaxLat, -90, 90);
+  const minLat = Math.min(minLatCandidate, maxLatCandidate);
+  const maxLat = Math.max(minLatCandidate, maxLatCandidate);
+
+  const minLng = wrapLng(rawMinLng);
+  const maxLng = wrapLng(rawMaxLng);
+
+  if (minLng > maxLng) {
+    return {
+      bbox: [
+        { minLng, minLat, maxLng: 180, maxLat },
+        { minLng: -180, minLat, maxLng, maxLat },
+      ],
+    };
+  }
+
+  return { bbox: [{ minLng, minLat, maxLng, maxLat }] };
+};

--- a/tests/places-bbox.test.ts
+++ b/tests/places-bbox.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseBbox } from "../lib/geo/bbox";
+
+describe("parseBbox", () => {
+  it("clamps latitude and wraps longitude without error", () => {
+    const result = parseBbox("0,-100,10,120");
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.bbox?.length, 1);
+    assert.deepEqual(result.bbox?.[0], {
+      minLng: 0,
+      minLat: -90,
+      maxLng: 10,
+      maxLat: 90,
+    });
+  });
+
+  it("splits bboxes that cross the antimeridian", () => {
+    const result = parseBbox("-196.875,-77.466028,196.875,83.829945");
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.bbox?.length, 2);
+    assert.deepEqual(result.bbox?.[0], {
+      minLng: 163.125,
+      minLat: -77.466028,
+      maxLng: 180,
+      maxLat: 83.829945,
+    });
+    assert.deepEqual(result.bbox?.[1], {
+      minLng: -180,
+      minLat: -77.466028,
+      maxLng: -163.125,
+      maxLat: 83.829945,
+    });
+  });
+
+  it("returns errors for malformed bboxes", () => {
+    const result = parseBbox("1,2,3");
+
+    assert.equal(result.error, "bbox must be four comma-separated numbers");
+    assert.equal(result.bbox, null);
+  });
+});


### PR DESCRIPTION
### Motivation
- The /api/places bbox parsing returned 400 for out-of-range coordinates and did not handle antimeridian-crossing ranges, causing desktop pins to never appear in the UX audit. 
- The mobile “Filters” button could overlap the sticky header on small viewports, failing the mobile UX audit. 
- The goal is to normalize bbox inputs (clamp/wrap) and ensure mobile overlay positioning without changing response schema. 

### Description
- Extracted and implemented a shared `parseBbox` in `lib/geo/bbox.ts` that clamps latitudes to [-90,90], wraps longitudes to [-180,180], and splits antimeridian-crossing boxes into two normalized bboxes. 
- Updated `app/api/places/route.ts` to accept an array of `ParsedBbox` and build ORed queries (PostGIS `ST_MakeEnvelope` or `lat/lng BETWEEN`) so out-of-range bbox no longer returns 400 and results from split bboxes are merged. 
- Added mobile layout fixes by exposing header height as CSS var `--cpm-header-h` in `components/GlobalHeader.tsx` and using that var in `MapClient` and `components/map/map.css` so the map and Filters UI never overlap the header. 
- Added unit tests `tests/places-bbox.test.ts` covering wrapping/clamping, antimeridian splitting, and malformed input handling. 

### Testing
- Ran the repository test suite with `npm test` which executed the TypeScript compile and Node tests, and all tests passed. 
- The new `tests/places-bbox.test.ts` unit tests executed as part of `npm test` and passed. 
- A Playwright smoke script was run to load the site at `390x844` and capture a mobile screenshot, which completed and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a0c69c6848328bd84dda24501de2d)