### PR TITLE
Handle image processing failures in submissions

### DIFF
--- a/lib/media/processImage.ts
+++ b/lib/media/processImage.ts
@@ -3,28 +3,42 @@ import sharp from "sharp";
 const MAX_DIMENSION = 1600;
 const WEBP_QUALITY = 80;
 
+export class MediaProcessingError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message);
+    this.name = "MediaProcessingError";
+    if (options?.cause) {
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
 type ProcessImageResult = {
   buffer: Buffer;
   contentType: "image/webp";
 };
 
 export const processImage = async (input: Buffer): Promise<ProcessImageResult> => {
-  const pipeline = sharp(input, { failOn: "error" })
-    .rotate()
-    .resize({
-      width: MAX_DIMENSION,
-      height: MAX_DIMENSION,
-      fit: "inside",
-      withoutEnlargement: true,
-    })
-    .webp({ quality: WEBP_QUALITY });
+  try {
+    const pipeline = sharp(input, { failOn: "error" })
+      .rotate()
+      .resize({
+        width: MAX_DIMENSION,
+        height: MAX_DIMENSION,
+        fit: "inside",
+        withoutEnlargement: true,
+      })
+      .webp({ quality: WEBP_QUALITY });
 
-  const buffer = await pipeline.toBuffer();
+    const buffer = await pipeline.toBuffer();
 
-  return {
-    buffer,
-    contentType: "image/webp",
-  };
+    return {
+      buffer,
+      contentType: "image/webp",
+    };
+  } catch (error) {
+    throw new MediaProcessingError("Failed to process image", { cause: error });
+  }
 };
 
 export const mediaProcessingConfig = {


### PR DESCRIPTION
### Motivation

- Make image processing failures (Sharp decode/convert/resize) observable and return a clear JSON error instead of a generic upload failure.
- Ensure the submission pipeline can distinguish invalid image data from storage/DB faults so callers receive actionable errors.

### Description

- Add `MediaProcessingError` and wrap the Sharp pipeline in `lib/media/processImage.ts` to surface processing failures with a specific error and cause.
- Keep the existing processing steps (rotate, resize to `MAX_DIMENSION`, convert to WebP with fixed quality) and return `image/webp` buffers on success.
- Import and propagate `MediaProcessingError` in `lib/submissions.ts`, preserve cleanup of any uploaded objects on failure, and rethrow media errors to avoid treating them as generic upload failures.
- Return a JSON 400 response with code `MEDIA_PROCESSING_FAILED` and message `Invalid image data` when image processing fails during multipart submissions.

### Testing

- No automated tests were run for this change during the rollout.
- Existing multipart validation (mime/type/size/count) was left intact and continues to enforce the 2MB and per-kind count constraints prior to processing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c54caa6e4832881e92acfef7333ac)