### PR TITLE
Implement submission media serving routes (public gallery + internal proof/evidence)

### DIFF
--- a/app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts
+++ b/app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts
@@ -1,0 +1,93 @@
+import { Readable } from "node:stream";
+
+import { NextResponse } from "next/server";
+
+import { DbUnavailableError, hasDatabaseUrl } from "@/lib/db";
+import { findSubmissionMediaById } from "@/lib/db/media";
+import { requireInternalAuth } from "@/lib/internalAuth";
+import { buildSubmissionMediaKey, getSubmissionMediaObject } from "@/lib/storage/r2";
+
+export const runtime = "nodejs";
+
+const toReadableStream = (body: unknown): ReadableStream | null => {
+  if (!body) return null;
+  if (body instanceof ReadableStream) return body;
+  if (body instanceof Readable) {
+    return Readable.toWeb(body) as ReadableStream;
+  }
+  if (typeof (body as { transformToWebStream?: () => ReadableStream }).transformToWebStream === "function") {
+    return (body as { transformToWebStream: () => ReadableStream }).transformToWebStream();
+  }
+  return null;
+};
+
+const isNotFoundError = (error: unknown) => {
+  const err = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return err?.name === "NoSuchKey" || err?.$metadata?.httpStatusCode === 404;
+};
+
+const isAllowedKind = (kind: string): kind is "proof" | "evidence" =>
+  kind === "proof" || kind === "evidence";
+
+export async function GET(
+  request: Request,
+  { params }: { params: { submissionId: string; kind: string; mediaId: string } },
+) {
+  if (!isAllowedKind(params.kind)) {
+    return new Response(null, { status: 404 });
+  }
+
+  const auth = requireInternalAuth(request);
+  if (!("ok" in auth)) {
+    return auth;
+  }
+
+  if (!hasDatabaseUrl()) {
+    return NextResponse.json({ error: "DB_UNAVAILABLE" }, { status: 503 });
+  }
+
+  const { submissionId, kind, mediaId } = params;
+
+  if (!submissionId || !mediaId) {
+    return new Response(null, { status: 404 });
+  }
+
+  try {
+    const record = await findSubmissionMediaById({
+      submissionId,
+      kind,
+      mediaId,
+      route: "api_internal_media",
+    });
+
+    if (!record) {
+      return new Response(null, { status: 404 });
+    }
+
+    const key = buildSubmissionMediaKey(submissionId, kind, mediaId);
+    const result = await getSubmissionMediaObject(key);
+    const stream = toReadableStream(result.Body);
+
+    if (!stream) {
+      return new Response(null, { status: 404 });
+    }
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "image/webp",
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (error) {
+    if (error instanceof DbUnavailableError || (error as Error).message?.includes("DATABASE_URL")) {
+      return NextResponse.json({ error: "DB_UNAVAILABLE" }, { status: 503 });
+    }
+
+    if (isNotFoundError(error)) {
+      return new Response(null, { status: 404 });
+    }
+
+    console.error("[internal media] failed to load", error);
+    return NextResponse.json({ error: "MEDIA_UNAVAILABLE" }, { status: 500 });
+  }
+}

--- a/app/api/media/submissions/[submissionId]/gallery/[mediaId]/route.ts
+++ b/app/api/media/submissions/[submissionId]/gallery/[mediaId]/route.ts
@@ -1,0 +1,80 @@
+import { Readable } from "node:stream";
+
+import { NextResponse } from "next/server";
+
+import { DbUnavailableError, hasDatabaseUrl } from "@/lib/db";
+import { findSubmissionMediaById } from "@/lib/db/media";
+import { buildSubmissionMediaKey, getSubmissionMediaObject } from "@/lib/storage/r2";
+
+export const runtime = "nodejs";
+
+const toReadableStream = (body: unknown): ReadableStream | null => {
+  if (!body) return null;
+  if (body instanceof ReadableStream) return body;
+  if (body instanceof Readable) {
+    return Readable.toWeb(body) as ReadableStream;
+  }
+  if (typeof (body as { transformToWebStream?: () => ReadableStream }).transformToWebStream === "function") {
+    return (body as { transformToWebStream: () => ReadableStream }).transformToWebStream();
+  }
+  return null;
+};
+
+const isNotFoundError = (error: unknown) => {
+  const err = error as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return err?.name === "NoSuchKey" || err?.$metadata?.httpStatusCode === 404;
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { submissionId: string; mediaId: string } },
+) {
+  if (!hasDatabaseUrl()) {
+    return NextResponse.json({ error: "DB_UNAVAILABLE" }, { status: 503 });
+  }
+
+  const { submissionId, mediaId } = params;
+
+  if (!submissionId || !mediaId) {
+    return new Response(null, { status: 404 });
+  }
+
+  try {
+    const record = await findSubmissionMediaById({
+      submissionId,
+      kind: "gallery",
+      mediaId,
+      route: "api_media_gallery",
+    });
+
+    if (!record) {
+      return new Response(null, { status: 404 });
+    }
+
+    const key = buildSubmissionMediaKey(submissionId, "gallery", mediaId);
+    const result = await getSubmissionMediaObject(key);
+    const stream = toReadableStream(result.Body);
+
+    if (!stream) {
+      return new Response(null, { status: 404 });
+    }
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "image/webp",
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    });
+  } catch (error) {
+    if (error instanceof DbUnavailableError || (error as Error).message?.includes("DATABASE_URL")) {
+      return NextResponse.json({ error: "DB_UNAVAILABLE" }, { status: 503 });
+    }
+
+    if (isNotFoundError(error)) {
+      return new Response(null, { status: 404 });
+    }
+
+    console.error("[media gallery] failed to load", error);
+    return NextResponse.json({ error: "MEDIA_UNAVAILABLE" }, { status: 500 });
+  }
+}

