### PR TITLE
SEO: minimal metadata/OG/sitemap alignment

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,14 +4,30 @@ import { ReactNode } from 'react';
 import GlobalHeader from '@/components/GlobalHeader';
 
 const description = 'CryptoPayMap — discover places that accept cryptocurrency payments.';
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
 
 export const metadata: Metadata = {
-  title: 'CryptoPayMap',
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: 'CryptoPayMap',
+    template: '%s | CryptoPayMap',
+  },
   description,
   icons: {
     icon: '/favicon.svg',
   },
   openGraph: {
+    title: 'CryptoPayMap',
+    description,
+    url: siteUrl,
+    siteName: 'CryptoPayMap',
+    images: ['/og.svg'],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
     title: 'CryptoPayMap',
     description,
     images: ['/og.svg'],

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ??
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
+
+const routes = ['', '/map', '/discover', '/about', '/donate', '/stats', '/submit', '/status'];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return routes.map((route) => ({
+    url: `${siteUrl}${route}`,
+    lastModified,
+  }));
+}


### PR DESCRIPTION
### Motivation
- Ensure a minimal, consistent SEO/OG baseline so public pages render correct Open Graph previews and are indexable by search engines.
- Provide robots and sitemap endpoints so crawlers can discover and index primary site routes without changing existing assets.
- Keep changes minimal and respect the existing app structure and public images.

### Description
- Added a dynamic `siteUrl` (using `NEXT_PUBLIC_SITE_URL`, falling back to `VERCEL_URL` or `http://localhost:3000`) and set `metadataBase` in `app/layout.tsx` to normalize absolute URLs.
- Updated global metadata in `app/layout.tsx` to use a `title` template, explicit `openGraph` fields (`url`, `siteName`, `type`, `images`) and a `twitter` card configuration pointing to `/og.svg`.
- Added `app/robots.ts` as a Next.js metadata route that returns permissive `robots.txt` rules and a `sitemap` link derived from the same `siteUrl`.
- Added `app/sitemap.ts` as a Next.js metadata route that enumerates key public routes and emits a sitemap with `lastModified` timestamps.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69676fc8fb64832896f7975815f93347)