### PR TITLE
Add support for `report` submission kind end-to-end (API, DB persistence, internal review UI)

### DIFF
--- a/app/api/internal/submissions/[id]/route.ts
+++ b/app/api/internal/submissions/[id]/route.ts
@@ -38,18 +38,24 @@ export async function GET(request: Request, { params }: { params: { id: string }
       id: string;
       status: string;
       kind: string;
+      level: string | null;
       created_at: string;
+      updated_at: string | null;
       name: string;
       country: string;
       city: string;
+      place_id: string | null;
+      submitted_by: Record<string, unknown> | null;
+      reviewed_by: Record<string, unknown> | null;
+      review_note: string | null;
       payload: Parameters<typeof mapSubmissionRow>[0]["payload"];
       published_place_id: string | null;
       approved_at: string | null;
       rejected_at: string | null;
       reject_reason: string | null;
     }>(
-      `SELECT id, status, kind, created_at, name, country, city, payload,
-        published_place_id, approved_at, rejected_at, reject_reason
+      `SELECT id, status, kind, level, created_at, updated_at, name, country, city, place_id,
+        submitted_by, reviewed_by, review_note, payload, published_place_id, approved_at, rejected_at, reject_reason
        FROM submissions
        WHERE id = $1`,
       [id],

--- a/app/api/internal/submissions/route.ts
+++ b/app/api/internal/submissions/route.ts
@@ -52,8 +52,8 @@ export async function GET(request: NextRequest) {
       where.push(`status = $${params.length}`);
     }
 
-    const query = `SELECT id, status, kind, created_at, name, country, city, payload,
-      published_place_id, approved_at, rejected_at, reject_reason
+    const query = `SELECT id, status, kind, level, created_at, updated_at, name, country, city, place_id,
+      submitted_by, reviewed_by, review_note, payload, published_place_id, approved_at, rejected_at, reject_reason
       FROM submissions
       ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
       ORDER BY created_at DESC
@@ -65,10 +65,16 @@ export async function GET(request: NextRequest) {
       id: string;
       status: string;
       kind: string;
+      level: string | null;
       created_at: string;
+      updated_at: string | null;
       name: string;
       country: string;
       city: string;
+      place_id: string | null;
+      submitted_by: Record<string, unknown> | null;
+      reviewed_by: Record<string, unknown> | null;
+      review_note: string | null;
       payload: Parameters<typeof mapSubmissionRow>[0]["payload"];
       published_place_id: string | null;
       approved_at: string | null;

--- a/lib/internal-submissions.ts
+++ b/lib/internal-submissions.ts
@@ -7,11 +7,17 @@ export type InternalSubmission = {
   id: string;
   status: string;
   kind: string;
+  level?: string | null;
   createdAt: string;
+  updatedAt?: string | null;
   name: string;
   country: string;
   city: string;
   payload: SubmissionPayload;
+  placeId?: string | null;
+  submittedBy?: Record<string, unknown> | null;
+  reviewedBy?: Record<string, unknown> | null;
+  reviewNote?: string | null;
   publishedPlaceId?: string | null;
   approvedAt?: string | null;
   rejectedAt?: string | null;
@@ -24,7 +30,13 @@ export const ensureSubmissionColumns = async (route: string, client?: PoolClient
       ADD COLUMN IF NOT EXISTS published_place_id TEXT,
       ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ,
       ADD COLUMN IF NOT EXISTS rejected_at TIMESTAMPTZ,
-      ADD COLUMN IF NOT EXISTS reject_reason TEXT`,
+      ADD COLUMN IF NOT EXISTS reject_reason TEXT,
+      ADD COLUMN IF NOT EXISTS place_id TEXT,
+      ADD COLUMN IF NOT EXISTS submitted_by JSONB,
+      ADD COLUMN IF NOT EXISTS reviewed_by JSONB,
+      ADD COLUMN IF NOT EXISTS review_note TEXT,
+      ADD COLUMN IF NOT EXISTS level TEXT,
+      ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now()`,
     [],
     { route, client },
   );
@@ -60,26 +72,45 @@ export const mapSubmissionRow = (row: {
   id: string;
   status: string;
   kind: string;
+  level?: string | null;
   created_at: string;
+  updated_at?: string | null;
   name: string;
   country: string;
   city: string;
-  payload: SubmissionPayload;
+  payload: SubmissionPayload | string;
+  place_id?: string | null;
+  submitted_by?: Record<string, unknown> | null;
+  reviewed_by?: Record<string, unknown> | null;
+  review_note?: string | null;
   published_place_id?: string | null;
   approved_at?: string | null;
   rejected_at?: string | null;
   reject_reason?: string | null;
-}): InternalSubmission => ({
-  id: row.id,
-  status: row.status,
-  kind: row.kind,
-  createdAt: row.created_at,
-  name: row.name,
-  country: row.country,
-  city: row.city,
-  payload: row.payload,
-  publishedPlaceId: row.published_place_id ?? null,
-  approvedAt: row.approved_at ?? null,
-  rejectedAt: row.rejected_at ?? null,
-  rejectReason: row.reject_reason ?? null,
-});
+}): InternalSubmission => {
+  const payload =
+    typeof row.payload === "string"
+      ? (JSON.parse(row.payload) as SubmissionPayload)
+      : row.payload;
+
+  return {
+    id: row.id,
+    status: row.status,
+    kind: row.kind,
+    level: row.level ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at ?? null,
+    name: row.name,
+    country: row.country,
+    city: row.city,
+    payload,
+    placeId: row.place_id ?? payload.placeId ?? null,
+    submittedBy: row.submitted_by ?? payload.submittedBy ?? null,
+    reviewedBy: row.reviewed_by ?? null,
+    reviewNote: row.review_note ?? null,
+    publishedPlaceId: row.published_place_id ?? null,
+    approvedAt: row.approved_at ?? null,
+    rejectedAt: row.rejected_at ?? null,
+    rejectReason: row.reject_reason ?? null,
+  };
+};

--- a/lib/submission-to-place.ts
+++ b/lib/submission-to-place.ts
@@ -1,6 +1,6 @@
 import type { Place } from "@/types/places";
 
-import type { StoredSubmission } from "./submissions";
+import type { OwnerCommunitySubmissionPayload, StoredSubmission } from "./submissions";
 
 const slugify = (value: string): string =>
   value
@@ -37,7 +37,12 @@ export const submissionToPlace = (
 ): Place => {
   const { payload } = submission;
 
-  const { lat: rawLat, lng: rawLng } = payload;
+  if (payload.verificationRequest === "report") {
+    throw new Error("Report submissions cannot be converted to places");
+  }
+
+  const ownerPayload = payload as OwnerCommunitySubmissionPayload;
+  const { lat: rawLat, lng: rawLng } = ownerPayload;
   if (
     typeof rawLat !== "number" ||
     typeof rawLng !== "number" ||
@@ -55,32 +60,31 @@ export const submissionToPlace = (
   const id = `${prefix}${suffix}`;
 
   const verification: Place["verification"] =
-    payload.verificationRequest === "owner" ? "owner" : "community";
+    ownerPayload.verificationRequest === "owner" ? "owner" : "community";
 
   return {
     id,
-    name: payload.name,
-    category: payload.category,
+    name: ownerPayload.name,
+    category: ownerPayload.category,
     verification,
     lat,
     lng,
-    country: payload.country,
-    city: payload.city,
-    address_full: payload.address,
-    address: payload.address,
-    supported_crypto: payload.acceptedChains,
-    accepted: payload.acceptedChains,
-    about: payload.about ?? null,
-    paymentNote: payload.paymentNote ?? null,
-    social_website: payload.website ?? null,
-    social_twitter: payload.twitter ?? null,
-    social_instagram: payload.instagram ?? null,
-    website: payload.website ?? null,
-    twitter: payload.twitter ?? null,
-    instagram: payload.instagram ?? null,
-    facebook: payload.facebook ?? null,
-    amenities: payload.amenities ?? null,
-    submitterName: payload.contactName ?? null,
+    country: ownerPayload.country,
+    city: ownerPayload.city,
+    address_full: ownerPayload.address,
+    address: ownerPayload.address,
+    supported_crypto: ownerPayload.acceptedChains,
+    accepted: ownerPayload.acceptedChains,
+    about: ownerPayload.about ?? null,
+    paymentNote: ownerPayload.paymentNote ?? null,
+    social_website: ownerPayload.website ?? null,
+    social_twitter: ownerPayload.twitter ?? null,
+    social_instagram: ownerPayload.instagram ?? null,
+    website: ownerPayload.website ?? null,
+    twitter: ownerPayload.twitter ?? null,
+    instagram: ownerPayload.instagram ?? null,
+    facebook: ownerPayload.facebook ?? null,
+    amenities: ownerPayload.amenities ?? null,
+    submitterName: ownerPayload.contactName ?? null,
   };
 };
-


### PR DESCRIPTION
### Motivation
- Implement `kind='report'` across the submission pipeline so reports can be stored, reviewed, and visible to operators per `docs/submissions.md` while not enabling media/promote reflection yet. 
- Ensure `submissions.level` is fixed per spec (owner→`owner`, community→`community`, report→`unverified`) to avoid divergence between Submission and Place verification concepts. 
- Make internal review surfaces show report-specific fields (place id, notes) and enforce that reports cannot be promoted into places.

### Description
- Extended the submission model and normalization to accept `report` as a valid kind and added a hardcoded mapping `report -> level = 'unverified'` (see `lib/submissions.ts`).
- Persisted report metadata into the submissions compatibility schema by adding/ensuring columns and writing `place_id`, `submitted_by`, `level`, and `updated_at` when available (see `ensureSubmissionCompatColumns` + `insertSubmissionToDb` in `lib/submissions.ts`).
- Added `multipart/form-data` handling for `payload` in `POST /api/submissions` and the unified handler so confirm-screen POSTs (with `payload` field) and the NDJSON fallback still work when DB is degraded (see `app/api/submissions/route.ts` and `lib/submissions.ts`).
- Expanded internal listing/detail queries and mapping to include report-related columns and parse `payload` JSON for internal APIs (see `app/api/internal/submissions/route.ts`, `app/api/internal/submissions/[id]/route.ts`, and `lib/internal-submissions.ts`).
- Updated internal review UI to clearly present report submissions: list shows a readable title/place_id and a summary, and the detail view renders a dedicated report summary + submitter section while preserving owner/community displays (see `app/internal/submissions/PendingSubmissionsClient.tsx` and `SubmissionDetailClient.tsx`).
- Prevented converting `report` submissions into `places` by hard-blocking report-to-place conversion in `lib/submission-to-place.ts` and kept promote logic unchanged for owner/community.
- Kept backwards-compatible behavior for owner/community submissions and NDJSON fallback behavior when DB is unavailable (`data/submissions-pending.ndjson`).

### Testing
- Ran `npm run build` (Next.js production build + type checks) and it completed successfully. ✅
- Ran `npm run test` (project test runner); it failed due to pre-existing TypeScript issues in test specs (nullability / implicit any in `tests/*`) that are unrelated to the changes in this PR. ❌
- Started the dev server (`npm run dev`) and exercised the internal submissions page; captured a Playwright screenshot of `/internal/submissions` to verify report-aware UI renders without runtime errors. ✅
- Manual code checks: ensured `report` cannot be converted to a place (throws in `submissionToPlace`) and that `promote` path still rejects non-promotable kinds (existing logic unchanged). ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974df765d6c832891c05eb129801d11)