### PR TITLE
Finalize multipart submission intake validation

### DIFF
--- a/lib/submissions/parseMultipart.ts
+++ b/lib/submissions/parseMultipart.ts
@@ -1,0 +1,104 @@
+const KNOWN_FILE_FIELDS = ["proof", "gallery", "evidence"] as const;
+
+type KnownFileField = (typeof KNOWN_FILE_FIELDS)[number];
+
+const knownFieldSet = new Set<string>(KNOWN_FILE_FIELDS);
+
+type MultipartParseError = {
+  code: "INVALID_PAYLOAD";
+  message: string;
+  details?: Record<string, unknown>;
+};
+
+export type MultipartFilesByField = Record<KnownFileField, File[]>;
+
+export type ParsedMultipartSubmission = {
+  payload: Record<string, unknown>;
+  filesByField: MultipartFilesByField;
+  unexpectedFileFields: string[];
+};
+
+export type MultipartParseResult =
+  | { ok: true; value: ParsedMultipartSubmission }
+  | { ok: false; error: MultipartParseError };
+
+const emptyFilesByField = (): MultipartFilesByField => ({
+  proof: [],
+  gallery: [],
+  evidence: [],
+});
+
+const toFiles = (entries: FormDataEntryValue[]): File[] => entries.filter((entry): entry is File => entry instanceof File);
+
+export const parseMultipartSubmission = async (request: Request): Promise<MultipartParseResult> => {
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_PAYLOAD",
+        message: "Failed to parse multipart form data",
+      },
+    };
+  }
+
+  const payloadField = form.get("payload");
+  if (typeof payloadField !== "string") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_PAYLOAD",
+        message: "payload must be a JSON string",
+        details: { field: "payload" },
+      },
+    };
+  }
+
+  let parsedPayload: unknown;
+  try {
+    parsedPayload = JSON.parse(payloadField);
+  } catch {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_PAYLOAD",
+        message: "payload must be valid JSON",
+        details: { field: "payload" },
+      },
+    };
+  }
+
+  if (!parsedPayload || typeof parsedPayload !== "object") {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_PAYLOAD",
+        message: "payload must be a JSON object",
+        details: { field: "payload" },
+      },
+    };
+  }
+
+  const filesByField = emptyFilesByField();
+  for (const field of KNOWN_FILE_FIELDS) {
+    filesByField[field] = toFiles(form.getAll(field));
+  }
+
+  const unexpectedFileFields = new Set<string>();
+  for (const [field, value] of form.entries()) {
+    if (value instanceof File && !knownFieldSet.has(field)) {
+      unexpectedFileFields.add(field);
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      payload: parsedPayload as Record<string, unknown>,
+      filesByField,
+      unexpectedFileFields: [...unexpectedFileFields],
+    },
+  };
+};

