### PR TITLE
Runtime: finalize auto fallback ops (headers/docs)

### DIFF
--- a/app/api/filters/meta/route.ts
+++ b/app/api/filters/meta/route.ts
@@ -239,24 +239,36 @@ export async function GET() {
       if (error instanceof DbUnavailableError) {
         logDbFailure("database unavailable", error);
         if (dataSource === "db") {
-          return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503 });
+          return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, {
+            status: 503,
+            headers: buildDataSourceHeaders("db", true),
+          });
         }
       } else {
         logDbFailure("database query failed", error);
         if (dataSource === "db") {
-          return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503 });
+          return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, {
+            status: 503,
+            headers: buildDataSourceHeaders("db", true),
+          });
         }
       }
     }
   } else if (dataSource === "db") {
     logDbFailure("database unavailable");
-    return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503 });
+    return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, {
+      status: 503,
+      headers: buildDataSourceHeaders("db", true),
+    });
   }
 
   if (dataSource === "db") {
     if (!dbMeta) {
       logDbFailure("database unavailable");
-      return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503 });
+      return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, {
+        status: 503,
+        headers: buildDataSourceHeaders("db", true),
+      });
     }
     cache = {
       data: dbMeta,
@@ -288,7 +300,10 @@ export async function GET() {
   }
 
   if (!shouldAllowJson) {
-    return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503 });
+    return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, {
+      status: 503,
+      headers: buildDataSourceHeaders("db", true),
+    });
   }
 
   const fallbackPlaces = await loadPlacesFromJson();

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from "next/server";
 
 import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+import { buildDataSourceHeaders } from "@/lib/dataSource";
 
 export async function GET() {
   if (!hasDatabaseUrl()) {
-    return NextResponse.json({ ok: false, db: { ok: false } }, { status: 503 });
+    return NextResponse.json(
+      { ok: false, db: { ok: false } },
+      { status: 503, headers: buildDataSourceHeaders("db", true) },
+    );
   }
 
   const start = Date.now();
@@ -12,13 +16,21 @@ export async function GET() {
   try {
     await dbQuery("SELECT 1", [], { route: "api_health" });
     const latencyMs = Date.now() - start;
-    return NextResponse.json({ ok: true, db: { ok: true, latencyMs } });
+    return NextResponse.json({ ok: true, db: { ok: true, latencyMs } }, {
+      headers: buildDataSourceHeaders("db", false),
+    });
   } catch (error) {
     if (error instanceof DbUnavailableError) {
-      return NextResponse.json({ ok: false, db: { ok: false } }, { status: 503 });
+      return NextResponse.json(
+        { ok: false, db: { ok: false } },
+        { status: 503, headers: buildDataSourceHeaders("db", true) },
+      );
     }
 
     console.error("[health] db query failed", error);
-    return NextResponse.json({ ok: false, db: { ok: false } }, { status: 503 });
+    return NextResponse.json(
+      { ok: false, db: { ok: false } },
+      { status: 503, headers: buildDataSourceHeaders("db", true) },
+    );
   }
 }

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -2,6 +2,8 @@
 
 import { FormEvent, useEffect, useMemo, useState } from "react";
 
+import LimitedModeNotice from "@/components/status/LimitedModeNotice";
+import { isLimitedHeader } from "@/lib/clientDataSource";
 import type { SubmissionKind } from "@/lib/submissions";
 import type { FilterMeta } from "@/lib/filters";
 
@@ -67,6 +69,7 @@ export default function SubmitPage() {
   const [serverError, setServerError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [meta, setMeta] = useState<FilterMeta | null>(null);
+  const [limitedMode, setLimitedMode] = useState(false);
 
   useEffect(() => {
     const loadMeta = async () => {
@@ -75,6 +78,7 @@ export default function SubmitPage() {
         if (!res.ok) throw new Error("Failed to load meta");
         const data = (await res.json()) as FilterMeta;
         setMeta(data);
+        setLimitedMode(isLimitedHeader(res.headers));
       } catch (error) {
         console.error(error);
       }
@@ -187,6 +191,7 @@ export default function SubmitPage() {
           <h1 className="text-3xl font-bold text-gray-900">Submit a place</h1>
           <p className="text-gray-600">Request a new listing or an update.</p>
         </div>
+        {limitedMode ? <LimitedModeNotice className="w-full max-w-sm" /> : null}
 
         <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-2">
           <p className="text-gray-800 font-semibold">Submitter type</p>

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/lib/filters";
 import DbStatusIndicator from "@/components/status/DbStatusIndicator";
 import LimitedModeNotice from "@/components/status/LimitedModeNotice";
+import { isLimitedHeader } from "@/lib/clientDataSource";
 import MapFetchStatus from "./MapFetchStatus";
 
 const HEADER_HEIGHT = 64;
@@ -434,9 +435,7 @@ export default function MapClient() {
             throw new Error(`Request failed with status ${response.status}`);
           }
           const nextPlaces = (await response.json()) as Place[];
-          const sourceHeader = response.headers.get("x-cpm-data-source");
-          const limitedHeader = response.headers.get("x-cpm-limited");
-          const isLimited = limitedHeader === "true" || sourceHeader === "json";
+          const isLimited = isLimitedHeader(response.headers);
           if (!isMounted || requestIdRef.current !== requestId) return;
 
           if (process.env.NODE_ENV !== "production") {

--- a/docs/data-source.md
+++ b/docs/data-source.md
@@ -18,7 +18,7 @@ This controls how `/api/places`, `/api/stats`, and `/api/filters/meta` select th
 
 ## Limited mode
 
-When JSON data is used (forced or fallback), responses include `X-CPM-Limited: true`. This is used by the UI to show the Limited mode banner. The DB path sets `X-CPM-Limited: false`.
+When JSON data is used (forced or fallback), responses include `x-cpm-limited: 1`. This is used by the UI to show the Limited mode banner. DB-only errors can also return `x-cpm-limited: 1` to signal degraded data availability.
 
 ## Headers
 
@@ -26,8 +26,18 @@ Responses include these headers:
 
 | Header | Description |
 | --- | --- |
-| `X-CPM-Data-Source` | `db` or `json` to indicate the source |
-| `X-CPM-Limited` | `true` when fallback JSON is used |
+| `x-cpm-data-source` | `db` or `json` to indicate the source |
+| `x-cpm-limited` | `1` when fallback/limited mode is active, `0` otherwise |
+
+## Auto mode quick check
+
+`auto` uses the DB when `DATABASE_URL` is configured and reachable; it falls back to JSON if the DB is unavailable or times out. If `DATABASE_URL` is not set, `auto` immediately uses JSON.
+
+## Local fallback reproduction
+
+1. Set `DATA_SOURCE=auto`.
+2. Use an invalid `DATABASE_URL` (or stop your DB) to force a timeout/unavailable error.
+3. Request `/api/places`, `/api/stats`, or `/api/filters/meta` and confirm headers `x-cpm-data-source: json` and `x-cpm-limited: 1`.
 
 ## Logging vs user-facing behavior
 

--- a/lib/clientDataSource.ts
+++ b/lib/clientDataSource.ts
@@ -1,0 +1,6 @@
+export const isLimitedHeader = (headers: Headers): boolean => {
+  const limitedHeader = headers.get("x-cpm-limited");
+  const sourceHeader = headers.get("x-cpm-data-source");
+
+  return limitedHeader === "1" || limitedHeader === "true" || sourceHeader === "json";
+};

--- a/lib/dataSource.ts
+++ b/lib/dataSource.ts
@@ -41,8 +41,8 @@ export const getDataSourceContext = (setting: DataSourceSetting) => {
 };
 
 export const buildDataSourceHeaders = (source: DataSourceResult, limited: boolean) => ({
-  "X-CPM-Data-Source": source,
-  "X-CPM-Limited": limited ? "true" : "false",
+  "x-cpm-data-source": source,
+  "x-cpm-limited": limited ? "1" : "0",
 });
 
 export const withDbTimeout = async <T>(promise: Promise<T>, options: TimeoutOptions = {}) => {


### PR DESCRIPTION
### Motivation

- Make DATA_SOURCE=`auto` behavior observable and consistent so operators can immediately tell whether the site is serving DB or JSON fallback data.
- Standardize API response headers for data-source and limited-mode signaling across all endpoints.
- Ensure UI banners for Limited mode are consistent across Map/Stats/Submit pages.
- Document `auto` fallback rules and a short local reproduction procedure.

### Description

- Standardized data-source headers to `x-cpm-data-source: db|json` and `x-cpm-limited: 1|0` in `lib/dataSource.ts` and applied them across API routes (`places`, `stats/trends`, `filters/meta`, `health`, `submissions`, internal submissions) for both success and error responses.
- Added a small client helper `lib/clientDataSource.ts` (`isLimitedHeader`) and replaced ad-hoc header parsing in `components/map/MapClient.tsx` and the Submit page to drive `LimitedModeNotice` consistently.
- Surface the limited-mode banner on the Submit page (`app/submit/page.tsx`) to match Map and Stats behavior, and attach data-source headers for submission-handling responses.
- Updated `docs/data-source.md` to reflect the header format, explain `auto` behavior, and give a quick local fallback reproduction checklist.

### Testing

- Started the development server with `npm run dev` and observed successful compilation of the changed pages and API routes (including `/submit` and `/api/filters/meta`).
- Ran a Playwright script (Python) that navigated to `/submit` and captured a screenshot demonstrating the limited-mode banner rendering (succeeded).
- Verified that API handlers now include `x-cpm-data-source` / `x-cpm-limited` headers on the examined endpoints during local runs (observed).
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965147980b08328b4f0640daafd1c8e)