--- a/lib/storage/r2.ts
+++ b/lib/storage/r2.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 
 type SubmissionMediaKind = "gallery" | "proof" | "evidence";
 
@@ -77,6 +77,16 @@ export const uploadSubmissionMediaObject = async (params: {
   );
 
   return { key };
+};
+
+export const getSubmissionMediaObject = async (key: string) => {
+  const { client, env } = getR2Client();
+  return client.send(
+    new GetObjectCommand({
+      Bucket: env.bucket,
+      Key: key,
+    }),
+  );
 };
 
 export const deleteSubmissionMediaObject = async (key: string) => {


### PR DESCRIPTION
### Motivation
- Serve submission-attached images through application endpoints per media storage and API specs to avoid exposing direct R2 URLs and to enforce public/internal access and caching policies. 
- Validate media presence in DB before serving and ensure internal routes require authentication.

### Description
- Added public gallery route `app/api/media/submissions/[submissionId]/gallery/[mediaId]/route.ts` with `export const runtime = "nodejs"`, DB validation via `findSubmissionMediaById`, R2 object fetch, streaming response, `Content-Type: image/webp`, and `Cache-Control: public, max-age=31536000, immutable`.
- Added internal route `app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts` with `export const runtime = "nodejs"`, `kind` validation limited to `proof` or `evidence`, authentication via `requireInternalAuth`, DB validation, R2 fetch and streaming, and `Cache-Control: no-store`.
- Extended storage helper `lib/storage/r2.ts` with `getSubmissionMediaObject` (uses `GetObjectCommand`) and reused existing `buildSubmissionMediaKey` for keys of form `submissions/{submissionId}/{kind}/{mediaId}.webp`.
- Extended DB helper `lib/db/media.ts` with `findSubmissionMediaById` and `hasMediaIdColumn` to validate the requested media against `submission_media` either by `media_id` column or by URL pattern, while caching the column existence check.
- All work follows hard rules: no signed URLs are generated or exposed and R2 direct hostnames are not returned.

### Testing
- Ran `npm run build` to validate the changes, but the build failed in this environment with `next` not found so a full production build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975d58b2a9c83289da743ce0f3dde33)