### PR TITLE
Runtime: auto fallback + Limited mode unified

### DIFF
--- a/app/internal/submissions/[id]/page.tsx
+++ b/app/internal/submissions/[id]/page.tsx
@@ -6,8 +6,8 @@ export default function SubmissionDetailPage({ params }: { params: { id: string 
     <main className="mx-auto max-w-5xl space-y-6 p-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
-          <p className="text-sm font-semibold">Internal only / 暫定レビュー画面</p>
-          <p className="text-sm">直リンクのみ。外部には公開しないでください。</p>
+          <p className="text-sm font-semibold">Internal only</p>
+          <p className="text-sm">Direct link only. Do not share publicly.</p>
         </div>
         <DbStatusIndicator showBanner />
       </div>

--- a/app/internal/submissions/page.tsx
+++ b/app/internal/submissions/page.tsx
@@ -6,8 +6,8 @@ export default function SubmissionsPage() {
     <main className="mx-auto max-w-6xl space-y-6 p-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
-          <p className="text-sm font-semibold">Internal only / 暫定レビュー画面</p>
-          <p className="text-sm">直リンクのみ。外部には公開しないでください。</p>
+          <p className="text-sm font-semibold">Internal only</p>
+          <p className="text-sm">Direct link only. Do not share publicly.</p>
         </div>
         <DbStatusIndicator showBanner />
       </div>

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
+import LimitedModeNotice from '@/components/status/LimitedModeNotice';
 import { safeFetch } from '@/lib/safeFetch';
 
 type StatsResponse = {
@@ -253,21 +254,20 @@ export default function StatsPage() {
         </header>
 
         {showLimited ? (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900">
-            <p className="font-medium">Limited stats data available.</p>
-            <p className="text-sm">
-              Some aggregates are unavailable right now. Showing fallback totals while data catches up.
-            </p>
-            {state.notice ? (
-              <button
-                type="button"
-                onClick={fetchStats}
-                className="mt-3 inline-flex items-center gap-2 rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-700"
-              >
-                Retry
-              </button>
-            ) : null}
-          </div>
+          <LimitedModeNotice
+            className="px-4 py-3 text-sm"
+            actions={
+              state.notice ? (
+                <button
+                  type="button"
+                  onClick={fetchStats}
+                  className="inline-flex items-center gap-2 rounded-md bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-amber-700"
+                >
+                  Retry
+                </button>
+              ) : null
+            }
+          />
         ) : null}
 
         <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -101,15 +101,15 @@ export default function SubmitPage() {
 
   const validate = () => {
     const newErrors: Record<string, string> = {};
-    if (!formState.name.trim()) newErrors.name = "Required / 必須";
-    if (!formState.country.trim()) newErrors.country = "Required / 必須";
-    if (!formState.city.trim()) newErrors.city = "Required / 必須";
-    if (!formState.address.trim()) newErrors.address = "Required / 必須";
-    if (!formState.category.trim()) newErrors.category = "Required / 必須";
-    if (!formState.accepted.length) newErrors.accepted = "Select at least one / 1つ以上選択";
-    if (!formState.submitterName.trim()) newErrors.submitterName = "Required / 必須";
+    if (!formState.name.trim()) newErrors.name = "Required";
+    if (!formState.country.trim()) newErrors.country = "Required";
+    if (!formState.city.trim()) newErrors.city = "Required";
+    if (!formState.address.trim()) newErrors.address = "Required";
+    if (!formState.category.trim()) newErrors.category = "Required";
+    if (!formState.accepted.length) newErrors.accepted = "Select at least one";
+    if (!formState.submitterName.trim()) newErrors.submitterName = "Required";
     if (!formState.submitterEmail.trim()) {
-      newErrors.submitterEmail = "Required / 必須";
+      newErrors.submitterEmail = "Required";
     } else if (!emailRegex.test(formState.submitterEmail)) {
       newErrors.submitterEmail = "Invalid email";
     }
@@ -165,11 +165,11 @@ export default function SubmitPage() {
       const data = (await res.json()) as SubmissionResponse;
       const suggestion = data.suggestedPlaceId ? ` Suggested ID: ${data.suggestedPlaceId}` : "";
       setSuccessMessage(
-        `Thanks for your submission! / ご登録ありがとうございます。 We’ll review your place before publishing it on the map.${suggestion}`,
+        `Thanks for your submission! We’ll review your place before publishing it on the map.${suggestion}`,
       );
     } catch (error) {
       console.error(error);
-      setServerError((error as Error)?.message || "Submission failed. Please try again / 送信に失敗しました");
+      setServerError((error as Error)?.message || "Submission failed. Please try again.");
     } finally {
       setIsSubmitting(false);
     }
@@ -187,11 +187,11 @@ export default function SubmitPage() {
       <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
         <div className="space-y-2">
           <h1 className="text-3xl font-bold text-gray-900">Submit a crypto-friendly place</h1>
-          <p className="text-gray-600">店舗情報の登録 / 更新リクエスト</p>
+          <p className="text-gray-600">Request a new listing or update an existing place.</p>
         </div>
 
         <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-2">
-          <p className="text-gray-800 font-semibold">Choose submitter type / 投稿者を選択</p>
+          <p className="text-gray-800 font-semibold">Choose submitter type</p>
           <div className="flex space-x-2">
             <button
               type="button"
@@ -200,7 +200,7 @@ export default function SubmitPage() {
                 mode === "owner" ? "bg-blue-600 text-white border-blue-600" : "bg-white text-gray-800"
               }`}
             >
-              Owner / 店舗オーナー
+              Owner
             </button>
             <button
               type="button"
@@ -209,20 +209,20 @@ export default function SubmitPage() {
                 mode === "community" ? "bg-blue-600 text-white border-blue-600" : "bg-white text-gray-800"
               }`}
             >
-              Community / コミュニティ
+              Community
             </button>
           </div>
           <p className="text-sm text-gray-700">
             {mode === "owner"
-              ? "For store owners / staff to request verification or updates. 店舗オーナー・スタッフ向けの申請フォーム"
-              : "For customers and fans to recommend a place. 常連客・ファン向けの推薦フォーム"}
+              ? "For store owners or staff to request verification or updates."
+              : "For customers and fans to recommend a place."}
           </p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-4">
             <div className="space-y-1">
-              {fieldLabel("Store name / 店舗名 (required)")}
+              {fieldLabel("Store name (required)")}
               <input
                 type="text"
                 className="w-full rounded-md border px-3 py-2"
@@ -234,13 +234,13 @@ export default function SubmitPage() {
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-1">
-                {fieldLabel("Country / 国 (required)")}
+                {fieldLabel("Country (required)")}
                 <select
                   className="w-full rounded-md border px-3 py-2"
                   value={formState.country}
                   onChange={(e) => handleInputChange("country", e.target.value)}
                 >
-                  <option value="">Select / 選択</option>
+                  <option value="">Select</option>
                   {meta?.countries.map((country) => (
                     <option key={country} value={country}>
                       {country}
@@ -251,14 +251,14 @@ export default function SubmitPage() {
               </div>
 
               <div className="space-y-1">
-                {fieldLabel("City / 市区町村 (required)")}
+                {fieldLabel("City (required)")}
                 {citiesForCountry.length ? (
                   <select
                     className="w-full rounded-md border px-3 py-2"
                     value={formState.city}
                     onChange={(e) => handleInputChange("city", e.target.value)}
                   >
-                    <option value="">Select / 選択</option>
+                    <option value="">Select</option>
                     {citiesForCountry.map((city) => (
                       <option key={city} value={city}>
                         {city}
@@ -278,7 +278,7 @@ export default function SubmitPage() {
             </div>
 
             <div className="space-y-1">
-              {fieldLabel("Address / 住所 (required)")}
+              {fieldLabel("Address (required)")}
               <input
                 type="text"
                 className="w-full rounded-md border px-3 py-2"
@@ -290,13 +290,13 @@ export default function SubmitPage() {
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-1">
-                {fieldLabel("Category / カテゴリー (required)")}
+                {fieldLabel("Category (required)")}
                 <select
                   className="w-full rounded-md border px-3 py-2"
                   value={formState.category}
                   onChange={(e) => handleInputChange("category", e.target.value)}
                 >
-                  <option value="">Select / 選択</option>
+                  <option value="">Select</option>
                   {meta?.categories.map((cat) => (
                     <option key={cat} value={cat}>
                       {cat}
@@ -307,7 +307,7 @@ export default function SubmitPage() {
               </div>
 
               <div className="space-y-1">
-                {fieldLabel("Accepted crypto / 受け入れ (required)")}
+                {fieldLabel("Accepted crypto (required)")}
                 <div className="flex flex-wrap gap-2">
                   {meta?.chains.map((chain) => (
                     <label key={chain} className="flex items-center space-x-2 border rounded px-2 py-1">
@@ -358,7 +358,7 @@ export default function SubmitPage() {
             </div>
 
             <div className="space-y-1">
-              {fieldLabel("About / 店舗紹介 (optional)")}
+              {fieldLabel("About (optional)")}
               <textarea
                 className="w-full rounded-md border px-3 py-2"
                 rows={3}
@@ -369,7 +369,7 @@ export default function SubmitPage() {
             </div>
 
             <div className="space-y-1">
-              {fieldLabel("Payment note / 支払いメモ (optional)")}
+              {fieldLabel("Payment note (optional)")}
               <input
                 type="text"
                 className="w-full rounded-md border px-3 py-2"
@@ -427,10 +427,10 @@ export default function SubmitPage() {
           </div>
 
           <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-4">
-            <h2 className="text-lg font-semibold text-gray-900">Submitter info / 申請者情報</h2>
+            <h2 className="text-lg font-semibold text-gray-900">Submitter info</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-1">
-                {fieldLabel("Name / お名前 (required)")}
+                {fieldLabel("Name (required)")}
                 <input
                   type="text"
                   className="w-full rounded-md border px-3 py-2"
@@ -453,20 +453,20 @@ export default function SubmitPage() {
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-1">
-                {fieldLabel("Role / 役割")}
+                {fieldLabel("Role")}
                 <select
                   className="w-full rounded-md border px-3 py-2"
                   value={formState.role}
                   onChange={(e) => handleInputChange("role", e.target.value)}
                 >
-                  <option value="owner">Owner / オーナー</option>
-                  <option value="staff">Staff / スタッフ</option>
-                  <option value="customer">Customer / 常連</option>
-                  <option value="other">Other / その他</option>
+                  <option value="owner">Owner</option>
+                  <option value="staff">Staff</option>
+                  <option value="customer">Customer</option>
+                  <option value="other">Other</option>
                 </select>
               </div>
               <div className="space-y-1">
-                {fieldLabel("Notes for admin / 補足")}
+                {fieldLabel("Notes for admin")}
                 <textarea
                   className="w-full rounded-md border px-3 py-2"
                   rows={2}
@@ -495,10 +495,10 @@ export default function SubmitPage() {
               disabled={isSubmitting}
               className="rounded-md bg-blue-600 text-white px-4 py-2 font-semibold disabled:opacity-60"
             >
-              {isSubmitting ? "Submitting..." : "Submit / 送信"}
+              {isSubmitting ? "Submitting..." : "Submit"}
             </button>
             <button type="button" onClick={resetForm} className="text-sm text-gray-600 underline">
-              Send another / もう一度入力
+              Send another
             </button>
           </div>
         </form>

--- a/components/status/DbStatusIndicator.tsx
+++ b/components/status/DbStatusIndicator.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 
 import { useHealthStatus } from "./useHealthStatus";
+import LimitedModeNotice from "./LimitedModeNotice";
 
 type DbStatusIndicatorProps = {
   className?: string;
@@ -50,10 +51,7 @@ export default function DbStatusIndicator({
         DB: {label}
       </div>
       {showBanner && isDown && (
-        <div className="mt-2 w-full max-w-sm rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 shadow-sm">
-          <p className="font-semibold">Temporary data issue</p>
-          <p>Some data may not load while the database is unavailable. Please try again shortly.</p>
-        </div>
+        <LimitedModeNotice className="mt-2 w-full max-w-sm" />
       )}
     </div>
   );

--- a/components/status/LimitedModeNotice.tsx
+++ b/components/status/LimitedModeNotice.tsx
@@ -1,0 +1,22 @@
+import { type ReactNode } from "react";
+
+type LimitedModeNoticeProps = {
+  className?: string;
+  actions?: ReactNode;
+};
+
+const title = "Limited mode";
+const description = "Data may be partial (fallback mode). Try again later.";
+
+export default function LimitedModeNotice({ className, actions }: LimitedModeNoticeProps) {
+  return (
+    <div
+      className={`rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 shadow-sm ${className ?? ""}`}
+      role="status"
+    >
+      <p className="font-semibold">{title}</p>
+      <p>{description}</p>
+      {actions ? <div className="mt-2">{actions}</div> : null}
+    </div>
+  );
+}

--- a/lib/dataSource.ts
+++ b/lib/dataSource.ts
@@ -1,0 +1,66 @@
+import { DbUnavailableError, hasDatabaseUrl } from "@/lib/db";
+
+export type DataSourceSetting = "auto" | "db" | "json";
+export type DataSourceResult = "db" | "json";
+
+type TimeoutOptions = {
+  timeoutMs?: number;
+  message?: string;
+};
+
+// DATA_SOURCE=auto rules:
+// - Respect DATA_SOURCE (server) or NEXT_PUBLIC_DATA_SOURCE (client-visible) when set.
+// - auto tries the DB when DATABASE_URL is configured; on timeout/unavailable errors it falls back to JSON.
+// - auto does not fall back on valid empty DB results (empty lists are returned as-is).
+// - Limited mode is signaled when JSON data is served (forced or fallback).
+// - Errors are logged server-side; user-facing responses only indicate limited mode.
+const DEFAULT_DB_TIMEOUT_MS = 4500;
+
+const normalizeSetting = (value: string | undefined) => value?.trim().toLowerCase() ?? "";
+
+export const getDataSourceSetting = (): DataSourceSetting => {
+  const envValue = normalizeSetting(process.env.DATA_SOURCE);
+  if (envValue === "auto" || envValue === "db" || envValue === "json") {
+    return envValue;
+  }
+  const publicValue = normalizeSetting(process.env.NEXT_PUBLIC_DATA_SOURCE);
+  if (publicValue === "auto" || publicValue === "db" || publicValue === "json") {
+    return publicValue;
+  }
+  return "auto";
+};
+
+export const getDataSourceContext = (setting: DataSourceSetting) => {
+  const hasDb = hasDatabaseUrl();
+  return {
+    setting,
+    hasDb,
+    shouldAttemptDb: setting !== "json" && hasDb,
+    shouldAllowJson: setting !== "db",
+  };
+};
+
+export const buildDataSourceHeaders = (source: DataSourceResult, limited: boolean) => ({
+  "X-CPM-Data-Source": source,
+  "X-CPM-Limited": limited ? "true" : "false",
+});
+
+export const withDbTimeout = async <T>(promise: Promise<T>, options: TimeoutOptions = {}) => {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_DB_TIMEOUT_MS;
+  const message = options.message ?? "DB_TIMEOUT";
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new DbUnavailableError(message));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+};


### PR DESCRIPTION
### Motivation

- Make runtime data source selection predictable and robust by clarifying and hardening DB → JSON fallback rules.
- Provide a single, consistent user-facing "Limited mode" badge/banner across Map, Stats, and status components.
- Remove accidentally introduced Japanese copy so the Submit and internal pages do not mix languages.

### Description

- Add a centralized `lib/dataSource.ts` utility that reads `DATA_SOURCE`/`NEXT_PUBLIC_DATA_SOURCE`, exposes a DB timeout helper `withDbTimeout`, and builds `X-CPM-Data-Source` / `X-CPM-Limited` headers.
- Update `/api/places`, `/api/stats`, and `/api/filters/meta` to use the centralized data-source logic and to return predictable limited-mode headers without changing existing response shapes.
- Add `components/status/LimitedModeNotice.tsx` and wire it into Map, Stats, and `DbStatusIndicator` to unify the Limited mode copy as English-only.
- Remove mixed-language strings from `app/submit/page.tsx` and internal submission pages and tidy a few map/internal comments to English.

### Testing

- Started the dev server with `npm run dev` and confirmed the affected pages compiled successfully.
- Executed a Playwright script to load `/submit` and capture a screenshot, which completed successfully and verifies the submit page is English-only.
- To simulate fallback locally: run `DATA_SOURCE=json npm run dev` to force JSON fallback, or run `DATA_SOURCE=auto` with `DATABASE_URL` unset or invalid to trigger DB → JSON fallback and observe `X-CPM-Limited: true` on API responses.
- No automated unit/integration test suite changes were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b6d26718832894a0a4b44dc0ad1d)