### PR TITLE
Add Playwright map-smoke workflow and force CI workers=1

### DIFF
--- a/.github/workflows/playwright-map-smoke.yml
+++ b/.github/workflows/playwright-map-smoke.yml
@@ -1,0 +1,81 @@
+name: Playwright map-smoke
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  map-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CI: "1"
+      PW_BASE_URL: http://127.0.0.1:3201
+      PW_DEBUG_PROBE: "0"
+      NEXT_TELEMETRY_DISABLED: "1"
+      NEXT_PUBLIC_DATA_SOURCE: "json"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Build (stable for CI)
+        run: npm run build
+
+      - name: Start server + map smoke
+        shell: bash
+        run: |
+          set -eo pipefail
+          PORT=3201
+          HOST=127.0.0.1
+          BASE="${PW_BASE_URL:-http://${HOST}:${PORT}}"
+          LOG="/tmp/cpm-start-${PORT}.log"
+
+          npm run start -- -H "${HOST}" -p "${PORT}" > "${LOG}" 2>&1 &
+          PID=$!
+          trap 'kill -9 ${PID} >/dev/null 2>&1 || true' EXIT
+
+          # 起動待ち（応答が返るまで）
+          for i in $(seq 1 240); do
+            CODE=$(curl -4 -s -o /tmp/health.body -w "%{http_code}" "${BASE}/api/health" || true)
+            if [ "${CODE}" != "000" ]; then
+              echo "[INFO] health responded with http ${CODE}"
+              break
+            fi
+            sleep 0.5
+          done
+
+          CODE=$(curl -4 -s -o /tmp/health.body -w "%{http_code}" "${BASE}/api/health" || true)
+          if [ "${CODE}" = "000" ]; then
+            echo "[ERROR] server not reachable: ${BASE}/api/health"
+            echo "---- server log ----"
+            tail -n 200 "${LOG}" || true
+            exit 1
+          fi
+
+          npm run test:map-smoke
+
+      - name: Upload Playwright artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            test-results/**
+            playwright-report/**

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   timeout: 60_000,
   expect: { timeout: 10_000 },
   retries: 0,
+  workers: process.env.CI ? 1 : undefined,
   use: {
     baseURL,
     trace: 'retain-on-failure',


### PR DESCRIPTION
### Motivation
- Add an automated per-PR smoke test for the map UI so regressions are detected without manual checks. 
- Ensure Playwright artifacts (trace/video/screenshots/report) are collected when tests fail so failures can be diagnosed. 
- Speed up CI by caching Playwright browser downloads. 
- Stabilize Playwright runs in CI by forcing a single worker.

### Description
- Added `.github/workflows/playwright-map-smoke.yml` which checks out code, sets up Node, caches Playwright browsers, installs deps, builds the app, starts the server on port `3201`, runs `npm run test:map-smoke`, and uploads `test-results/**` and `playwright-report/**` on failure. 
- Set environment defaults in the workflow: `CI=1`, `PW_BASE_URL=http://127.0.0.1:3201`, `PW_DEBUG_PROBE=0`, and `NEXT_PUBLIC_DATA_SOURCE=json`. 
- Updated `playwright.config.ts` to set `workers: process.env.CI ? 1 : undefined` to force `workers=1` in CI. 
- Workflow is triggered on `pull_request` and `push` to `main` and includes a wait-for-health loop before running Playwright tests.

### Testing
- No automated tests were executed as part of this change in the local environment, since this is a CI workflow addition. 
- The workflow will run automatically on PRs and pushes to `main` where artifacts will be uploaded on failure. 
- Playwright test files (e.g. `tests/map-smoke.spec.ts`) remain unchanged and will be exercised by the new workflow. 
- Browser cache step uses `actions/cache@v4` keyed on `package-lock.json` to speed subsequent CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dbd43bd2c83289815c658359201c0)