### PR TITLE
test: mock /api/places in map-smoke using fixed fixture

### DIFF
--- a/tests/fixtures/places.sample.json
+++ b/tests/fixtures/places.sample.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "fixture-place-1",
+    "name": "Fixture Coffee Spot",
+    "category": "cafe",
+    "verification": "community",
+    "lat": 35.681236,
+    "lng": 139.767125,
+    "country": "JP",
+    "city": "Tokyo",
+    "address_full": "1-9-1 Marunouchi, Chiyoda City, Tokyo"
+  }
+]


### PR DESCRIPTION
### Motivation
- Stabilize the map smoke tests so they do not fail due to DB unavailability or `/api/health` returning 503.
- Make pin rendering deterministic by using a DB-independent, fixed fixture for `/api/places` responses.
- Keep changes strictly inside `tests/` and limit routing mock to `/api/places` only.
- Preserve existing `[perf]` logging format while allowing additional output for diagnostics.

### Description
- Added a fixture file `tests/fixtures/places.sample.json` containing at least one place with `lat`/`lng` and `name` for stable pin/display behavior.
- Updated `tests/map-smoke.spec.ts` to load the fixture, mock `/api/places` via `page.route(

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db2b8a41883288b47a2099693ab7e)