### PR TITLE
Fix Playwright test typings and baseURL for map-smoke & overlap-zindex

### DIFF
--- a/tests/map-smoke.spec.ts
+++ b/tests/map-smoke.spec.ts
@@ -297,7 +297,7 @@ test("map smoke: clicking a map marker opens the drawer (anti-overlay)", async (
           ? document.elementsFromPoint(x, y)
           : [document.elementFromPoint(x, y)];
         return Array.from(els)
-          .filter(Boolean)
+          .filter((el): el is Element => Boolean(el))
           .slice(0, 6)
           .map((el) => ({
             tag: el.tagName,

--- a/tests/ux/overlap-zindex.spec.ts
+++ b/tests/ux/overlap-zindex.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-const baseURL = () => process.env.PW_BASE_URL ?? "http://127.0.0.1:3000";
+const baseURL = () => process.env.PW_BASE_URL ?? "http://127.0.0.1:3201";
 
 async function assertNotUnderLeaflet(page: any, locator: any, label: string) {
   const box = await locator.boundingBox();
@@ -9,7 +9,7 @@ async function assertNotUnderLeaflet(page: any, locator: any, label: string) {
   const x = Math.floor(box.x + Math.min(box.width / 2, Math.max(2, box.width - 2)));
   const y = Math.floor(box.y + Math.min(box.height / 2, Math.max(2, box.height - 2)));
 
-  const top = await page.evaluate(({ x, y }) => {
+  const top = await page.evaluate(({ x, y }: { x: number; y: number }) => {
     const el = document.elementFromPoint(x, y) as HTMLElement | null;
     return { tag: el?.tagName ?? null, id: (el as any)?.id ?? null, cls: el?.className ? String(el.className).slice(0,180) : null };
   }, { x, y });
@@ -21,8 +21,8 @@ async function assertNotUnderLeaflet(page: any, locator: any, label: string) {
 test("UI overlays stay above the map after zoom-in; mobile Filters hidden on desktop", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
 
-  await page.goto(baseURL() + "/map", { waitUntil: "domcontentloaded" }).catch(async () => {
-    await page.goto(baseURL() + "/", { waitUntil: "domcontentloaded" });
+  await page.goto("/map", { waitUntil: "domcontentloaded" }).catch(async () => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
   });
   await page.waitForTimeout(900);
 


### PR DESCRIPTION
### Motivation

- Tests were failing under strict TypeScript and Playwright usage: type errors and mismatched navigation caused test compilation/runtime errors.
- The change set aims to make the two failing Playwright specs (`map-smoke.spec.ts`, `ux/overlap-zindex.spec.ts`) compile and behave against the configured test host with minimal diffs and no production code changes.

### Description

- Use the same default port as Playwright config by updating the overlap z-index spec default to `3201` and switching to relative `page.goto` calls so `baseURL` is respected.
- Add an explicit type annotation for the `page.evaluate` destructured coordinates in `tests/ux/overlap-zindex.spec.ts` to satisfy strict `tsc` checks (`{ x: number; y: number }`).
- Narrow the `.filter(Boolean)` call in the click-probe stack inside `tests/map-smoke.spec.ts` to a TypeScript type guard `.filter((el): el is Element => Boolean(el))` so `el` is no longer possibly `null` under strict checking.
- All edits are limited to the two test files named above; no app/UI/CSS or submission pipeline changes were made.

### Testing

- Ran `npx tsc --project tsconfig.test.json` and it succeeded after the changes.
- Attempted `npx playwright test tests/map-smoke.spec.ts --trace on --headed` and `npx playwright test tests/ux/overlap-zindex.spec.ts --trace on --headed` but both runs were blocked by Playwright browser installation failures in this environment (browser executable missing / `npx playwright install` returned HTTP 403), so test execution could not complete here.
- Ran `npm test` in this environment; TypeScript compilation succeeded, but the Node-runner execution of Playwright specs in the CI-like harness failed due to Playwright runtime/module resolution constraints in this environment (these failures are unrelated to the small test-file fixes in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f2f441548328bc98b5839b4d261e)