### PR TITLE
Handle DB submission failures with local NDJSON fallback and 202 response

### DIFF
--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -1,5 +1,85 @@
-import { handleUnifiedSubmission } from "@/lib/submissions";
+import { randomUUID } from "crypto";
+import { promises as fs } from "fs";
+import path from "path";
+
+import { handleUnifiedSubmission, normalizeSubmission, SubmissionPayload } from "@/lib/submissions";
+
+const pendingSubmissionsPath = path.join(process.cwd(), "data", "submissions-pending.ndjson");
+
+type PendingSubmissionRecord = {
+  submissionId: string;
+  receivedAt: string;
+  payload: SubmissionPayload | Record<string, unknown> | null;
+  error: string;
+};
+
+const appendPendingSubmission = async (record: PendingSubmissionRecord) => {
+  try {
+    await fs.mkdir(path.dirname(pendingSubmissionsPath), { recursive: true });
+    await fs.appendFile(pendingSubmissionsPath, `${JSON.stringify(record)}\n`, "utf8");
+  } catch (error) {
+    console.warn("[submissions] failed to write pending submission", error);
+  }
+};
+
+const getDbFailureSummary = async (response: Response) => {
+  if (![500, 503].includes(response.status)) return null;
+
+  try {
+    const payload = (await response.clone().json()) as { error?: string };
+    if (response.status === 503 && payload.error === "DB_UNAVAILABLE") return payload.error;
+    if (response.status === 500 && payload.error === "Submissions table missing") return payload.error;
+  } catch {
+    return null;
+  }
+
+  return null;
+};
 
 export async function POST(request: Request) {
-  return handleUnifiedSubmission(request);
+  let parsedBody: Record<string, unknown> | null = null;
+  let normalizedPayload: SubmissionPayload | null = null;
+
+  try {
+    const parsed = await request.clone().json();
+    if (parsed && typeof parsed === "object") {
+      parsedBody = parsed as Record<string, unknown>;
+      const normalized = normalizeSubmission(parsed);
+      if (normalized.ok) {
+        normalizedPayload = normalized.payload;
+      }
+    }
+  } catch {
+    parsedBody = null;
+  }
+
+  const response = await handleUnifiedSubmission(request);
+  const dbFailureSummary = await getDbFailureSummary(response);
+
+  if (!dbFailureSummary) {
+    return response;
+  }
+
+  const submissionId = randomUUID();
+  const receivedAt = new Date().toISOString();
+  const payload = normalizedPayload ?? parsedBody;
+
+  console.warn(
+    `[submissions] db_failure accepted pending submission id=${submissionId} error=${dbFailureSummary}`,
+  );
+  await appendPendingSubmission({
+    submissionId,
+    receivedAt,
+    payload,
+    error: dbFailureSummary,
+  });
+
+  return new Response(
+    JSON.stringify({
+      submissionId,
+      status: "pending",
+      accepted: true,
+    }),
+    { status: 202, headers: { "Content-Type": "application/json" } },
+  );
 }


### PR DESCRIPTION
### Motivation
- Prevent the submit API from returning repeated 500s when the database is unavailable by providing a robust fallback path.
- Ensure submissions are always acknowledged to clients and include a tracking `submissionId` for follow-up regardless of DB state.
- Persist pending submissions locally so they can be recovered later if the DB is down.
- Preserve existing validation and normal successful behavior when the DB is healthy.

### Description
- Replace the simple route passthrough with logic that calls `handleUnifiedSubmission(request)` and inspects the response for DB-related failures (503 `DB_UNAVAILABLE` or 500 `Submissions table missing`).
- If a DB failure is detected, generate a `submissionId` with `randomUUID()`, attempt to parse/normalize the request body, log a warning, and append a fallback record to `data/submissions-pending.ndjson` using a safe `appendPendingSubmission` helper.
- Return `202 Accepted` with a minimal body containing `submissionId`, `status: "pending"`, and `accepted: true` when DB failures occur, and otherwise return the original response unchanged so healthy DB behavior is preserved.
- Add imports for `randomUUID`, `fs`, and `path`, and use `normalizeSubmission` to capture a normalized payload when possible; file write errors are caught and logged without affecting the API response.

### Testing
- No automated tests were run against these changes.
- Basic behavior to verify manually: POST to `/api/submissions` with DB up returns existing success response, and with DB down returns `202` and appends a line to `data/submissions-pending.ndjson` (not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd5219a8c832885449c8aabce1d06)