### PR TITLE
Stabilize map-smoke tests: mock /api/places as array and assert hits

### DIFF
--- a/tests/fixtures/places.sample.json
+++ b/tests/fixtures/places.sample.json
@@ -2,12 +2,12 @@
   {
     "id": "fixture-place-1",
     "name": "Fixture Coffee Spot",
-    "category": "cafe",
-    "verification": "community",
     "lat": 35.681236,
     "lng": 139.767125,
-    "country": "JP",
+    "verification": "community",
+    "category": "cafe",
     "city": "Tokyo",
-    "address_full": "1-9-1 Marunouchi, Chiyoda City, Tokyo"
+    "country": "JP",
+    "accepted": true
   }
 ]


### PR DESCRIPTION
### Motivation
- Prevent flaky `map-smoke` failures caused by `/api/places` returning a non-array shape or the mock not being applied (pins=0).
- Ensure tests are independent of DB state by providing a deterministic fixture that matches the API shape.
- Make mock behavior explicit and visible by logging each hit and rejecting non-GET requests.
- Fail tests early when the `/api/places` mock was never exercised to detect routing/installation problems.

### Description
- Updated the fixture `tests/fixtures/places.sample.json` to be a strict array response and added the `accepted` flag to match the `/api/places` consumer shape.
- Reworked `mockPlacesRoute` in `tests/map-smoke.spec.ts` to register `page.route("**/api/places**")` before navigation, reject non-GET requests with `route.fallback()`, always log hits, and return a `getHitCount()` accessor.
- Moved mock installation into each test (removed the previous global `test.beforeEach`) so the route is guaranteed to be active before `page.goto` runs.
- Added assertions `expect(getHitCount()).toBeGreaterThanOrEqual(1)` at the end of each test to fail when the mock was not hit.

### Testing
- No automated tests were executed as part of this change during the rollout.
- Intended verification is to run `PW_BASE_URL=http://127.0.0.1:3201 npm run test:map-smoke` locally, which should report `3/3 PASS` when the server is reachable and the mock is used.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7925a4cc8328a2dc020634666df7)