### PR TITLE
Update map-smoke fixtures to initial bbox (London) and add first-place log

### DIFF
--- a/tests/fixtures/places.sample.json
+++ b/tests/fixtures/places.sample.json
@@ -2,12 +2,34 @@
   {
     "id": "fixture-place-1",
     "name": "Fixture Coffee Spot",
-    "lat": 35.681236,
-    "lng": 139.767125,
+    "lat": 51.5034,
+    "lng": -0.1276,
     "verification": "community",
     "category": "cafe",
-    "city": "Tokyo",
-    "country": "JP",
+    "city": "London",
+    "country": "GB",
+    "accepted": true
+  },
+  {
+    "id": "fixture-place-2",
+    "name": "Fixture Crypto Pub",
+    "lat": 51.5099,
+    "lng": -0.1357,
+    "verification": "community",
+    "category": "bar",
+    "city": "London",
+    "country": "GB",
+    "accepted": true
+  },
+  {
+    "id": "fixture-place-3",
+    "name": "Fixture BTC Books",
+    "lat": 51.5154,
+    "lng": -0.0995,
+    "verification": "community",
+    "category": "shop",
+    "city": "London",
+    "country": "GB",
     "accepted": true
   }
 ]

--- a/tests/map-smoke.spec.ts
+++ b/tests/map-smoke.spec.ts
@@ -45,6 +45,14 @@ function pickLabel(place: any): string | null {
   return s.length ? s : null;
 }
 
+function logFirstPlace(places: any[]) {
+  if (!places.length) return;
+  const first = places[0];
+  console.log(
+    `[fixture] firstPlace id=${first?.id ?? ""} lat=${first?.lat ?? ""} lng=${first?.lng ?? ""}`
+  );
+}
+
 async function mockPlacesRoute(page: import("@playwright/test").Page) {
   let hitCount = 0;
   await page.route("**/api/places**", async (route) => {
@@ -101,6 +109,7 @@ test("map smoke: map renders and pins appear when /api/places returns data", asy
   } catch {}
 
   const placesCount = extractCount(placesJson);
+  logFirstPlace(extractPlaces(placesJson));
   expect(placesRes.status()).toBe(200);
   expect(placesCount).toBe(FIXTURE_COUNT);
   expect(__pinIcons).toBeGreaterThanOrEqual(FIXTURE_COUNT);
@@ -142,6 +151,7 @@ test("map smoke: selecting a place from the mobile sheet opens the drawer", asyn
     placesJson = await placesRes.json();
   } catch {}
   const places = extractPlaces(placesJson);
+  logFirstPlace(places);
   const firstWithLabel = places.map(pickLabel).find(Boolean) as string | undefined;
 
   expect(firstWithLabel, "could not infer a place name from /api/places response").toBeTruthy();
@@ -194,6 +204,7 @@ test("map smoke: clicking a map marker opens the drawer (anti-overlay)", async (
   let placesJson: any = null;
   try { placesJson = await placesRes.json(); } catch {}
   const places = extractPlaces(placesJson);
+  logFirstPlace(places);
   const firstWithLabel = places.map(pickLabel).find(Boolean) as string | undefined;
 
   const cpmPins = page.locator(".cpm-pin");


### PR DESCRIPTION
### Motivation

- Prevent accidental `pins=0` by ensuring fixtures are inside the initial bbox used by map smoke tests. 
- Make test failures easier to triage by logging the first fixture location returned by the mocked `/api/places`.

### Description

- Updated `tests/fixtures/places.sample.json` to replace the Tokyo fixture with three London-area entries inside the initial bbox and increased fixture count to 3. 
- Added `logFirstPlace` helper to `tests/map-smoke.spec.ts` and invoked it at the points where the test reads the `/api/places` response. 
- Kept existing behavior of the `/api/places` mock and test assertions; only fixtures and a single-line diagnostic log were added. 

### Testing

- Ran `npm run test:map-smoke` which invokes Playwright tests for `tests/map-smoke.spec.ts`. 
- The test run failed to execute due to missing Playwright browser binaries with the error recommending `npx playwright install`. 
- No test assertions were changed; test failures were environmental (Playwright browsers not installed) rather than logic regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e7f095f988328a6b7ff2e27f0a32f)