### PR TITLE
Mobile drawer: Preview/Full state fixed

### DIFF
--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 type SheetStage = "peek" | "expanded";
 
-const PEEK_HEIGHT = 32;
+const PEEK_HEIGHT = 35;
 const EXPANDED_HEIGHT = 88;
 
 const VERIFICATION_COLORS: Record<Place["verification"], string> = {
@@ -167,12 +167,8 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
 
       if (deltaY < -threshold) {
         setStage("expanded");
-      } else if (deltaY > threshold) {
-        if (stage === "expanded") {
-          setStage("peek");
-        } else {
-          onClose();
-        }
+      } else if (deltaY > threshold && stage === "expanded") {
+        setStage("peek");
       }
 
       touchStartY.current = null;


### PR DESCRIPTION
### Motivation
- Stabilize the mobile bottom sheet to the spec's two stages (Preview ≈35% / Full ≈88%) so users understand what’s happening. 
- Prevent accidental close gestures from the Preview stage and make transitions predictable. 
- Ensure photos and detailed content only appear in Full state to reduce cognitive load on small screens. 
- Keep visual design and existing component structure intact while adjusting behavior only.

### Description
- Increase the preview height constant from `32` to `35` by updating `PEEK_HEIGHT` in `components/map/MobileBottomSheet.tsx`.
- Constrain swipe logic in `handleTouchEnd` so upward swipes set the sheet to `expanded` and downward swipes only collapse `expanded` back to `peek`, removing swipe-to-close from the `peek` stage.
- Preserve existing behavior that photos and other detailed sections are rendered only when `effectiveStage === "expanded"`, ensuring no images appear in Preview.
- Manual test checklist: marker clickでPreviewが開く; expand操作でFullになる; collapse操作でPreviewに戻る; closeで完全に閉じて選択解除.

### Testing
- No automated tests were run for this change.
- The change was committed and the modified file is `components/map/MobileBottomSheet.tsx`.
- Manual verification is expected via the provided checklist.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650f39a69083288bb63c749f05659d)