### PR TITLE
Map: selection URL/state consistency

### DIFF
--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -11,6 +11,7 @@ type Props = {
   mode: "full" | null;
   onClose: () => void;
   headerHeight?: number;
+  selectionStatus?: "idle" | "loading" | "error";
 };
 
 const VERIFICATION_COLORS: Record<Place["verification"], string> = {
@@ -28,7 +29,7 @@ const VERIFICATION_LABELS: Record<Place["verification"], string> = {
 };
 
 const Drawer = forwardRef<HTMLDivElement, Props>(
-  ({ place, isOpen, mode, onClose, headerHeight = 0 }, ref) => {
+  ({ place, isOpen, mode, onClose, headerHeight = 0, selectionStatus = "idle" }, ref) => {
     useEffect(() => {
       if (!isOpen) return;
 
@@ -107,6 +108,10 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
     }, [place]);
 
     if (!place) {
+      const emptyMessage =
+        selectionStatus === "loading"
+          ? "Loading place details..."
+          : "Place details are unavailable right now.";
       return (
         <div
           ref={ref}
@@ -117,7 +122,31 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
           }}
           data-testid="place-drawer"
           aria-hidden
-        />
+        >
+          {isOpen && (
+            <div className="cpm-drawer__panel">
+              <header className="cpm-drawer__header">
+                <div className="cpm-drawer__title-block">
+                  <h2 className="cpm-drawer__title">Place details</h2>
+                </div>
+                <button
+                  type="button"
+                  className="cpm-drawer__close"
+                  aria-label="Close drawer"
+                  onClick={onClose}
+                >
+                  ×
+                </button>
+              </header>
+              <div className="cpm-drawer__content" role="presentation">
+                <section className="cpm-drawer__section">
+                  <h3 className="cpm-drawer__section-title">Status</h3>
+                  <p className="cpm-drawer__muted">{emptyMessage}</p>
+                </section>
+              </div>
+            </div>
+          )}
+        </div>
       );
     }
 

--- a/components/map/MobileBottomSheet.css
+++ b/components/map/MobileBottomSheet.css
@@ -49,6 +49,26 @@
   gap: 12px;
 }
 
+.cpm-bottom-sheet__close {
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  color: #6b7280;
+  font-size: 18px;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.cpm-bottom-sheet__close:hover {
+  background: #eef2ff;
+  color: #111827;
+}
+
 .cpm-bottom-sheet__title-block {
   display: flex;
   flex-direction: column;

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -231,8 +231,12 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
       );
     }
 
+    if (!renderedPlace) {
+      return null;
+    }
+
     return (
-      <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
+    <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
         <div
           className="cpm-bottom-sheet__panel"
           style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -10,6 +10,7 @@ type Props = {
   place: Place | null;
   isOpen: boolean;
   onClose: () => void;
+  selectionStatus?: "idle" | "loading" | "error";
 };
 
 type SheetStage = "peek" | "expanded";
@@ -90,271 +91,316 @@ const buildNavigationLinks = (place: Place | null) => {
   ];
 };
 
-const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(({ place, isOpen, onClose }, ref) => {
-  const [stage, setStage] = useState<SheetStage>("peek");
-  const [renderedPlace, setRenderedPlace] = useState<Place | null>(null);
-  const touchStartY = useRef<number | null>(null);
-  const touchCurrentY = useRef<number | null>(null);
+const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
+  ({ place, isOpen, onClose, selectionStatus = "idle" }, ref) => {
+    const [stage, setStage] = useState<SheetStage>("peek");
+    const [renderedPlace, setRenderedPlace] = useState<Place | null>(null);
+    const touchStartY = useRef<number | null>(null);
+    const touchCurrentY = useRef<number | null>(null);
 
-  useEffect(() => {
-    if (place) {
-      setRenderedPlace(place);
-      setStage("peek");
-      return;
-    }
-
-    if (!isOpen) {
-      const timeout = window.setTimeout(() => setRenderedPlace(null), 220);
-      return () => window.clearTimeout(timeout);
-    }
-
-    return undefined;
-  }, [isOpen, place]);
-
-  const supportedCrypto = useMemo(() => formatSupportedCrypto(renderedPlace), [renderedPlace]);
-  const socialLinks = useMemo(() => buildSocialLinks(renderedPlace), [renderedPlace]);
-  const navigationLinks = useMemo(() => buildNavigationLinks(renderedPlace), [renderedPlace]);
-  const photos = useMemo(() => {
-    if (!renderedPlace) return [] as string[];
-    return renderedPlace.photos?.length ? renderedPlace.photos : renderedPlace.images ?? [];
-  }, [renderedPlace]);
-
-  const isRestricted =
-    renderedPlace?.verification === "directory" || renderedPlace?.verification === "unverified";
-  const canShowPhotos =
-    renderedPlace && (renderedPlace.verification === "owner" || renderedPlace.verification === "community")
-      ? photos.length > 0
-      : false;
-  const canShowDescription =
-    renderedPlace && !isRestricted && (renderedPlace.description ?? renderedPlace.about);
-  const fullAddress = renderedPlace?.address_full ?? renderedPlace?.address ?? "";
-  const shortAddress = [renderedPlace?.city, renderedPlace?.country].filter(Boolean).join(", ");
-  const amenities = renderedPlace?.amenities ?? [];
-  const paymentNote = renderedPlace?.paymentNote;
-  const submitter = renderedPlace?.submitterName ?? renderedPlace?.updatedAt;
-
-  useEffect(() => {
-    if (!isOpen || !renderedPlace) return undefined;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
+    useEffect(() => {
+      if (place) {
+        setRenderedPlace(place);
+        setStage("peek");
+        return;
       }
+
+      if (!isOpen) {
+        const timeout = window.setTimeout(() => setRenderedPlace(null), 220);
+        return () => window.clearTimeout(timeout);
+      }
+
+      return undefined;
+    }, [isOpen, place]);
+
+    const supportedCrypto = useMemo(() => formatSupportedCrypto(renderedPlace), [renderedPlace]);
+    const socialLinks = useMemo(() => buildSocialLinks(renderedPlace), [renderedPlace]);
+    const navigationLinks = useMemo(() => buildNavigationLinks(renderedPlace), [renderedPlace]);
+    const photos = useMemo(() => {
+      if (!renderedPlace) return [] as string[];
+      return renderedPlace.photos?.length ? renderedPlace.photos : renderedPlace.images ?? [];
+    }, [renderedPlace]);
+
+    const isRestricted =
+      renderedPlace?.verification === "directory" || renderedPlace?.verification === "unverified";
+    const canShowPhotos =
+      renderedPlace && (renderedPlace.verification === "owner" || renderedPlace.verification === "community")
+        ? photos.length > 0
+        : false;
+    const canShowDescription =
+      renderedPlace && !isRestricted && (renderedPlace.description ?? renderedPlace.about);
+    const fullAddress = renderedPlace?.address_full ?? renderedPlace?.address ?? "";
+    const shortAddress = [renderedPlace?.city, renderedPlace?.country].filter(Boolean).join(", ");
+    const amenities = renderedPlace?.amenities ?? [];
+    const paymentNote = renderedPlace?.paymentNote;
+    const submitter = renderedPlace?.submitterName ?? renderedPlace?.updatedAt;
+
+    useEffect(() => {
+      if (!isOpen || !renderedPlace) return undefined;
+
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+          onClose();
+        }
+      };
+
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [isOpen, onClose, renderedPlace]);
+
+    const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
+      touchStartY.current = event.touches[0]?.clientY ?? null;
+      touchCurrentY.current = touchStartY.current;
     };
 
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose, renderedPlace]);
+    const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
+      touchCurrentY.current = event.touches[0]?.clientY ?? null;
+    };
 
-  const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
-    touchStartY.current = event.touches[0]?.clientY ?? null;
-    touchCurrentY.current = touchStartY.current;
-  };
-
-  const handleTouchMove = (event: React.TouchEvent<HTMLDivElement>) => {
-    touchCurrentY.current = event.touches[0]?.clientY ?? null;
-  };
-
-  const handleTouchEnd = () => {
-    if (touchStartY.current === null || touchCurrentY.current === null) {
-      return;
-    }
-
-    const deltaY = touchCurrentY.current - touchStartY.current;
-    const threshold = 40;
-
-    if (deltaY < -threshold) {
-      setStage("expanded");
-    } else if (deltaY > threshold) {
-      if (stage === "expanded") {
-        setStage("peek");
-      } else {
-        onClose();
+    const handleTouchEnd = () => {
+      if (touchStartY.current === null || touchCurrentY.current === null) {
+        return;
       }
+
+      const deltaY = touchCurrentY.current - touchStartY.current;
+      const threshold = 40;
+
+      if (deltaY < -threshold) {
+        setStage("expanded");
+      } else if (deltaY > threshold) {
+        if (stage === "expanded") {
+          setStage("peek");
+        } else {
+          onClose();
+        }
+      }
+
+      touchStartY.current = null;
+      touchCurrentY.current = null;
+    };
+
+    if (!renderedPlace && !isOpen) {
+      return null;
     }
 
-    touchStartY.current = null;
-    touchCurrentY.current = null;
-  };
+    const showPlaceholder = isOpen && !renderedPlace;
+    const effectiveStage = showPlaceholder ? "expanded" : stage;
+    const sheetHeight = effectiveStage === "expanded" ? `${EXPANDED_HEIGHT}vh` : `${PEEK_HEIGHT}vh`;
+    const showDetails = effectiveStage === "expanded";
+    const isVisible = isOpen && (Boolean(renderedPlace) || showPlaceholder);
 
-  if (!renderedPlace) {
-    return null;
-  }
-
-  const sheetHeight = stage === "expanded" ? `${EXPANDED_HEIGHT}vh` : `${PEEK_HEIGHT}vh`;
-  const showDetails = stage === "expanded";
-  const isVisible = isOpen && Boolean(renderedPlace);
-
-  return (
-    <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
-      <div
-        className="cpm-bottom-sheet__panel"
-        style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}
-      >
-        <div
-          className="cpm-bottom-sheet__handle"
-          onTouchStart={handleTouchStart}
-          onTouchMove={handleTouchMove}
-          onTouchEnd={handleTouchEnd}
-          onClick={() => setStage((prev) => (prev === "peek" ? "expanded" : "peek"))}
-        >
-          <span className="cpm-bottom-sheet__handle-bar" aria-hidden />
-        </div>
-
-        <header className="cpm-bottom-sheet__header">
-          <div className="cpm-bottom-sheet__title-block">
-            <div className="cpm-bottom-sheet__title-row">
-              <h2 className="cpm-bottom-sheet__title">{renderedPlace.name}</h2>
-              <span
-                className="cpm-bottom-sheet__badge"
-                style={{
-                  color: VERIFICATION_COLORS[renderedPlace.verification],
-                  borderColor: VERIFICATION_COLORS[renderedPlace.verification],
-                  backgroundColor: `${VERIFICATION_COLORS[renderedPlace.verification]}1A`,
-                }}
-              >
-                <span
-                  className="cpm-bottom-sheet__badge-dot"
-                  style={{ backgroundColor: VERIFICATION_COLORS[renderedPlace.verification] }}
-                  aria-hidden
-                />
-                {VERIFICATION_LABELS[renderedPlace.verification]}
-              </span>
+    if (showPlaceholder) {
+      const placeholderMessage =
+        selectionStatus === "loading"
+          ? "Loading place details..."
+          : "Place details are unavailable right now.";
+      return (
+        <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
+          <div
+            className="cpm-bottom-sheet__panel"
+            style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}
+          >
+            <div className="cpm-bottom-sheet__handle">
+              <span className="cpm-bottom-sheet__handle-bar" aria-hidden />
             </div>
-            <div className="cpm-bottom-sheet__meta-row">
-              <span className="cpm-bottom-sheet__category">{renderedPlace.category}</span>
-              {shortAddress && <span className="cpm-bottom-sheet__meta-dot">•</span>}
-              {shortAddress && <span className="cpm-bottom-sheet__address">{shortAddress}</span>}
+            <header className="cpm-bottom-sheet__header">
+              <div className="cpm-bottom-sheet__title-block">
+                <div className="cpm-bottom-sheet__title-row">
+                  <h2 className="cpm-bottom-sheet__title">Place details</h2>
+                </div>
+              </div>
+              <button
+                type="button"
+                className="cpm-bottom-sheet__close"
+                onClick={onClose}
+                aria-label="Close drawer"
+              >
+                ×
+              </button>
+            </header>
+            <div className="cpm-bottom-sheet__content" role="presentation">
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Status</h3>
+                </div>
+                <p className="cpm-bottom-sheet__muted">{placeholderMessage}</p>
+              </section>
             </div>
           </div>
-        </header>
+        </div>
+      );
+    }
 
-        <div className="cpm-bottom-sheet__content" role="presentation">
-          <section className="cpm-bottom-sheet__section">
-            <div className="cpm-bottom-sheet__section-head">
-              <h3 className="cpm-bottom-sheet__section-title">Accepted payments</h3>
-            </div>
-            <div className="cpm-bottom-sheet__pill-row">
-              {supportedCrypto.map((item) => (
-                <span key={item} className="cpm-bottom-sheet__pill">
-                  {item}
+    return (
+      <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
+        <div
+          className="cpm-bottom-sheet__panel"
+          style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}
+        >
+          <div
+            className="cpm-bottom-sheet__handle"
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+            onClick={() => setStage((prev) => (prev === "peek" ? "expanded" : "peek"))}
+          >
+            <span className="cpm-bottom-sheet__handle-bar" aria-hidden />
+          </div>
+
+          <header className="cpm-bottom-sheet__header">
+            <div className="cpm-bottom-sheet__title-block">
+              <div className="cpm-bottom-sheet__title-row">
+                <h2 className="cpm-bottom-sheet__title">{renderedPlace.name}</h2>
+                <span
+                  className="cpm-bottom-sheet__badge"
+                  style={{
+                    color: VERIFICATION_COLORS[renderedPlace.verification],
+                    borderColor: VERIFICATION_COLORS[renderedPlace.verification],
+                    backgroundColor: `${VERIFICATION_COLORS[renderedPlace.verification]}1A`,
+                  }}
+                >
+                  <span
+                    className="cpm-bottom-sheet__badge-dot"
+                    style={{ backgroundColor: VERIFICATION_COLORS[renderedPlace.verification] }}
+                    aria-hidden
+                  />
+                  {VERIFICATION_LABELS[renderedPlace.verification]}
                 </span>
-              ))}
-              {supportedCrypto.length === 0 && <span className="cpm-bottom-sheet__muted">Not provided</span>}
+              </div>
+              <div className="cpm-bottom-sheet__meta-row">
+                <span className="cpm-bottom-sheet__category">{renderedPlace.category}</span>
+                {shortAddress && <span className="cpm-bottom-sheet__meta-dot">•</span>}
+                {shortAddress && <span className="cpm-bottom-sheet__address">{shortAddress}</span>}
+              </div>
             </div>
-          </section>
+          </header>
 
-          {showDetails && !isRestricted && canShowPhotos && (
+          <div className="cpm-bottom-sheet__content" role="presentation">
             <section className="cpm-bottom-sheet__section">
               <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Photos</h3>
-              </div>
-              <div className="cpm-bottom-sheet__carousel" aria-label={`${renderedPlace.name} photos`}>
-                {photos.map((image) => (
-                  <div key={image} className="cpm-bottom-sheet__carousel-item">
-                    <img src={image} alt={`${renderedPlace.name} photo`} className="cpm-bottom-sheet__photo" />
-                  </div>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {showDetails && canShowDescription && (
-            <section className="cpm-bottom-sheet__section">
-              <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Description</h3>
-              </div>
-              <p className="cpm-bottom-sheet__body">{renderedPlace.description ?? renderedPlace.about}</p>
-            </section>
-          )}
-
-          {showDetails && !isRestricted && socialLinks.length > 0 && (
-            <section className="cpm-bottom-sheet__section">
-              <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Links</h3>
-              </div>
-              <div className="cpm-bottom-sheet__links">
-                {socialLinks.map((social) => (
-                  <a
-                    key={social.key}
-                    className="cpm-bottom-sheet__link"
-                    href={social.href}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {social.label}
-                  </a>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {showDetails && !isRestricted && navigationLinks.length > 0 && (
-            <section className="cpm-bottom-sheet__section">
-              <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Navigate</h3>
-              </div>
-              <div className="cpm-bottom-sheet__nav">
-                {navigationLinks.map((link) => (
-                  <a
-                    key={link.key}
-                    className="cpm-bottom-sheet__nav-link"
-                    href={link.href}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {link.label}
-                  </a>
-                ))}
-              </div>
-            </section>
-          )}
-
-          {showDetails && !isRestricted && paymentNote && (
-            <section className="cpm-bottom-sheet__section">
-              <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Payment note</h3>
-              </div>
-              <p className="cpm-bottom-sheet__body">{paymentNote}</p>
-            </section>
-          )}
-
-          {showDetails && !isRestricted && amenities.length > 0 && (
-            <section className="cpm-bottom-sheet__section">
-              <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Amenities</h3>
+                <h3 className="cpm-bottom-sheet__section-title">Accepted payments</h3>
               </div>
               <div className="cpm-bottom-sheet__pill-row">
-                {amenities.map((item) => (
-                  <span key={item} className="cpm-bottom-sheet__pill muted">
+                {supportedCrypto.map((item) => (
+                  <span key={item} className="cpm-bottom-sheet__pill">
                     {item}
                   </span>
                 ))}
+                {supportedCrypto.length === 0 && <span className="cpm-bottom-sheet__muted">Not provided</span>}
               </div>
             </section>
-          )}
 
-          {showDetails && !isRestricted && fullAddress && (
-            <section className="cpm-bottom-sheet__section">
-              <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Address</h3>
-              </div>
-              <p className="cpm-bottom-sheet__body">{fullAddress}</p>
-            </section>
-          )}
+            {showDetails && !isRestricted && canShowPhotos && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Photos</h3>
+                </div>
+                <div className="cpm-bottom-sheet__carousel" aria-label={`${renderedPlace.name} photos`}>
+                  {photos.map((image) => (
+                    <div key={image} className="cpm-bottom-sheet__carousel-item">
+                      <img src={image} alt={`${renderedPlace.name} photo`} className="cpm-bottom-sheet__photo" />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
 
-          {showDetails && !isRestricted && submitter && (
-            <section className="cpm-bottom-sheet__section">
-              <div className="cpm-bottom-sheet__section-head">
-                <h3 className="cpm-bottom-sheet__section-title">Submitted by</h3>
-              </div>
-              <p className="cpm-bottom-sheet__body muted">{submitter}</p>
-            </section>
-          )}
+            {showDetails && canShowDescription && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Description</h3>
+                </div>
+                <p className="cpm-bottom-sheet__body">{renderedPlace.description ?? renderedPlace.about}</p>
+              </section>
+            )}
+
+            {showDetails && !isRestricted && socialLinks.length > 0 && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Links</h3>
+                </div>
+                <div className="cpm-bottom-sheet__links">
+                  {socialLinks.map((social) => (
+                    <a
+                      key={social.key}
+                      className="cpm-bottom-sheet__link"
+                      href={social.href}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {social.label}
+                    </a>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {showDetails && !isRestricted && navigationLinks.length > 0 && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Navigate</h3>
+                </div>
+                <div className="cpm-bottom-sheet__nav">
+                  {navigationLinks.map((link) => (
+                    <a
+                      key={link.key}
+                      className="cpm-bottom-sheet__nav-link"
+                      href={link.href}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {link.label}
+                    </a>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {showDetails && !isRestricted && paymentNote && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Payment note</h3>
+                </div>
+                <p className="cpm-bottom-sheet__body">{paymentNote}</p>
+              </section>
+            )}
+
+            {showDetails && !isRestricted && amenities.length > 0 && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Amenities</h3>
+                </div>
+                <div className="cpm-bottom-sheet__pill-row">
+                  {amenities.map((item) => (
+                    <span key={item} className="cpm-bottom-sheet__pill muted">
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {showDetails && !isRestricted && fullAddress && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Address</h3>
+                </div>
+                <p className="cpm-bottom-sheet__body">{fullAddress}</p>
+              </section>
+            )}
+
+            {showDetails && !isRestricted && submitter && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Submitted by</h3>
+                </div>
+                <p className="cpm-bottom-sheet__body muted">{submitter}</p>
+              </section>
+            )}
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
 });
 
 MobileBottomSheet.displayName = "MobileBottomSheet";

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -236,7 +236,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
     }
 
     return (
-    <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
+      <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
         <div
           className="cpm-bottom-sheet__panel"
           style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}


### PR DESCRIPTION
### Motivation
- Ensure the currently selected place is kept in sync between the URL (`?select=<id>`), internal state and the UI so reload/back/forward do not break selection.
- Keep the drawer open and show a safe placeholder when a selected `placeId` is outside the current bbox or not present in the current markers list.
- Avoid adding new routes and reuse existing API endpoints to fetch a single place detail when needed.

### Description
- Added `selectedPlaceDetail` and `selectedPlaceDetailStatus` state and fetch logic to load `/api/places/:id` when `selectedPlaceId` exists but the place is not present in the current `places` list, and wired `selectedPlaceForDrawer = selectedPlace ?? selectedPlaceDetail`.
- Stopped closing the drawer when a selection is outside the current bbox and instead show a loading/placeholder panel until the detail fetch completes or fails, by passing `selectionStatus` into `Drawer` and `MobileBottomSheet` and rendering a safe message/UI while missing.
- Kept URL/state sync: the `select` query param is read into selection on initial/back/forward navigation and `selectedPlaceId` updates replace the URL query (no new routes introduced), while preserving existing marker click / list click behaviors.
- Manual test checklist (for reviewers): `marker click -> drawer open -> URLにselect付与`, `reload -> 同じ選択でdrawerが開く`, `close -> 選択解除 + URLからselect消える`, `戻る/進むで選択状態がUIと一致`.

### Testing
- Started the dev server with `npm run dev` and the Next app compiled the `/map` page successfully (dev server ready).
- Executed a headless Playwright script that opened `http://127.0.0.1:3000/map?select=cpm:tokyo:owner-cafe-1` and captured a screenshot, which completed successfully and produced an artifact.
- No automated unit tests were run as part of this rollout (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964f0f8d1288328937afc8a9e031ddb)