### PR TITLE
Show full submission fields on confirm page

### DIFF
--- a/components/submit/SubmitConfirm.tsx
+++ b/components/submit/SubmitConfirm.tsx
@@ -133,6 +133,7 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
           <dl className="space-y-2">
             {bundle.payload.kind === "report" ? (
               <>
+                <SummaryRow label="Place ID" value={bundle.payload.placeId} />
                 <SummaryRow label="Place name" value={bundle.payload.placeName} />
                 <SummaryRow label="Reason" value={bundle.payload.reportReason} />
                 <SummaryRow label="Details" value={bundle.payload.reportDetails} />
@@ -145,8 +146,18 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
                 <SummaryRow label="Address" value={bundle.payload.address} />
                 <SummaryRow label="Category" value={bundle.payload.category} />
                 <SummaryRow label="Accepted crypto" value={bundle.payload.acceptedChains.join(", ")} />
+                <SummaryRow label="Latitude" value={bundle.payload.lat} />
+                <SummaryRow label="Longitude" value={bundle.payload.lng} />
                 <SummaryRow label="About" value={bundle.payload.about} />
                 <SummaryRow label="Payment note" value={bundle.payload.paymentNote} />
+                <SummaryRow label="Website" value={bundle.payload.website} />
+                <SummaryRow label="Twitter / X" value={bundle.payload.twitter} />
+                <SummaryRow label="Instagram" value={bundle.payload.instagram} />
+                <SummaryRow label="Facebook" value={bundle.payload.facebook} />
+                <SummaryRow label="Role" value={bundle.payload.role} />
+                <SummaryRow label="Notes for admin" value={bundle.payload.notesForAdmin} />
+                <SummaryRow label="Related place ID" value={bundle.payload.placeId} />
+                <SummaryRow label="Related place name" value={bundle.payload.placeName} />
               </>
             )}
           </dl>


### PR DESCRIPTION
### Motivation
- Reviewers need to see all captured submission fields on the confirm screen so they can verify inputs (including place references and media counts) before the final POST is performed.

### Description
- Updated `components/submit/SubmitConfirm.tsx` to surface additional submission fields on the confirmation screen: `placeId` for reports, and for owner/community flows `lat`, `lng`, `website`, `twitter`, `instagram`, `facebook`, `role`, `notesForAdmin`, and related place ID/name.

### Testing
- Ran `npm run build` which completed successfully (build warnings about `<img>` usage and some CSR deoptimizations were emitted). 
- Attempted an automated Playwright check to navigate to `/submit/owner` and capture the confirm page, but the Playwright run timed out.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c3ed6368c83288123be59ab4ef91b)