### PR TITLE
Map: loading/error UX for bbox fetching

### DIFF
--- a/components/map/MapFetchStatus.tsx
+++ b/components/map/MapFetchStatus.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+type MapFetchStatusProps = {
+  isLoading: boolean;
+  error: string | null;
+  onRetry: () => void;
+};
+
+export default function MapFetchStatus({
+  isLoading,
+  error,
+  onRetry,
+}: MapFetchStatusProps) {
+  if (!isLoading && !error) return null;
+
+  return (
+    <div className="cpm-map-fetch-status" role="status" aria-live="polite">
+      {isLoading ? (
+        <>
+          <span className="cpm-map-fetch-status__spinner" aria-hidden />
+          <span>Loading markers…</span>
+        </>
+      ) : (
+        <>
+          <span className="cpm-map-fetch-status__dot" aria-hidden />
+          <span>Failed to load markers.</span>
+          <button type="button" onClick={onRetry} className="cpm-map-fetch-status__retry">
+            Retry
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -87,32 +87,52 @@
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.2);
 }
 
-.cpm-map-loading {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 60;
+.cpm-map-fetch-status {
+  align-self: flex-end;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px;
+  padding: 6px 12px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid #e5e7eb;
   color: #475569;
-  font-size: 0.8125rem;
+  font-size: 0.75rem;
   font-weight: 600;
   box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
-  pointer-events: none;
+  pointer-events: auto;
 }
 
-.cpm-map-loading__spinner {
-  width: 14px;
-  height: 14px;
+.cpm-map-fetch-status__spinner {
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
   border: 2px solid #c7d2fe;
   border-top-color: #6366f1;
   animation: cpm-spin 0.9s linear infinite;
+}
+
+.cpm-map-fetch-status__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #ef4444;
+}
+
+.cpm-map-fetch-status__retry {
+  appearance: none;
+  border: none;
+  background: #ef4444;
+  color: #ffffff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 4px 8px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.cpm-map-fetch-status__retry:hover {
+  background: #dc2626;
 }
 
 .cpm-map-empty {


### PR DESCRIPTION
### Motivation
- Provide a minimal, consistent loading/error indicator while bbox/filter fetches run so the user understands what's happening instead of seeing an empty map.
- Avoid blocking map interactions while fetches happen or fail, and prefer to keep previously loaded markers visible on fetch error.
- Reduce flicker from rapid map moves by debouncing the small loading indicator.

### Description
- Add a small reusable component `MapFetchStatus` that shows a compact loading badge or a non-blocking error state with a `Retry` button. 
- Wire the component into the map overlay in `MapClient` and pass `isLoading`/`error` plus `onRetry` (calls `fetchPlacesRef.current?.()`).
- Debounce the loading badge with a 220ms delay so quick consecutive map moves do not cause flicker, controlled by `showLoadingIndicator` and `placesStatus`.
- Replace the previous larger blocking loading/error UI with the compact badge and styles in `components/map/map.css` to keep the map interactive.

### Testing
- Started the dev server with `npm run dev` and confirmed the app compiled and served successfully. (succeeded)
- Ran a Playwright script to open the app and capture a screenshot of the map overlay to visually verify the badge appears; screenshot run completed. (succeeded)
- No unit or integration test suite was executed as part of this change. (none run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696510f18a048328b64c3d8f5e9aac64)