### PR TITLE
Hotfix: stats page hooks order

### DIFF
--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -161,6 +161,8 @@ function SectionCard({
 
 export default function StatsPage() {
   const [state, setState] = useState<StatsState>({ status: 'loading' });
+  const stats = state.stats ?? EMPTY_STATS;
+  const trends = state.trends ?? { points: [], meta: { reason: 'no_history_data' } };
 
   const fetchStats = useCallback(async () => {
     setState({ status: 'loading' });
@@ -182,35 +184,6 @@ export default function StatsPage() {
     fetchStats();
   }, [fetchStats]);
 
-  if (state.status === 'loading') {
-    return (
-      <main className="flex min-h-screen flex-col gap-8 bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 animate-pulse">
-          <header className="space-y-3">
-            <div className="h-4 w-16 rounded bg-sky-100" />
-            <div className="h-8 w-64 rounded bg-gray-200" />
-            <div className="h-4 w-full max-w-2xl rounded bg-gray-200" />
-          </header>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {[...Array(3)].map((_, index) => (
-              <div key={index} className="rounded-lg bg-white p-4 shadow-sm">
-                <div className="h-4 w-24 rounded bg-gray-200" />
-                <div className="mt-3 h-7 w-32 rounded bg-gray-300" />
-                <div className="mt-2 h-3 w-20 rounded bg-gray-200" />
-              </div>
-            ))}
-          </div>
-          <div className="rounded-lg bg-white p-6 shadow-sm">
-            <div className="h-4 w-32 rounded bg-gray-200" />
-            <div className="mt-4 h-48 rounded bg-gray-100" />
-          </div>
-        </div>
-      </main>
-    );
-  }
-
-  const stats = state.stats ?? EMPTY_STATS;
-  const trends = state.trends ?? { points: [], meta: { reason: 'no_history_data' } };
   const trendPoints = trends.points;
   const trendLabels = trendPoints.map((point) => point.date);
   const trendSeries: ChartSeries[] = [
@@ -240,6 +213,33 @@ export default function StatsPage() {
 
   const lastUpdated = stats.generated_at ? new Date(stats.generated_at).toLocaleString() : null;
   const showLimited = Boolean(stats.limited || state.notice);
+
+  if (state.status === 'loading') {
+    return (
+      <main className="flex min-h-screen flex-col gap-8 bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 animate-pulse">
+          <header className="space-y-3">
+            <div className="h-4 w-16 rounded bg-sky-100" />
+            <div className="h-8 w-64 rounded bg-gray-200" />
+            <div className="h-4 w-full max-w-2xl rounded bg-gray-200" />
+          </header>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {[...Array(3)].map((_, index) => (
+              <div key={index} className="rounded-lg bg-white p-4 shadow-sm">
+                <div className="h-4 w-24 rounded bg-gray-200" />
+                <div className="mt-3 h-7 w-32 rounded bg-gray-300" />
+                <div className="mt-2 h-3 w-20 rounded bg-gray-200" />
+              </div>
+            ))}
+          </div>
+          <div className="rounded-lg bg-white p-6 shadow-sm">
+            <div className="h-4 w-32 rounded bg-gray-200" />
+            <div className="mt-4 h-48 rounded bg-gray-100" />
+          </div>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="flex min-h-screen flex-col bg-gray-50 px-4 py-8 text-gray-900 sm:px-6 lg:px-10">


### PR DESCRIPTION
### Motivation
- Next build failed with `react-hooks/rules-of-hooks` because `useMemo` and other hook-dependent logic were executed conditionally after an early return in `app/stats/page.tsx`.
- Hooks must be called unconditionally and before any early return to satisfy the Rules of Hooks and avoid build/runtime errors.
- The page should still show limited/zero placeholders when data is missing, so a safe fallback is required.

### Description
- Move stats/trends fallback assignments and all hook-dependent derived values (including `useMemo` for `summaryCards` and `chainEntries`) above the loading early return so hooks run unconditionally.
- Use the existing `EMPTY_STATS` and a trends fallback to ensure memoized calculations can run even when API data is missing.
- Preserve the loading skeleton, limited-mode notice, and UI placeholders so visuals remain unchanged.

### Testing
- Ran `pnpm build` to verify the Next build and the rules-of-hooks error resolution, but the command failed due to a Corepack/pnpm download network/proxy error (HTTP 403) in this environment.
- No automated build/test completed successfully here; verify locally or in CI by confirming `/stats` loads and that `pnpm build` (or `next build`) completes without `react-hooks/rules-of-hooks` violations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963be3fad908328830ca20edbcca57b)