### PR TITLE
Internal submissions console: UI, API, media & auth enhancements

### DIFF
--- a/app/api/internal/submissions/[id]/history/route.ts
+++ b/app/api/internal/submissions/[id]/history/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: Request, { params }: { params: { id: string }
       `SELECT id, actor, action, submission_id, place_id, created_at, meta
        FROM public.history
        WHERE submission_id = $1
-       ORDER BY created_at DESC
+       ORDER BY created_at ASC
        LIMIT 50`,
       [id],
       { route },

--- a/app/internal/page.tsx
+++ b/app/internal/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function InternalIndexPage() {
+  redirect("/internal/submissions");
+}

--- a/app/internal/submissions/[id]/page.tsx
+++ b/app/internal/submissions/[id]/page.tsx
@@ -1,9 +1,9 @@
-import SubmissionDetailClient from "../SubmissionDetailClient";
 import DbStatusIndicator from "@/components/status/DbStatusIndicator";
+import SubmissionDetail from "@/components/internal/SubmissionDetail";
 
 export default function SubmissionDetailPage({ params }: { params: { id: string } }) {
   return (
-    <main className="mx-auto max-w-5xl space-y-6 p-6">
+    <main className="mx-auto max-w-6xl space-y-6 p-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900">
           <p className="text-sm font-semibold">Internal only</p>
@@ -12,7 +12,7 @@ export default function SubmissionDetailPage({ params }: { params: { id: string 
         <DbStatusIndicator showBanner />
       </div>
 
-      <SubmissionDetailClient submissionId={params.id} />
+      <SubmissionDetail submissionId={params.id} />
     </main>
   );
 }

--- a/app/internal/submissions/page.tsx
+++ b/app/internal/submissions/page.tsx
@@ -1,5 +1,5 @@
-import PendingSubmissionsClient from "./PendingSubmissionsClient";
 import DbStatusIndicator from "@/components/status/DbStatusIndicator";
+import SubmissionsList from "@/components/internal/SubmissionsList";
 
 export default function SubmissionsPage() {
   return (
@@ -12,7 +12,7 @@ export default function SubmissionsPage() {
         <DbStatusIndicator showBanner />
       </div>
 
-      <PendingSubmissionsClient />
+      <SubmissionsList />
     </main>
   );
 }

--- a/components/internal/ErrorBox.tsx
+++ b/components/internal/ErrorBox.tsx
@@ -1,0 +1,13 @@
+import type { ApiError } from "@/lib/internal/submissions";
+
+export default function ErrorBox({ title = "Error", error }: { title?: string; error: ApiError }) {
+  return (
+    <div className="rounded-lg border border-rose-200 bg-rose-50 p-4 text-sm text-rose-800">
+      <p className="font-semibold">{title}</p>
+      <div className="mt-2 space-y-1">
+        {error.code && <p className="text-xs uppercase text-rose-600">{error.code}</p>}
+        <p>{error.message ?? "Something went wrong."}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/internal/MediaPreviewGrid.tsx
+++ b/components/internal/MediaPreviewGrid.tsx
@@ -1,0 +1,68 @@
+import { buildSubmissionMediaUrl } from "@/lib/internal/submissions";
+import type { SubmissionMedia } from "@/lib/internal/submissions";
+
+const KIND_LABELS: Record<string, string> = {
+  gallery: "Gallery",
+  proof: "Proof",
+  evidence: "Evidence",
+};
+
+const groupByKind = (media: SubmissionMedia[]) => {
+  return media.reduce<Record<string, SubmissionMedia[]>>((acc, item) => {
+    if (!acc[item.kind]) {
+      acc[item.kind] = [];
+    }
+    acc[item.kind].push(item);
+    return acc;
+  }, {});
+};
+
+export default function MediaPreviewGrid({
+  submissionId,
+  media,
+}: {
+  submissionId: string;
+  media: SubmissionMedia[];
+}) {
+  if (!media.length) {
+    return <p className="text-sm text-gray-500">No media uploaded.</p>;
+  }
+
+  const groups = groupByKind(media);
+
+  return (
+    <div className="space-y-6">
+      {Object.entries(groups).map(([kind, items]) => (
+        <div key={kind}>
+          <h3 className="text-sm font-semibold text-gray-800">{KIND_LABELS[kind] ?? kind}</h3>
+          <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {items.map((item) => {
+              const src = buildSubmissionMediaUrl(submissionId, item.kind, item.mediaId);
+              return (
+                <a
+                  key={`${item.kind}-${item.mediaId}`}
+                  className="group overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
+                  href={src}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  <div className="aspect-video w-full overflow-hidden bg-gray-50">
+                    <img
+                      src={src}
+                      alt={`${item.kind} ${item.mediaId}`}
+                      className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                    />
+                  </div>
+                  <div className="space-y-1 p-3 text-xs text-gray-600">
+                    <p className="font-semibold text-gray-700">{KIND_LABELS[item.kind] ?? item.kind}</p>
+                    <p className="break-all">{item.mediaId}</p>
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/internal/Pagination.tsx
+++ b/components/internal/Pagination.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+type PaginationProps = {
+  page: number;
+  limit: number;
+  total?: number | null;
+  hasMore?: boolean;
+  onPageChange: (page: number) => void;
+};
+
+export default function Pagination({ page, limit, total, hasMore, onPageChange }: PaginationProps) {
+  const totalPages = total ? Math.ceil(total / limit) : null;
+  const start = total ? (page - 1) * limit + 1 : null;
+  const end = total ? Math.min(page * limit, total) : null;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-gray-100 px-4 py-3 text-sm">
+      <div className="text-gray-600">
+        {total ? (
+          <span>
+            {start}–{end} of {total}
+          </span>
+        ) : (
+          <span>Page {page}</span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          className="rounded-md border border-gray-200 px-3 py-1 text-sm font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={() => onPageChange(page - 1)}
+          disabled={page <= 1}
+        >
+          Prev
+        </button>
+        <button
+          type="button"
+          className="rounded-md border border-gray-200 px-3 py-1 text-sm font-semibold text-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={() => onPageChange(page + 1)}
+          disabled={totalPages ? page >= totalPages : !hasMore}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/internal/StatusBadge.tsx
+++ b/components/internal/StatusBadge.tsx
@@ -1,0 +1,14 @@
+const STATUS_STYLES: Record<string, string> = {
+  pending: "bg-amber-100 text-amber-700 border-amber-200",
+  approved: "bg-emerald-100 text-emerald-700 border-emerald-200",
+  rejected: "bg-rose-100 text-rose-700 border-rose-200",
+};
+
+export default function StatusBadge({ status }: { status: string }) {
+  const style = STATUS_STYLES[status] ?? "bg-slate-100 text-slate-700 border-slate-200";
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${style}`}>
+      {status}
+    </span>
+  );
+}

--- a/components/internal/SubmissionActions.tsx
+++ b/components/internal/SubmissionActions.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from "react";
+
+import type { SubmissionDetail } from "@/lib/internal/submissions";
+import { approveSubmission, promoteSubmission, rejectSubmission } from "@/lib/internal/submissions";
+
+type SubmissionActionsProps = {
+  submission: SubmissionDetail;
+  onActionComplete: (message: { type: "success" | "error"; text: string; placeId?: string | null }) => void;
+  onRefresh: () => void;
+};
+
+export default function SubmissionActions({ submission, onActionComplete, onRefresh }: SubmissionActionsProps) {
+  const [reviewNote, setReviewNote] = useState("");
+  const [rejectReason, setRejectReason] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isPending = submission.status === "pending";
+  const isApproved = submission.status === "approved";
+  const isPromotableKind = submission.kind === "owner" || submission.kind === "community";
+  const canPromote = isPromotableKind && isApproved;
+  const isAlreadyPromoted = Boolean(submission.publishedPlaceId);
+
+  const handleApprove = async () => {
+    setIsSubmitting(true);
+    const result = await approveSubmission(submission.id, reviewNote.trim() || undefined);
+    if (result.ok) {
+      onActionComplete({ type: "success", text: "Submission approved." });
+      onRefresh();
+    } else {
+      onActionComplete({
+        type: "error",
+        text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to approve."}`,
+      });
+    }
+    setIsSubmitting(false);
+  };
+
+  const handleReject = async () => {
+    const reason = rejectReason.trim();
+    if (!reason) {
+      onActionComplete({ type: "error", text: "Reject reason is required." });
+      return;
+    }
+    setIsSubmitting(true);
+    const result = await rejectSubmission(submission.id, reason, reviewNote.trim() || undefined);
+    if (result.ok) {
+      onActionComplete({ type: "success", text: "Submission rejected." });
+      onRefresh();
+    } else {
+      onActionComplete({
+        type: "error",
+        text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to reject."}`,
+      });
+    }
+    setIsSubmitting(false);
+  };
+
+  const handlePromote = async () => {
+    setIsSubmitting(true);
+    const result = await promoteSubmission(submission.id);
+    if (result.ok) {
+      onActionComplete({
+        type: "success",
+        text: "Submission promoted to a place.",
+        placeId: result.data.placeId ?? null,
+      });
+      onRefresh();
+    } else {
+      onActionComplete({
+        type: "error",
+        text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to promote."}`,
+      });
+    }
+    setIsSubmitting(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-2">
+          <label className="text-sm font-semibold text-gray-700" htmlFor="review-note">
+            Reviewer note (optional)
+          </label>
+          <textarea
+            id="review-note"
+            className="min-h-[96px] w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={reviewNote}
+            onChange={(event) => setReviewNote(event.target.value)}
+            placeholder="Add context for approval/rejection."
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-semibold text-gray-700" htmlFor="reject-reason">
+            Reject reason (required)
+          </label>
+          <textarea
+            id="reject-reason"
+            className="min-h-[96px] w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={rejectReason}
+            onChange={(event) => setRejectReason(event.target.value)}
+            placeholder="Provide a clear reason for rejection."
+            disabled={!isPending || isSubmitting}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleApprove}
+          disabled={!isPending || isSubmitting}
+        >
+          Approve
+        </button>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-md bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-700 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={handleReject}
+          disabled={!isPending || isSubmitting}
+        >
+          Reject
+        </button>
+        {canPromote && (
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-md border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={handlePromote}
+            disabled={isSubmitting || isAlreadyPromoted}
+          >
+            {isAlreadyPromoted ? "Already promoted" : "Promote to place"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/internal/SubmissionDetail.tsx
+++ b/components/internal/SubmissionDetail.tsx
@@ -32,6 +32,17 @@ const toStringValue = (value: unknown) => {
   return String(value);
 };
 
+const toText = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
 const getSubmittedByValue = (submission: SubmissionDetail, key: string) => {
   const source = submission.submittedBy ?? submission.payload?.submittedBy;
   if (!source || typeof source !== "object") return undefined;
@@ -104,6 +115,7 @@ export default function SubmissionDetailCard({ submissionId }: { submissionId: s
     submission.payload?.contactEmail ??
     submission.payload?.submittedByEmail;
   const placeName = submission.payload?.placeName ?? submission.payload?.name ?? submission.name;
+  const placeNameText = toText(placeName ?? submission.payload?.placeName ?? "");
   const placeId = submission.placeId ?? submission.payload?.placeId;
   const acceptedMediaSummary = submission.acceptedMediaSummary ?? submission.payload?.acceptedMediaSummary;
   const mediaSaved = submission.mediaSaved ?? submission.payload?.mediaSaved;
@@ -113,7 +125,7 @@ export default function SubmissionDetailCard({ submissionId }: { submissionId: s
       <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h1 className="text-xl font-semibold text-gray-900">{placeName}</h1>
+            <h1 className="text-xl font-semibold text-gray-900">{placeNameText || "(no place name)"}</h1>
             <p className="text-sm text-gray-500">Submission ID: {submission.id}</p>
           </div>
           <StatusBadge status={submission.status} />

--- a/components/internal/SubmissionDetail.tsx
+++ b/components/internal/SubmissionDetail.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import ErrorBox from "@/components/internal/ErrorBox";
+import MediaPreviewGrid from "@/components/internal/MediaPreviewGrid";
+import StatusBadge from "@/components/internal/StatusBadge";
+import SubmissionActions from "@/components/internal/SubmissionActions";
+import {
+  fetchSubmissionDetail,
+  fetchSubmissionHistory,
+  type SubmissionDetail,
+  type SubmissionHistoryEntry,
+} from "@/lib/internal/submissions";
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+};
+
+const toStringValue = (value: unknown) => {
+  if (value === null || value === undefined || value === "") return "—";
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "—";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  return String(value);
+};
+
+const getSubmittedByValue = (submission: SubmissionDetail, key: string) => {
+  const source = submission.submittedBy ?? submission.payload?.submittedBy;
+  if (!source || typeof source !== "object") return undefined;
+  return (source as Record<string, unknown>)[key];
+};
+
+export default function SubmissionDetailCard({ submissionId }: { submissionId: string }) {
+  const router = useRouter();
+  const [submission, setSubmission] = useState<SubmissionDetail | null>(null);
+  const [history, setHistory] = useState<SubmissionHistoryEntry[]>([]);
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const [historyStatus, setHistoryStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const [error, setError] = useState<{ code?: string; message?: string } | null>(null);
+  const [toast, setToast] = useState<{ type: "success" | "error"; text: string; placeId?: string | null } | null>(
+    null,
+  );
+
+  const refresh = useCallback(async () => {
+    setStatus("loading");
+    const result = await fetchSubmissionDetail(submissionId);
+    if (result.ok) {
+      setSubmission(result.data.submission);
+      setStatus("loaded");
+    } else {
+      setStatus("error");
+      setError(result.error);
+    }
+  }, [submissionId]);
+
+  const refreshHistory = useCallback(async () => {
+    setHistoryStatus("loading");
+    const result = await fetchSubmissionHistory(submissionId);
+    if (result.ok) {
+      setHistory(result.data.entries ?? []);
+      setHistoryStatus("loaded");
+    } else {
+      setHistoryStatus("error");
+    }
+  }, [submissionId]);
+
+  useEffect(() => {
+    void refresh();
+    void refreshHistory();
+  }, [refresh, refreshHistory]);
+
+  const reviewInfo = useMemo(() => {
+    if (!submission) return null;
+    return {
+      reviewer: submission.reviewedBy?.name ?? submission.reviewedBy?.email,
+      reviewNote: submission.reviewNote,
+      approvedAt: submission.approvedAt,
+      rejectedAt: submission.rejectedAt,
+    };
+  }, [submission]);
+
+  if (status === "loading") {
+    return <div className="rounded-lg border bg-white p-6 text-sm text-gray-500">Loading submission…</div>;
+  }
+
+  if (status === "error" || !submission) {
+    return <ErrorBox title="Unable to load submission" error={error ?? { message: "Unknown error." }} />;
+  }
+
+  const submitterName =
+    getSubmittedByValue(submission, "name") ??
+    submission.payload?.contactName ??
+    submission.payload?.submittedByName;
+  const submitterEmail =
+    getSubmittedByValue(submission, "email") ??
+    submission.payload?.contactEmail ??
+    submission.payload?.submittedByEmail;
+  const placeName = submission.payload?.placeName ?? submission.payload?.name ?? submission.name;
+  const placeId = submission.placeId ?? submission.payload?.placeId;
+  const acceptedMediaSummary = submission.acceptedMediaSummary ?? submission.payload?.acceptedMediaSummary;
+  const mediaSaved = submission.mediaSaved ?? submission.payload?.mediaSaved;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">{placeName}</h1>
+            <p className="text-sm text-gray-500">Submission ID: {submission.id}</p>
+          </div>
+          <StatusBadge status={submission.status} />
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-3">
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <h2 className="text-sm font-semibold text-gray-800">Submission</h2>
+            <dl className="mt-3 space-y-2 text-sm text-gray-700">
+              <div className="flex justify-between gap-4">
+                <dt>Kind</dt>
+                <dd>{submission.kind}</dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt>Status</dt>
+                <dd>{submission.status}</dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt>Submitted</dt>
+                <dd>{formatDate(submission.createdAt)}</dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt>Reviewed</dt>
+                <dd>{formatDate(reviewInfo?.approvedAt ?? reviewInfo?.rejectedAt)}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <h2 className="text-sm font-semibold text-gray-800">Reviewer</h2>
+            <dl className="mt-3 space-y-2 text-sm text-gray-700">
+              <div className="flex justify-between gap-4">
+                <dt>Reviewer</dt>
+                <dd>{toStringValue(reviewInfo?.reviewer)}</dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt>Review note</dt>
+                <dd>{toStringValue(reviewInfo?.reviewNote)}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <h2 className="text-sm font-semibold text-gray-800">Place</h2>
+            <dl className="mt-3 space-y-2 text-sm text-gray-700">
+              <div className="flex justify-between gap-4">
+                <dt>Place ID</dt>
+                <dd>{toStringValue(placeId)}</dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt>Published</dt>
+                <dd>{toStringValue(submission.publishedPlaceId)}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <h2 className="text-sm font-semibold text-gray-800">Submitter</h2>
+            <dl className="mt-3 space-y-2 text-sm text-gray-700">
+              <div className="flex justify-between gap-4">
+                <dt>Name</dt>
+                <dd>{toStringValue(submitterName)}</dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt>Email</dt>
+                <dd>{toStringValue(submitterEmail)}</dd>
+              </div>
+            </dl>
+          </div>
+          <div className="rounded-lg border border-gray-100 bg-gray-50 p-4">
+            <h2 className="text-sm font-semibold text-gray-800">Media summary</h2>
+            <dl className="mt-3 space-y-2 text-sm text-gray-700">
+              <div className="flex justify-between gap-4">
+                <dt>Accepted media</dt>
+                <dd>
+                  {acceptedMediaSummary
+                    ? Object.entries(acceptedMediaSummary)
+                        .map(([key, value]) => `${key}: ${value}`)
+                        .join(", ")
+                    : "—"}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt>Media saved</dt>
+                <dd>{mediaSaved ? "Yes" : "—"}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-sm font-semibold text-gray-800">Media preview</h2>
+        <div className="mt-4">
+          <MediaPreviewGrid submissionId={submission.id} media={submission.media ?? []} />
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-sm font-semibold text-gray-800">Normalized payload</h2>
+        <details className="mt-3 rounded-md border border-gray-100 bg-gray-50 p-3">
+          <summary className="cursor-pointer text-sm font-semibold text-gray-700">View payload JSON</summary>
+          <pre className="mt-3 max-h-96 overflow-auto text-xs text-gray-700">
+            {JSON.stringify(submission.payload, null, 2)}
+          </pre>
+        </details>
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-sm font-semibold text-gray-800">Action history</h2>
+        {historyStatus === "loading" && <p className="mt-3 text-sm text-gray-500">Loading history…</p>}
+        {historyStatus === "error" && <p className="mt-3 text-sm text-rose-700">Failed to load history.</p>}
+        {historyStatus === "loaded" && history.length === 0 && (
+          <p className="mt-3 text-sm text-gray-500">No history entries yet.</p>
+        )}
+        {historyStatus === "loaded" && history.length > 0 && (
+          <div className="mt-4 space-y-3 text-sm text-gray-700">
+            {history.map((entry) => (
+              <div key={entry.id} className="rounded-md border border-gray-100 bg-gray-50 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-semibold text-gray-800">{entry.action}</span>
+                  <span className="text-xs text-gray-500">{formatDate(entry.createdAt)}</span>
+                </div>
+                <div className="mt-2 grid gap-2 sm:grid-cols-3">
+                  <div>
+                    <p className="text-xs uppercase text-gray-400">Actor</p>
+                    <p>{entry.actor}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-gray-400">Place</p>
+                    <p>{entry.placeId ?? "—"}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase text-gray-400">Meta</p>
+                    <p className="truncate">{entry.meta ? JSON.stringify(entry.meta) : "—"}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold text-gray-800">Actions</h2>
+          <Link className="text-sm font-semibold text-blue-600 hover:text-blue-700" href="/internal/submissions">
+            Back to list
+          </Link>
+        </div>
+        <div className="mt-4 space-y-4">
+          <SubmissionActions
+            submission={submission}
+            onActionComplete={(message) => setToast(message)}
+            onRefresh={() => {
+              void refresh();
+              void refreshHistory();
+              router.refresh();
+            }}
+          />
+          {toast && (
+            <div
+              className={`rounded-md border px-4 py-3 text-sm ${
+                toast.type === "success"
+                  ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                  : "border-rose-200 bg-rose-50 text-rose-700"
+              }`}
+            >
+              <p>{toast.text}</p>
+              {toast.placeId && (
+                <p className="mt-1">
+                  Place: <Link className="font-semibold text-emerald-700" href={`/places/${toast.placeId}`}>
+                    {toast.placeId}
+                  </Link>
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/internal/SubmissionsList.tsx
+++ b/components/internal/SubmissionsList.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import ErrorBox from "@/components/internal/ErrorBox";
+import Pagination from "@/components/internal/Pagination";
+import StatusBadge from "@/components/internal/StatusBadge";
+import { buildSubmissionQuery, parseSubmissionFilters } from "@/components/internal/filters";
+import { fetchSubmissionList, type SubmissionListItem } from "@/lib/internal/submissions";
+
+const formatDate = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+};
+
+const getSubmittedByValue = (submission: SubmissionListItem, key: string) => {
+  const source = submission.submittedBy ?? submission.payload?.submittedBy;
+  if (!source || typeof source !== "object") return undefined;
+  return (source as Record<string, unknown>)[key];
+};
+
+export default function SubmissionsList() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const filters = useMemo(() => parseSubmissionFilters(new URLSearchParams(searchParams)), [searchParams]);
+  const [items, setItems] = useState<SubmissionListItem[]>([]);
+  const [pageInfo, setPageInfo] = useState<{ page: number; limit: number; total?: number | null; hasMore?: boolean }>(
+    {
+      page: filters.page,
+      limit: filters.limit,
+    },
+  );
+  const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
+  const [error, setError] = useState<{ code?: string; message?: string } | null>(null);
+  const [searchValue, setSearchValue] = useState(filters.q ?? "");
+
+  const load = useCallback(async () => {
+    setStatus("loading");
+    const result = await fetchSubmissionList(filters);
+    if (result.ok) {
+      setItems(result.data.items ?? []);
+      setPageInfo(result.data.pageInfo ?? { page: filters.page, limit: filters.limit });
+      setStatus("loaded");
+    } else {
+      setStatus("error");
+      setError(result.error);
+    }
+  }, [filters]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    setSearchValue(filters.q ?? "");
+  }, [filters.q]);
+
+  const updateFilters = (updates: Partial<typeof filters>) => {
+    const query = buildSubmissionQuery(filters, { ...updates, page: updates.page ?? 1 });
+    router.push(`/internal/submissions?${query}`);
+  };
+
+  if (status === "loading") {
+    return <div className="rounded-lg border bg-white p-6 text-sm text-gray-500">Loading submissions…</div>;
+  }
+
+  if (status === "error") {
+    return <ErrorBox title="Unable to load submissions" error={error ?? { message: "Unknown error." }} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <label className="text-sm">
+              <span className="text-xs font-semibold uppercase text-gray-500">Status</span>
+              <select
+                className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+                value={filters.status}
+                onChange={(event) => updateFilters({ status: event.target.value })}
+              >
+                <option value="pending">Pending</option>
+                <option value="approved">Approved</option>
+                <option value="rejected">Rejected</option>
+              </select>
+            </label>
+            <label className="text-sm">
+              <span className="text-xs font-semibold uppercase text-gray-500">Kind</span>
+              <select
+                className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+                value={filters.kind ?? ""}
+                onChange={(event) => updateFilters({ kind: event.target.value || undefined })}
+              >
+                <option value="">All</option>
+                <option value="owner">Owner</option>
+                <option value="community">Community</option>
+                <option value="report">Report</option>
+              </select>
+            </label>
+            <label className="text-sm">
+              <span className="text-xs font-semibold uppercase text-gray-500">Page size</span>
+              <select
+                className="mt-1 w-full rounded-md border border-gray-300 p-2 text-sm"
+                value={filters.limit}
+                onChange={(event) => updateFilters({ limit: Number(event.target.value) })}
+              >
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+                <option value={100}>100</option>
+              </select>
+            </label>
+          </div>
+          <form
+            className="flex w-full gap-2 lg:max-w-sm"
+            onSubmit={(event) => {
+              event.preventDefault();
+              updateFilters({ q: searchValue.trim() || undefined });
+            }}
+          >
+            <input
+              className="w-full rounded-md border border-gray-300 p-2 text-sm"
+              placeholder="Search submissions, names, emails"
+              value={searchValue}
+              onChange={(event) => setSearchValue(event.target.value)}
+            />
+            <button
+              type="submit"
+              className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white"
+            >
+              Search
+            </button>
+          </form>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center text-sm text-gray-500">
+          No submissions found for this filter.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-3">Submission</th>
+                <th className="px-4 py-3">Submitter</th>
+                <th className="px-4 py-3">Place</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Submitted</th>
+                <th className="px-4 py-3">Media</th>
+                <th className="px-4 py-3 text-right">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {items.map((submission) => {
+                const submitterName =
+                  getSubmittedByValue(submission, "name") ??
+                  submission.payload?.contactName ??
+                  submission.payload?.submittedByName;
+                const submitterEmail =
+                  getSubmittedByValue(submission, "email") ??
+                  submission.payload?.contactEmail ??
+                  submission.payload?.submittedByEmail;
+                const placeName = submission.payload?.placeName ?? submission.payload?.name ?? submission.name;
+                const placeId = submission.placeId ?? submission.payload?.placeId;
+                const acceptedMediaSummary =
+                  submission.acceptedMediaSummary ?? submission.payload?.acceptedMediaSummary;
+                const mediaSaved = submission.mediaSaved ?? submission.payload?.mediaSaved;
+
+                return (
+                  <tr key={submission.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3 text-gray-900">
+                      <div className="font-medium">{placeName}</div>
+                      <div className="text-xs text-gray-500">{submission.id}</div>
+                      <div className="text-xs text-gray-500">{submission.kind}</div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-700">
+                      <div>{submitterName ?? "—"}</div>
+                      <div className="text-xs text-gray-500">{submitterEmail ?? "—"}</div>
+                    </td>
+                    <td className="px-4 py-3 text-gray-700">
+                      <div>{placeId ?? "—"}</div>
+                      <div className="text-xs text-gray-500">{placeName}</div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={submission.status} />
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{formatDate(submission.createdAt)}</td>
+                    <td className="px-4 py-3 text-xs text-gray-600">
+                      <div>
+                        {acceptedMediaSummary
+                          ? Object.entries(acceptedMediaSummary)
+                              .map(([key, value]) => `${key}: ${value}`)
+                              .join(", ")
+                          : "—"}
+                      </div>
+                      <div className="text-gray-500">Saved: {mediaSaved ? "Yes" : "—"}</div>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Link
+                        className="inline-flex items-center rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700 hover:bg-indigo-100"
+                        href={`/internal/submissions/${submission.id}`}
+                      >
+                        Review
+                      </Link>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <Pagination
+            page={pageInfo.page}
+            limit={pageInfo.limit}
+            total={pageInfo.total ?? undefined}
+            hasMore={pageInfo.hasMore}
+            onPageChange={(nextPage) => updateFilters({ page: nextPage })}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/internal/SubmissionsList.tsx
+++ b/components/internal/SubmissionsList.tsx
@@ -25,6 +25,17 @@ const getSubmittedByValue = (submission: SubmissionListItem, key: string) => {
   return (source as Record<string, unknown>)[key];
 };
 
+const toText = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
 export default function SubmissionsList() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -164,12 +175,16 @@ export default function SubmissionsList() {
                   getSubmittedByValue(submission, "name") ??
                   submission.payload?.contactName ??
                   submission.payload?.submittedByName;
+                const submitterNameText = toText(submitterName ?? "");
                 const submitterEmail =
                   getSubmittedByValue(submission, "email") ??
                   submission.payload?.contactEmail ??
                   submission.payload?.submittedByEmail;
+                const submitterEmailText = toText(submitterEmail ?? "");
                 const placeName = submission.payload?.placeName ?? submission.payload?.name ?? submission.name;
+                const placeNameText = toText(placeName ?? submission.payload?.placeName ?? "");
                 const placeId = submission.placeId ?? submission.payload?.placeId;
+                const placeIdText = toText(placeId ?? "");
                 const acceptedMediaSummary =
                   submission.acceptedMediaSummary ?? submission.payload?.acceptedMediaSummary;
                 const mediaSaved = submission.mediaSaved ?? submission.payload?.mediaSaved;
@@ -177,17 +192,17 @@ export default function SubmissionsList() {
                 return (
                   <tr key={submission.id} className="hover:bg-gray-50">
                     <td className="px-4 py-3 text-gray-900">
-                      <div className="font-medium">{placeName}</div>
+                      <div className="font-medium">{placeNameText || "(no place name)"}</div>
                       <div className="text-xs text-gray-500">{submission.id}</div>
                       <div className="text-xs text-gray-500">{submission.kind}</div>
                     </td>
                     <td className="px-4 py-3 text-gray-700">
-                      <div>{submitterName ?? "—"}</div>
-                      <div className="text-xs text-gray-500">{submitterEmail ?? "—"}</div>
+                      <div>{submitterNameText || "—"}</div>
+                      <div className="text-xs text-gray-500">{submitterEmailText || "—"}</div>
                     </td>
                     <td className="px-4 py-3 text-gray-700">
-                      <div>{placeId ?? "—"}</div>
-                      <div className="text-xs text-gray-500">{placeName}</div>
+                      <div>{placeIdText || "—"}</div>
+                      <div className="text-xs text-gray-500">{placeNameText || "(no place name)"}</div>
                     </td>
                     <td className="px-4 py-3">
                       <StatusBadge status={submission.status} />

--- a/components/internal/filters.ts
+++ b/components/internal/filters.ts
@@ -1,0 +1,48 @@
+export type SubmissionFilters = {
+  status: string;
+  kind?: string;
+  q?: string;
+  page: number;
+  limit: number;
+};
+
+const parseNumber = (value: string | null, fallback: number) => {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+export const parseSubmissionFilters = (params: URLSearchParams): SubmissionFilters => {
+  const status = params.get("status") ?? "pending";
+  const kind = params.get("kind") ?? undefined;
+  const q = params.get("q") ?? undefined;
+  const page = parseNumber(params.get("page"), 1);
+  const limit = parseNumber(params.get("limit"), 20);
+
+  return {
+    status,
+    kind,
+    q,
+    page,
+    limit,
+  };
+};
+
+export const buildSubmissionQuery = (
+  current: SubmissionFilters,
+  updates: Partial<SubmissionFilters>,
+) => {
+  const merged: SubmissionFilters = {
+    ...current,
+    ...updates,
+  };
+
+  const params = new URLSearchParams();
+  if (merged.status) params.set("status", merged.status);
+  if (merged.kind) params.set("kind", merged.kind);
+  if (merged.q) params.set("q", merged.q);
+  if (merged.page) params.set("page", merged.page.toString());
+  if (merged.limit) params.set("limit", merged.limit.toString());
+
+  return params.toString();
+};

--- a/lib/internal/submissions.ts
+++ b/lib/internal/submissions.ts
@@ -1,0 +1,175 @@
+export type ApiError = {
+  code?: string;
+  message?: string;
+};
+
+export type SubmissionMedia = {
+  kind: string;
+  mediaId: string;
+  url?: string | null;
+};
+
+export type SubmissionListItem = {
+  id: string;
+  status: string;
+  kind: string;
+  createdAt: string;
+  updatedAt?: string | null;
+  name: string;
+  country?: string | null;
+  city?: string | null;
+  payload?: Record<string, unknown>;
+  placeId?: string | null;
+  submittedBy?: Record<string, unknown> | null;
+  reviewedBy?: Record<string, unknown> | null;
+  reviewNote?: string | null;
+  publishedPlaceId?: string | null;
+  approvedAt?: string | null;
+  rejectedAt?: string | null;
+  rejectReason?: string | null;
+  acceptedMediaSummary?: Record<string, number> | null;
+  mediaSaved?: boolean;
+};
+
+export type SubmissionDetail = SubmissionListItem & {
+  media?: SubmissionMedia[];
+};
+
+export type SubmissionListResponse = {
+  items: SubmissionListItem[];
+  pageInfo: {
+    page: number;
+    limit: number;
+    total?: number | null;
+    hasMore?: boolean;
+  };
+};
+
+export type SubmissionHistoryEntry = {
+  id: string;
+  actor: string;
+  action: string;
+  submissionId: string;
+  placeId: string | null;
+  createdAt: string;
+  meta: Record<string, unknown> | null;
+};
+
+export type SubmissionHistoryResponse = {
+  entries: SubmissionHistoryEntry[];
+};
+
+export type SubmissionActionResponse = {
+  status?: string;
+  placeId?: string;
+  promoted?: boolean;
+};
+
+type ApiResult<T> =
+  | { ok: true; status: number; data: T }
+  | { ok: false; status?: number; error: ApiError };
+
+const parseErrorPayload = (payload: unknown): ApiError => {
+  if (!payload || typeof payload !== "object") {
+    return { message: "Request failed" };
+  }
+
+  const record = payload as { error?: unknown; message?: unknown; code?: unknown };
+  if (record.error && typeof record.error === "object") {
+    const nested = record.error as { code?: unknown; message?: unknown };
+    return {
+      code: typeof nested.code === "string" ? nested.code : undefined,
+      message: typeof nested.message === "string" ? nested.message : "Request failed",
+    };
+  }
+
+  if (typeof record.error === "string") {
+    return { message: record.error };
+  }
+
+  return {
+    code: typeof record.code === "string" ? record.code : undefined,
+    message: typeof record.message === "string" ? record.message : "Request failed",
+  };
+};
+
+const parseJsonSafely = async (response: Response) => {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+};
+
+const buildAuthError = () => ({
+  code: "UNAUTHORIZED",
+  message: "Authentication required to access internal submissions.",
+});
+
+const fetchJson = async <T>(input: RequestInfo | URL, init?: RequestInit): Promise<ApiResult<T>> => {
+  const response = await fetch(input, { credentials: "same-origin", ...init });
+  const payload = await parseJsonSafely(response);
+
+  if (response.ok) {
+    return { ok: true, status: response.status, data: payload as T };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return { ok: false, status: response.status, error: buildAuthError() };
+  }
+
+  return { ok: false, status: response.status, error: parseErrorPayload(payload) };
+};
+
+export const buildSubmissionMediaUrl = (submissionId: string, kind: string, mediaId: string) => {
+  if (kind === "gallery") {
+    return `/api/media/submissions/${submissionId}/gallery/${mediaId}`;
+  }
+  return `/api/internal/media/submissions/${submissionId}/${kind}/${mediaId}`;
+};
+
+export const fetchSubmissionList = async (params: {
+  status?: string;
+  kind?: string;
+  q?: string;
+  page?: number;
+  limit?: number;
+}): Promise<ApiResult<SubmissionListResponse>> => {
+  const search = new URLSearchParams();
+  if (params.status) search.set("status", params.status);
+  if (params.kind) search.set("kind", params.kind);
+  if (params.q) search.set("q", params.q);
+  if (params.page) search.set("page", params.page.toString());
+  if (params.limit) search.set("limit", params.limit.toString());
+
+  return fetchJson<SubmissionListResponse>(`/api/internal/submissions?${search.toString()}`);
+};
+
+export const fetchSubmissionDetail = async (submissionId: string) =>
+  fetchJson<{ submission: SubmissionDetail }>(`/api/internal/submissions/${submissionId}`);
+
+export const fetchSubmissionHistory = async (submissionId: string) =>
+  fetchJson<SubmissionHistoryResponse>(`/api/internal/submissions/${submissionId}/history`);
+
+export const approveSubmission = async (submissionId: string, reviewNote?: string) =>
+  fetchJson<SubmissionActionResponse>(`/api/internal/submissions/${submissionId}/approve`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(reviewNote ? { review_note: reviewNote } : {}),
+  });
+
+export const rejectSubmission = async (
+  submissionId: string,
+  reason: string,
+  reviewNote?: string,
+) =>
+  fetchJson<SubmissionActionResponse>(`/api/internal/submissions/${submissionId}/reject`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ reject_reason: reason, ...(reviewNote ? { review_note: reviewNote } : {}) }),
+  });
+
+export const promoteSubmission = async (submissionId: string) =>
+  fetchJson<SubmissionActionResponse>(`/api/internal/submissions/${submissionId}/promote`, {
+    method: "POST",
+  });

--- a/lib/internalAuth.ts
+++ b/lib/internalAuth.ts
@@ -21,16 +21,35 @@ const buildErrorResponse = (
 
 export const requireInternalAuth = (request: Request): { ok: true } | NextResponse => {
   const configuredKey = process.env.CPM_INTERNAL_KEY?.trim();
+  const basicUser = process.env.INTERNAL_BASIC_USER;
+  const basicPass = process.env.INTERNAL_BASIC_PASS;
 
-  if (!configuredKey) {
+  const authorization = request.headers.get("authorization");
+  const hasBasic = Boolean(basicUser && basicPass);
+  const isBasicAuthed = (() => {
+    if (!authorization?.startsWith("Basic ") || !hasBasic) return false;
+    try {
+      const decoded = Buffer.from(authorization.slice(6), "base64").toString("utf8");
+      const [providedUser, providedPass] = decoded.split(":");
+      return providedUser === basicUser && providedPass === basicPass;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (!configuredKey && !hasBasic) {
     return buildErrorResponse(503, "INTERNAL_AUTH_MISCONFIG", "CPM internal auth is not configured.");
   }
 
   const providedKey = request.headers.get("x-cpm-internal-key");
 
-  if (!providedKey || providedKey !== configuredKey) {
-    return buildErrorResponse(401, "UNAUTHORIZED", "Missing or invalid internal authentication key.");
+  if (configuredKey && providedKey === configuredKey) {
+    return { ok: true };
   }
 
-  return { ok: true };
+  if (isBasicAuthed) {
+    return { ok: true };
+  }
+
+  return buildErrorResponse(401, "UNAUTHORIZED", "Missing or invalid internal authentication key.");
 };


### PR DESCRIPTION
### Motivation
- Provide operators with an internal console to list, inspect, review and act on submissions including media previews and history.
- Surface server-side filtering, pagination and media metadata to the operator UI while keeping storage URLs behind authenticated endpoints.
- Make internal API auth more flexible so the UI can be used with existing basic auth in environments where the internal key is not set.

### Description
- Added a client internal console with a list page and a detail page plus small UI primitives: `components/internal/SubmissionsList.tsx`, `SubmissionDetail.tsx`, `SubmissionActions.tsx`, `MediaPreviewGrid.tsx`, `StatusBadge.tsx`, `Pagination.tsx`, `ErrorBox.tsx`, and `components/internal/filters.ts`, and a redirect `app/internal/page.tsx` to `/internal/submissions`.
- Implemented internal API list/detail enhancements in `app/api/internal/submissions/route.ts` and `app/api/internal/submissions/[id]/route.ts` to support `status/kind/q/page/limit` filtering, return `pageInfo` and `items`, and include a `media` array for the detail payload (media rows are read only when the `submission_media` table exists).
- Kept media previews using safe endpoints only via `lib/internal/submissions.ts` helper `buildSubmissionMediaUrl` so gallery previews use `/api/media/submissions/{submissionId}/gallery/{mediaId}` and internal proof/evidence use `/api/internal/media/submissions/{submissionId}/{kind}/{mediaId}`; the UI never exposes raw storage keys.
- Enhanced auth handling by updating `lib/internalAuth.ts` to accept Basic auth (ENV `INTERNAL_BASIC_USER`/`INTERNAL_BASIC_PASS`) as a fallback for internal API requests, and changed history ordering to chronological (ASC) in `app/api/internal/submissions/[id]/history/route.ts`.
- How to manually verify (operator flow): 1) open `/internal/submissions` (use basic auth credentials if configured); 2) filter by `status/kind`, search with the box, and use Prev/Next pagination; 3) open `/internal/submissions/{id}` to view submission metadata, normalized payload, media previews, and history; 4) click `Approve` or `Reject` (Reject requires a reason) and confirm detail/list/history refresh; 5) for owner/community submissions that are `approved`, click `Promote to place` and confirm a place id/link appears and the promote control is disabled afterward.

### Testing
- Automated tests: no automated test suite or build was executed as part of this change.
- Manual test notes: follow the manual verification steps above using the exact URLs (`/internal/submissions`, `/internal/submissions/{id}`, and API endpoints under `/api/internal/submissions`) and ensure the UI shows clear auth error message when the API returns 401/403.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69778590c2cc8328a6c77fc48f88b3ba)