### PR TITLE
Fix validateUrl typing and include messages in validate_data.ts

### DIFF
--- a/scripts/validate_data.ts
+++ b/scripts/validate_data.ts
@@ -12,6 +12,8 @@ type ValidationIssue = {
   message: string;
 };
 
+type ValidationContext = Pick<ValidationIssue, "source" | "recordId">;
+
 type DbPlace = {
   id: string;
   name: string | null;
@@ -96,7 +98,13 @@ const isValidHttpUrl = (value: string): boolean => {
   }
 };
 
-const validateMaxLength = (issues: ValidationIssue[], context: ValidationIssue, label: string, value: string | null, max: number) => {
+const validateMaxLength = (
+  issues: ValidationIssue[],
+  context: ValidationContext,
+  label: string,
+  value: string | null,
+  max: number,
+) => {
   if (!value) return;
   if (value.length > max) {
     issues.push({
@@ -107,13 +115,18 @@ const validateMaxLength = (issues: ValidationIssue[], context: ValidationIssue, 
   }
 };
 
-const validateUrl = (issues: ValidationIssue[], context: ValidationIssue, label: string, value: string | null) => {
+const validateUrl = (
+  issues: ValidationIssue[],
+  context: ValidationContext,
+  field: string,
+  value: string | null | undefined,
+) => {
   if (!value) return;
   if (!isValidHttpUrl(value)) {
     issues.push({
       ...context,
-      field: label,
-      message: `${label} must be a http(s) URL`,
+      field,
+      message: `Invalid URL for ${field}: ${value}`,
     });
   }
 };
@@ -429,7 +442,7 @@ const findJsonFiles = async (dir: string): Promise<string[]> => {
   return files;
 };
 
-const validateSubmissionPayload = (issues: ValidationIssue[], context: ValidationIssue, payload: Record<string, unknown>) => {
+const validateSubmissionPayload = (issues: ValidationIssue[], context: ValidationContext, payload: Record<string, unknown>) => {
   const name = isNonEmptyString(payload.name);
   const contactName = isNonEmptyString(payload.contactName ?? payload.submitterName);
   const contactEmail = isNonEmptyString(payload.contactEmail ?? payload.submitterEmail);


### PR DESCRIPTION
### Motivation
- The TypeScript build failed because helpers like `validateUrl` accepted a full `ValidationIssue` while callers provided only `{ source, recordId }`, causing a missing `message` error.  
- URL validation pushed issues without a consistently meaningful `message` string required by `ValidationIssue`.  

### Description
- Introduce `ValidationContext = Pick<ValidationIssue, "source" | "recordId">` and use it for shared validators.  
- Change `validateUrl` signature to `(issues, context: ValidationContext, field: string, value: string | null | undefined)` and emit a clear message like `Invalid URL for ${field}: ${value}` when invalid.  
- Update `validateMaxLength` and `validateSubmissionPayload` to accept `ValidationContext` without changing validation behavior.  

### Testing
- No automated tests or build (`pnpm build`) were executed in this rollout.  
- Please run `pnpm build` / CI to verify TypeScript compilation and Vercel deployment status.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69644d350bd48328a2080a94ce442a59)