--- a/lib/submissions/validateMultipart.ts
+++ b/lib/submissions/validateMultipart.ts
@@ -1,0 +1,147 @@
+import type { SubmissionKind } from "@/lib/submissions";
+
+import type { MultipartFilesByField } from "./parseMultipart";
+
+type MediaField = "proof" | "gallery" | "evidence";
+
+type MultipartValidationErrorCode =
+  | "INVALID_MEDIA_TYPE"
+  | "FILE_TOO_LARGE"
+  | "TOO_MANY_FILES"
+  | "UNKNOWN_FORM_FIELD";
+
+type MultipartValidationError = {
+  code: MultipartValidationErrorCode;
+  message: string;
+  details: Record<string, unknown>;
+};
+
+type MultipartValidationResult =
+  | { ok: true; acceptedMediaSummary: Record<string, number> }
+  | { ok: false; error: MultipartValidationError };
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+
+const KIND_LIMITS: Record<SubmissionKind, Record<MediaField, number>> = {
+  owner: { proof: 1, gallery: 8, evidence: 0 },
+  community: { proof: 0, gallery: 4, evidence: 0 },
+  report: { proof: 0, gallery: 0, evidence: 4 },
+};
+
+const KIND_ALLOWED_FIELDS: Record<SubmissionKind, MediaField[]> = {
+  owner: ["proof", "gallery"],
+  community: ["gallery"],
+  report: ["evidence"],
+};
+
+const buildAcceptedMediaSummary = (
+  kind: SubmissionKind,
+  filesByField: MultipartFilesByField,
+): Record<string, number> => {
+  const allowedFields = KIND_ALLOWED_FIELDS[kind];
+  return allowedFields.reduce<Record<string, number>>((summary, field) => {
+    summary[field] = filesByField[field].length;
+    return summary;
+  }, {});
+};
+
+const validateCounts = (kind: SubmissionKind, filesByField: MultipartFilesByField): MultipartValidationError | null => {
+  const limits = KIND_LIMITS[kind];
+  const allowedFields = new Set(KIND_ALLOWED_FIELDS[kind]);
+
+  for (const field of Object.keys(filesByField) as MediaField[]) {
+    const count = filesByField[field].length;
+    const limit = limits[field];
+
+    if (!allowedFields.has(field) && count > 0) {
+      return {
+        code: "UNKNOWN_FORM_FIELD",
+        message: `Unexpected file field: ${field}`,
+        details: { field, allowedFields: KIND_ALLOWED_FIELDS[kind] },
+      };
+    }
+
+    if (count > limit) {
+      return {
+        code: "TOO_MANY_FILES",
+        message: `${field} exceeds the allowed file count`,
+        details: { field, count, limit },
+      };
+    }
+  }
+
+  return null;
+};
+
+const validateFile = (field: MediaField, file: File): MultipartValidationError | null => {
+  if (!ALLOWED_MIME_TYPES.includes(file.type as (typeof ALLOWED_MIME_TYPES)[number])) {
+    return {
+      code: "INVALID_MEDIA_TYPE",
+      message: `${field} has an unsupported media type`,
+      details: { field, mimeType: file.type || "unknown", allowedMimeTypes: ALLOWED_MIME_TYPES },
+    };
+  }
+
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    return {
+      code: "FILE_TOO_LARGE",
+      message: `${field} exceeds the maximum file size`,
+      details: { field, size: file.size, limitBytes: MAX_FILE_SIZE_BYTES },
+    };
+  }
+
+  return null;
+};
+
+const validateFiles = (kind: SubmissionKind, filesByField: MultipartFilesByField): MultipartValidationError | null => {
+  const allowedFields = new Set(KIND_ALLOWED_FIELDS[kind]);
+
+  for (const field of Object.keys(filesByField) as MediaField[]) {
+    if (!allowedFields.has(field)) continue;
+    for (const file of filesByField[field]) {
+      const error = validateFile(field, file);
+      if (error) return error;
+    }
+  }
+
+  return null;
+};
+
+export const validateMultipartSubmission = (
+  kind: SubmissionKind,
+  filesByField: MultipartFilesByField,
+  unexpectedFileFields: string[],
+): MultipartValidationResult => {
+  if (unexpectedFileFields.length > 0) {
+    return {
+      ok: false,
+      error: {
+        code: "UNKNOWN_FORM_FIELD",
+        message: "Unexpected file fields provided",
+        details: { fields: unexpectedFileFields, allowedFields: KIND_ALLOWED_FIELDS[kind] },
+      },
+    };
+  }
+
+  const countError = validateCounts(kind, filesByField);
+  if (countError) {
+    return { ok: false, error: countError };
+  }
+
+  const fileError = validateFiles(kind, filesByField);
+  if (fileError) {
+    return { ok: false, error: fileError };
+  }
+
+  return {
+    ok: true,
+    acceptedMediaSummary: buildAcceptedMediaSummary(kind, filesByField),
+  };
+};
+
+export const emptyAcceptedMediaSummary = (kind: SubmissionKind): Record<string, number> =>
+  KIND_ALLOWED_FIELDS[kind].reduce<Record<string, number>>((summary, field) => {
+    summary[field] = 0;
+    return summary;
+  }, {});

