### PR TITLE
Stabilize drawer open detection in map smoke tests

### DIFF
--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -115,6 +115,7 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
             top: `var(--header-height, ${headerHeight}px)`,
             height: `calc(100vh - ${headerHeight}px)`,
           }}
+          data-testid="place-drawer"
           aria-hidden
         />
       );
@@ -138,6 +139,7 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
         role="dialog"
         aria-label="Place details"
         aria-hidden={!isOpen}
+        data-testid="place-drawer"
       >
         <div className="cpm-drawer__panel">
           <header className="cpm-drawer__header">

--- a/tests/map-smoke.spec.ts
+++ b/tests/map-smoke.spec.ts
@@ -159,8 +159,8 @@ test("map smoke: selecting a place from the mobile sheet opens the drawer", asyn
     await fallback.click({ force: true });
   }
 
-  // Drawer が開く（Drawer.tsx の aria-label を使う）
-  const drawer = page.locator('[aria-label="Place details"]');
+  // Drawer が開く（data-testid を使う）
+  const drawer = page.locator('[data-testid="place-drawer"]');
   await expect(drawer).toHaveClass(/\bopen\b/, { timeout: 20000 });
   await expect(drawer).toHaveAttribute("aria-hidden", "false");
 });
@@ -207,18 +207,20 @@ test("map smoke: clicking a map marker opens the drawer (anti-overlay)", async (
     )
     .toBeGreaterThan(0);
 
-  const drawer = page.locator('[aria-label="Place details"], .cpm-drawer');
+  const drawer = page.locator('[data-testid="place-drawer"]');
 
   const isDrawerOpen = async () => {
     const cnt = await drawer.count();
     if (cnt === 0) return false;
-    return (
-      (await drawer
-        .first()
+    const first = drawer.first();
+    const [isVisible, className] = await Promise.all([
+      first
         .getAttribute("aria-hidden")
         .then((value) => value === "false")
-        .catch(() => false)) ?? false
-    );
+        .catch(() => false),
+      first.getAttribute("class").catch(() => ""),
+    ]);
+    return Boolean(isVisible && className?.split(/\s+/).includes("open"));
   };
 
   const clickMarker = async (


### PR DESCRIPTION
### Motivation

- Reduce flaky anti-overlay failures by making the test success condition a stable drawer open-state instead of brittle DOM hit-testing.
- Use a stable selector so tests don't fail due to `elementFromPoint`/`closest()` jitter or transient class differences.

### Description

- Add `data-testid="place-drawer"` to the drawer container in `components/map/Drawer.tsx` for both empty and populated render branches.
- Update `tests/map-smoke.spec.ts` to target the drawer via `[data-testid="place-drawer"]` instead of the previous `aria-label`/class combinations.
- Replace the prior open-state check with an `isDrawerOpen` helper that concurrently reads `aria-hidden` and the `class` attribute and considers the drawer open only when `aria-hidden` is `false` and the class list includes `open`.
- Refactor the drawer checks to use `Promise.all` for attribute reads to make the test more robust and less timing-sensitive.

### Testing

- No automated tests were executed as part of this change.
- Changes were limited to a test helper and component test id and therefore require running the Playwright map smoke tests to validate in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db7f8dca88328bdd2df4f685f8f04)