### PR TITLE
Store submission media metadata with R2 keys

### DIFF
--- a/app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts
+++ b/app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts
@@ -64,7 +64,7 @@ export async function GET(
       return new Response(null, { status: 404 });
     }
 
-    const key = buildSubmissionMediaKey(submissionId, kind, mediaId);
+    const key = record.r2Key ?? buildSubmissionMediaKey(submissionId, kind, mediaId);
     const result = await getSubmissionMediaObject(key);
     const stream = toReadableStream(result.Body);
 

--- a/app/api/media/submissions/[submissionId]/gallery/[mediaId]/route.ts
+++ b/app/api/media/submissions/[submissionId]/gallery/[mediaId]/route.ts
@@ -51,7 +51,7 @@ export async function GET(
       return new Response(null, { status: 404 });
     }
 
-    const key = buildSubmissionMediaKey(submissionId, "gallery", mediaId);
+    const key = record.r2Key ?? buildSubmissionMediaKey(submissionId, "gallery", mediaId);
     const result = await getSubmissionMediaObject(key);
     const stream = toReadableStream(result.Body);
 

--- a/lib/media/processImage.ts
+++ b/lib/media/processImage.ts
@@ -16,6 +16,8 @@ export class MediaProcessingError extends Error {
 type ProcessImageResult = {
   buffer: Buffer;
   contentType: "image/webp";
+  width: number | null;
+  height: number | null;
 };
 
 export const processImage = async (input: Buffer): Promise<ProcessImageResult> => {
@@ -30,11 +32,13 @@ export const processImage = async (input: Buffer): Promise<ProcessImageResult> =
       })
       .webp({ quality: WEBP_QUALITY });
 
-    const buffer = await pipeline.toBuffer();
+    const { data, info } = await pipeline.toBuffer({ resolveWithObject: true });
 
     return {
-      buffer,
+      buffer: data,
       contentType: "image/webp",
+      width: info.width ?? null,
+      height: info.height ?? null,
     };
   } catch (error) {
     throw new MediaProcessingError("Failed to process image", { cause: error });

--- a/lib/media/submissionMedia.ts
+++ b/lib/media/submissionMedia.ts
@@ -1,0 +1,12 @@
+import type { SubmissionMediaKind } from "@/lib/storage/r2";
+
+export const buildSubmissionMediaUrl = (
+  submissionId: string,
+  kind: SubmissionMediaKind,
+  mediaId: string,
+) => {
+  if (kind === "gallery") {
+    return `/api/media/submissions/${submissionId}/gallery/${mediaId}`;
+  }
+  return `/api/internal/media/submissions/${submissionId}/${kind}/${mediaId}`;
+};

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -714,13 +714,6 @@ const invalidPayloadResponse = (message: string, details?: Record<string, unknow
 
 const MEDIA_KINDS: SubmissionMediaKind[] = ["gallery", "proof", "evidence"];
 
-const buildSubmissionMediaUrl = (submissionId: string, kind: SubmissionMediaKind, mediaId: string) => {
-  if (kind === "gallery") {
-    return `/api/media/submissions/${submissionId}/gallery/${mediaId}`;
-  }
-  return `/api/internal/media/submissions/${submissionId}/${kind}/${mediaId}`;
-};
-
 const hasAnyMedia = (filesByField: MultipartFilesByField) =>
   MEDIA_KINDS.some((kind) => filesByField[kind].length > 0);
 
@@ -749,11 +742,14 @@ const processAndStoreSubmissionMedia = async (submissionId: string, filesByField
             });
             uploadedKeys.push(key);
 
-            const url = buildSubmissionMediaUrl(submissionId, kind, mediaId);
             await insertSubmissionMedia({
               submissionId,
               kind,
-              url,
+              mediaId,
+              r2Key: key,
+              mime: processed.contentType,
+              width: processed.width,
+              height: processed.height,
               client,
               route: "/api/submissions",
             });


### PR DESCRIPTION
### Motivation
- Avoid persisting direct or signed object URLs in the database and instead store lightweight references (media id / R2 key / mime / dimensions) so display URLs can be computed on demand.
- Ensure processed image dimensions are captured alongside uploaded objects to support display/layout decisions.
- Keep existing media delivery endpoints working while transitioning DB schema to reference-style media storage.

### Description
- Capture processed image `width` and `height` in `lib/media/processImage.ts` and return them from `processImage` along with the WebP buffer and content type.
- Add a shared URL builder `lib/media/submissionMedia.ts` that computes display URLs for media (`/api/media/...` and internal paths) instead of storing fixed URLs.
- Change DB wrapper `lib/db/media.ts` to insert and return submission media metadata (`media_id`, `r2_key`, `mime`, `width`, `height`, `created_at`) and to look up records flexibly by available columns, preferring `media_id`/`r2_key`/`url` when present.
- Update submission flow in `lib/submissions.ts` to upload processed images to R2 (using `lib/storage/r2`) and insert only reference metadata into the DB (`mediaId`, `r2Key`, `mime`, `width`, `height`) instead of persisting direct or signed URLs.
- Update media-serving endpoints and internal submission detail (`app/api/internal/media/...`, `app/api/media/...`, `app/api/internal/submissions/[id]/route.ts`) to prefer stored `r2_key` when retrieving objects and to compute display URLs for API responses using the new URL builder.
- The R2 key generation continues to follow the convention `submissions/{submissionId}/{kind}/{mediaId}.webp` via `buildSubmissionMediaKey`.

### Testing
- No automated tests were run as part of this change.
- Changes were compiled/committed locally and manual code inspection was used to verify updated call sites and SQL queries succeeded syntactically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c5a58bda48328b15d33864a2f8f18)