--- a/tests/submissions-multipart.test.ts
+++ b/tests/submissions-multipart.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseMultipartSubmission } from "@/lib/submissions/parseMultipart";
+import { emptyAcceptedMediaSummary, validateMultipartSubmission } from "@/lib/submissions/validateMultipart";
+
+const buildMultipartRequest = (form: FormData) =>
+  new Request("http://localhost/api/submissions", {
+    method: "POST",
+    body: form,
+  });
+
+test("parseMultipartSubmission rejects when payload is missing", async () => {
+  const form = new FormData();
+  const result = await parseMultipartSubmission(buildMultipartRequest(form));
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "INVALID_PAYLOAD");
+  }
+});
+
+test("parseMultipartSubmission extracts payload and files", async () => {
+  const form = new FormData();
+  form.set("payload", JSON.stringify({ verificationRequest: "owner", kind: "owner" }));
+  form.append("gallery", new File([new Uint8Array([1, 2, 3])], "a.png", { type: "image/png" }));
+  form.append("gallery", new File([new Uint8Array([4])], "b.png", { type: "image/png" }));
+  form.append("proof", new File([new Uint8Array([5])], "proof.png", { type: "image/png" }));
+
+  const result = await parseMultipartSubmission(buildMultipartRequest(form));
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.value.filesByField.gallery.length, 2);
+    assert.equal(result.value.filesByField.proof.length, 1);
+    assert.deepEqual(result.value.unexpectedFileFields, []);
+  }
+});
+
+test("validateMultipartSubmission enforces count limits", () => {
+  const files = {
+    proof: [],
+    evidence: [],
+    gallery: Array.from({ length: 5 }, (_, idx) =>
+      new File([new Uint8Array([idx])], `g${idx}.png`, { type: "image/png" }),
+    ),
+  };
+
+  const result = validateMultipartSubmission("community", files, []);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "TOO_MANY_FILES");
+    assert.equal(result.error.details.limit, 4);
+  }
+});
+
+test("validateMultipartSubmission rejects invalid media types", () => {
+  const files = {
+    proof: [],
+    evidence: [],
+    gallery: [new File([new Uint8Array([1])], "bad.gif", { type: "image/gif" })],
+  };
+
+  const result = validateMultipartSubmission("community", files, []);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "INVALID_MEDIA_TYPE");
+  }
+});
+
+test("validateMultipartSubmission rejects oversized files", () => {
+  const oversized = new Uint8Array(2 * 1024 * 1024 + 1);
+  const files = {
+    proof: [],
+    evidence: [],
+    gallery: [new File([oversized], "big.png", { type: "image/png" })],
+  };
+
+  const result = validateMultipartSubmission("community", files, []);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "FILE_TOO_LARGE");
+  }
+});
+
+test("validateMultipartSubmission rejects unexpected file fields", () => {
+  const files = {
+    proof: [new File([new Uint8Array([1])], "proof.png", { type: "image/png" })],
+    evidence: [],
+    gallery: [],
+  };
+
+  const result = validateMultipartSubmission("community", files, []);
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.error.code, "UNKNOWN_FORM_FIELD");
+  }
+});
+
+test("validateMultipartSubmission returns accepted media summary", () => {
+  const files = {
+    proof: [new File([new Uint8Array([1])], "proof.png", { type: "image/png" })],
+    evidence: [],
+    gallery: [new File([new Uint8Array([2])], "g.png", { type: "image/png" })],
+  };
+
+  const result = validateMultipartSubmission("owner", files, []);
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.deepEqual(result.acceptedMediaSummary, { proof: 1, gallery: 1 });
+  }
+
+  assert.deepEqual(emptyAcceptedMediaSummary("report"), { evidence: 0 });
+});


### PR DESCRIPTION
### Motivation
- Accept multipart/form-data submissions with attached images and enforce server-side media validation before implementing storage.
- Provide consistent, unified 400-style error responses with specific error codes for client feedback and future media pipeline wiring.
- Preserve existing JSON (`application/json`) submission path for backward compatibility and keep DB persistence for submission rows untouched.

### Description
- Add a multipart parser `lib/submissions/parseMultipart.ts` that requires a JSON `payload` field and extracts file `File` objects from `proof`, `gallery`, and `evidence` while reporting unexpected file fields.
- Add `lib/submissions/validateMultipart.ts` implementing per-kind count limits, MIME allowlist (`image/jpeg|image/png|image/webp`), 2MB file size cap, and error codes `INVALID_MEDIA_TYPE`, `FILE_TOO_LARGE`, `TOO_MANY_FILES`, `INVALID_PAYLOAD`, and `UNKNOWN_FORM_FIELD`, and return an `acceptedMediaSummary` (counts only).
- Wire parsing/validation into unified handler `lib/submissions.ts` so multipart requests are validated server-side, respond with unified JSON errors (`error.code`, `error.message`, `error.details`), and return success shape `{ submissionId, kind, acceptedMediaSummary }` without storing image bytes or creating media rows.
- Update `app/api/submissions/route.ts` to pre-parse multipart requests for the degraded DB-failure path and to understand the unified error format; keep JSON path intact and unchanged in behavior.
- Add focused unit tests `tests/submissions-multipart.test.ts` covering parsing, count limits, MIME/size checks, unexpected fields, and `acceptedMediaSummary` behavior.

### Testing
- Ran unit tests: `node --import tsx --test tests/submissions-multipart.test.ts` which passed (all tests in this file succeeded). 
- Ran linter: `npm run lint` which completed without error (warnings only). 
- Built the app: `npm run build` which produced a successful production build. 
- Ran full stats test suite: `npm run test:stats` which failed due to pre-existing strict TypeScript errors in unrelated Playwright spec files (these failures are not caused by the multipart changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e6d827708328ab2cb6f1db6afc99)