### PR TITLE
Add map layering rules (click-through prevention)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Install dependencies and start the development server:
 npm install
 npm run dev
 ```
+
+## Map Layout
+
+- [Map layering rules (click-through prevention)](docs/map-layering.md)

--- a/docs/map-layering.md
+++ b/docs/map-layering.md
@@ -1,0 +1,34 @@
+# Map Layering Rules (Click-Through Prevention)
+
+This document defines the layering and interaction rules for the map UI to prevent the regression where pins are visible but not clickable.
+
+## Key Layer Roles
+
+| Layer | Typical element(s) | Responsibility | Notes |
+| --- | --- | --- | --- |
+| Leaflet panes | tile, overlay, marker panes | Core map rendering | Marker pane must stay above tile/overlay panes so pins remain visible and clickable. |
+| Leaflet controls | zoom, attribution, custom controls | Map-level UI | Controls should remain on top of map panes but below app-level overlays. |
+| Drawer | side drawer / nav | Global navigation | Should sit above controls and map panes to avoid map interaction conflicts. |
+| Sheet / bottom panel | details sheet, filter panel | Contextual UI | Should overlay map when open; only its interactive regions should capture clicks. |
+| Overlays | modals, toasts, banners | App-level alerts and flows | Must appear above all map and layout layers. |
+
+## Pointer-Events Principles
+
+1. **Map interaction is the default.** Non-interactive overlay wrappers should use `pointer-events: none` so panning/zooming and pin clicks reach the map.
+2. **Only interactive regions opt in.** Buttons, list items, and form fields should explicitly set `pointer-events: auto` (or inherit) so they receive input.
+3. **Avoid full-screen blockers.** A full-screen overlay with `pointer-events: auto` should only be used when intentionally blocking map interaction (e.g., modal).
+4. **Sheet/Drawer boundaries matter.** Ensure only the visible sheet/drawer area captures clicks; the rest of the viewport should be transparent to events.
+
+## z-index Principles
+
+1. **Pins must stay above the map.** Leaflet marker pane should remain above tile and overlay panes to prevent invisible-but-unclickable pins.
+2. **Controls above map panes, below app overlays.** Leaflet controls should not obscure app-level UI (drawer/sheet/overlay).
+3. **App overlays are the top layer.** Modals, toasts, and banners should be the highest z-index when active.
+4. **Avoid arbitrary z-index inflation.** Use a shared scale (documented in CSS/tokens if available) and only bump z-index when the layer’s role requires it.
+
+## Quick Checklist
+
+- [ ] Pins are clickable in all map states (drawer open, sheet open, overlays shown).
+- [ ] Non-interactive wrappers use `pointer-events: none`.
+- [ ] Interactive UI elements explicitly allow pointer events.
+- [ ] z-index matches the layer’s role (map panes < controls < drawer/sheet < overlays).


### PR DESCRIPTION
### Motivation

- Prevent regressions where map pins are visible but not clickable by standardizing layering and interaction rules.
- Provide clear guidance on `pointer-events` usage to avoid UI elements unintentionally blocking map interactions.
- Define `z-index` expectations so controls, drawers, sheets, and overlays stack consistently above or below the map.

### Description

- Add `docs/map-layering.md` documenting layer roles, `pointer-events` principles, `z-index` principles, and a quick checklist.
- Update `README.md` to add a one-click link to the new map layering guide under the `Map Layout` section.
- Document recommended behavior for Leaflet panes, controls, drawer/sheet boundaries, and app overlays.

### Testing

- No automated tests were run because this is a documentation-only change.
- Changes were limited to `docs/map-layering.md` and `README.md` and do not affect application code.
- No test failures occurred (no tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dce77f4148328bef4c4b833957aea)