### PR TITLE
internal media: enforce internal auth, block gallery, preserve content-type & no-store

### DIFF
--- a/app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts
+++ b/app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts
@@ -33,13 +33,17 @@ export async function GET(
   request: Request,
   { params }: { params: { submissionId: string; kind: string; mediaId: string } },
 ) {
-  if (!isAllowedKind(params.kind)) {
-    return new Response(null, { status: 404 });
-  }
-
   const auth = requireInternalAuth(request);
   if (!("ok" in auth)) {
     return auth;
+  }
+
+  if (params.kind === "gallery") {
+    return new Response(null, { status: 403 });
+  }
+
+  if (!isAllowedKind(params.kind)) {
+    return new Response(null, { status: 404 });
   }
 
   if (!hasDatabaseUrl()) {
@@ -72,9 +76,12 @@ export async function GET(
       return new Response(null, { status: 404 });
     }
 
+    const contentType =
+      record.mime ?? (typeof result.ContentType === "string" ? result.ContentType : null) ?? "image/webp";
+
     return new Response(stream, {
       headers: {
-        "Content-Type": "image/webp",
+        "Content-Type": contentType,
         "Cache-Control": "no-store",
       },
     });


### PR DESCRIPTION
### Motivation
- Provide an internal-only media delivery endpoint that only serves `proof` and `evidence` media to authorized internal clients. 
- Prevent distribution of `gallery` assets via the internal media route and ensure responses are not cacheable (`Cache-Control: no-store`).

### Description
- Require internal authentication early by calling `requireInternalAuth(request)` before validating the requested `kind` and return the auth error response when present. 
- Explicitly return `403` when `params.kind === "gallery"` and return `404` for any `kind` other than `proof` or `evidence`. 
- Derive the `Content-Type` from `record.mime` or `result.ContentType` when available and keep the response header `"Cache-Control": "no-store"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c67612954832881db8975c655c365)