### PR TITLE
Add payload summary and resilient submission actions

### DIFF
--- a/components/internal/SubmissionActions.tsx
+++ b/components/internal/SubmissionActions.tsx
@@ -23,18 +23,27 @@ export default function SubmissionActions({ submission, onActionComplete, onRefr
   const isAlreadyPromoted = Boolean(submission.publishedPlaceId);
 
   const handleApprove = async () => {
+    if (isSubmitting) return;
     setIsSubmitting(true);
-    const result = await approveSubmission(submission.id, reviewNote.trim() || undefined);
-    if (result.ok) {
-      onActionComplete({ type: "success", text: "Submission approved." });
-      onRefresh();
-    } else {
+    try {
+      const result = await approveSubmission(submission.id, reviewNote.trim() || undefined);
+      if (result.ok) {
+        onActionComplete({ type: "success", text: "Submission approved." });
+        onRefresh();
+      } else {
+        onActionComplete({
+          type: "error",
+          text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to approve."}`,
+        });
+      }
+    } catch (error) {
       onActionComplete({
         type: "error",
-        text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to approve."}`,
+        text: error instanceof Error ? error.message : "Failed to approve.",
       });
+    } finally {
+      setIsSubmitting(false);
     }
-    setIsSubmitting(false);
   };
 
   const handleReject = async () => {
@@ -43,37 +52,55 @@ export default function SubmissionActions({ submission, onActionComplete, onRefr
       onActionComplete({ type: "error", text: "Reject reason is required." });
       return;
     }
+    if (isSubmitting) return;
     setIsSubmitting(true);
-    const result = await rejectSubmission(submission.id, reason, reviewNote.trim() || undefined);
-    if (result.ok) {
-      onActionComplete({ type: "success", text: "Submission rejected." });
-      onRefresh();
-    } else {
+    try {
+      const result = await rejectSubmission(submission.id, reason, reviewNote.trim() || undefined);
+      if (result.ok) {
+        onActionComplete({ type: "success", text: "Submission rejected." });
+        onRefresh();
+      } else {
+        onActionComplete({
+          type: "error",
+          text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to reject."}`,
+        });
+      }
+    } catch (error) {
       onActionComplete({
         type: "error",
-        text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to reject."}`,
+        text: error instanceof Error ? error.message : "Failed to reject.",
       });
+    } finally {
+      setIsSubmitting(false);
     }
-    setIsSubmitting(false);
   };
 
   const handlePromote = async () => {
+    if (isSubmitting) return;
     setIsSubmitting(true);
-    const result = await promoteSubmission(submission.id);
-    if (result.ok) {
-      onActionComplete({
-        type: "success",
-        text: "Submission promoted to a place.",
-        placeId: result.data.placeId ?? null,
-      });
-      onRefresh();
-    } else {
+    try {
+      const result = await promoteSubmission(submission.id);
+      if (result.ok) {
+        onActionComplete({
+          type: "success",
+          text: "Submission promoted to a place.",
+          placeId: result.data.placeId ?? null,
+        });
+        onRefresh();
+      } else {
+        onActionComplete({
+          type: "error",
+          text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to promote."}`,
+        });
+      }
+    } catch (error) {
       onActionComplete({
         type: "error",
-        text: `${result.error.code ?? "ERROR"}: ${result.error.message ?? "Failed to promote."}`,
+        text: error instanceof Error ? error.message : "Failed to promote.",
       });
+    } finally {
+      setIsSubmitting(false);
     }
-    setIsSubmitting(false);
   };
 
   return (

--- a/components/internal/SubmissionDetail.tsx
+++ b/components/internal/SubmissionDetail.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import ErrorBox from "@/components/internal/ErrorBox";
 import MediaPreviewGrid from "@/components/internal/MediaPreviewGrid";
+import SubmissionPayloadSummary from "@/components/internal/SubmissionPayloadSummary";
 import StatusBadge from "@/components/internal/StatusBadge";
 import SubmissionActions from "@/components/internal/SubmissionActions";
 import {
@@ -227,8 +228,11 @@ export default function SubmissionDetailCard({ submissionId }: { submissionId: s
       </div>
 
       <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
-        <h2 className="text-sm font-semibold text-gray-800">Normalized payload</h2>
-        <details className="mt-3 rounded-md border border-gray-100 bg-gray-50 p-3">
+        <h2 className="text-sm font-semibold text-gray-800">Payload summary</h2>
+        <div className="mt-4">
+          <SubmissionPayloadSummary payload={submission.payload} />
+        </div>
+        <details className="mt-4 rounded-md border border-gray-100 bg-gray-50 p-3">
           <summary className="cursor-pointer text-sm font-semibold text-gray-700">View payload JSON</summary>
           <pre className="mt-3 max-h-96 overflow-auto text-xs text-gray-700">
             {JSON.stringify(submission.payload, null, 2)}

--- a/components/internal/SubmissionPayloadSummary.tsx
+++ b/components/internal/SubmissionPayloadSummary.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+type PayloadValue = string | number | boolean | null | undefined | PayloadValue[] | Record<string, unknown>;
+
+const LABELS: Record<string, string> = {
+  verificationRequest: "Verification request",
+  kind: "Kind",
+  name: "Business name",
+  placeName: "Place name",
+  placeId: "Place ID",
+  country: "Country",
+  city: "City",
+  address: "Address",
+  category: "Category",
+  acceptedChains: "Accepted chains",
+  ownerVerification: "Owner verification",
+  ownerVerificationDomain: "Owner verification domain",
+  ownerVerificationWorkEmail: "Owner verification work email",
+  paymentUrl: "Payment URL",
+  paymentNote: "Payment note",
+  reportAction: "Report action",
+  reportReason: "Report reason",
+  reportDetails: "Report details",
+  desiredStatus: "Desired status",
+  communityEvidenceUrls: "Community evidence URLs",
+  notes: "Notes",
+  notesForAdmin: "Notes for admin",
+  amenities: "Amenities",
+  amenitiesNotes: "Amenities notes",
+  website: "Website",
+  twitter: "Twitter / X",
+  instagram: "Instagram",
+  facebook: "Facebook",
+  role: "Role",
+  submitterName: "Submitter name",
+  contactName: "Contact name",
+  contactEmail: "Contact email",
+  lat: "Latitude",
+  lng: "Longitude",
+};
+
+const ORDER = [
+  "verificationRequest",
+  "kind",
+  "name",
+  "placeName",
+  "placeId",
+  "country",
+  "city",
+  "address",
+  "category",
+  "acceptedChains",
+  "ownerVerification",
+  "ownerVerificationDomain",
+  "ownerVerificationWorkEmail",
+  "paymentUrl",
+  "paymentNote",
+  "reportAction",
+  "reportReason",
+  "reportDetails",
+  "desiredStatus",
+  "amenities",
+  "amenitiesNotes",
+  "website",
+  "twitter",
+  "instagram",
+  "facebook",
+  "role",
+  "submitterName",
+  "contactName",
+  "contactEmail",
+  "notes",
+  "notesForAdmin",
+  "lat",
+  "lng",
+  "communityEvidenceUrls",
+];
+
+const isUrl = (value: string) => value.startsWith("http://") || value.startsWith("https://");
+
+const formatValue = (value: PayloadValue): string => {
+  if (value === null || value === undefined || value === "") return "—";
+  if (Array.isArray(value)) return value.length ? value.map((entry) => formatValue(entry)).join(", ") : "—";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "[object]";
+    }
+  }
+  return String(value);
+};
+
+const getEvidenceUrls = (payload: Record<string, unknown>) => {
+  const candidates = [
+    payload.communityEvidenceUrls,
+    payload.reportEvidenceUrls,
+    payload.evidenceUrls,
+  ];
+  const urls = candidates.flatMap((value) =>
+    Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [],
+  );
+  return [...new Set(urls.map((entry) => entry.trim()).filter(Boolean))];
+};
+
+const buildEntries = (payload: Record<string, unknown>) => {
+  const entries: Array<[string, PayloadValue]> = [];
+  const seen = new Set<string>();
+
+  ORDER.forEach((key) => {
+    if (key in payload) {
+      entries.push([key, payload[key] as PayloadValue]);
+      seen.add(key);
+    }
+  });
+
+  Object.keys(payload)
+    .filter((key) => !seen.has(key))
+    .sort()
+    .forEach((key) => {
+      entries.push([key, payload[key] as PayloadValue]);
+    });
+
+  return entries;
+};
+
+export default function SubmissionPayloadSummary({ payload }: { payload?: Record<string, unknown> }) {
+  if (!payload || Object.keys(payload).length === 0) {
+    return <p className="text-sm text-gray-500">No payload data available.</p>;
+  }
+
+  const entries = buildEntries(payload);
+  const evidenceUrls = getEvidenceUrls(payload);
+
+  return (
+    <div className="space-y-6">
+      <dl className="grid gap-3 text-sm text-gray-700 sm:grid-cols-2">
+        {entries.map(([key, value]) => {
+          const label = LABELS[key] ?? key.replace(/([a-z])([A-Z])/g, "$1 $2");
+          if (typeof value === "string" && isUrl(value)) {
+            return (
+              <div key={key} className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
+                <dt className="text-xs font-semibold uppercase text-gray-500">{label}</dt>
+                <dd className="mt-1 break-all">
+                  <a className="text-blue-600 hover:text-blue-700" href={value} target="_blank" rel="noreferrer">
+                    {value}
+                  </a>
+                </dd>
+              </div>
+            );
+          }
+          return (
+            <div key={key} className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2">
+              <dt className="text-xs font-semibold uppercase text-gray-500">{label}</dt>
+              <dd className="mt-1 break-words">{formatValue(value)}</dd>
+            </div>
+          );
+        })}
+      </dl>
+
+      <div>
+        <h3 className="text-sm font-semibold text-gray-800">Evidence URLs</h3>
+        {evidenceUrls.length ? (
+          <ul className="mt-2 space-y-1 text-sm text-blue-700">
+            {evidenceUrls.map((url) => (
+              <li key={url} className="break-all">
+                <a href={url} target="_blank" rel="noreferrer" className="hover:text-blue-800">
+                  {url}
+                </a>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-sm text-gray-500">No evidence URLs provided.</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a human-friendly view of submission payloads and evidence URLs in the internal review UI so reviewers can inspect submission data without digging into raw JSON. 
- Prevent double-submits and infinite spinners during approve/reject/promote flows and ensure error messages surface correctly.

### Description
- Add `components/internal/SubmissionPayloadSummary.tsx` to render a prioritized, labeled summary of payload fields and collect evidence URLs for clickable links.  
- Embed the new payload summary into the internal submission detail view (`components/internal/SubmissionDetail.tsx`) while keeping the raw JSON expandable.  
- Harden approve/reject/promote handlers in `components/internal/SubmissionActions.tsx` to early-return on concurrent submits, wrap network calls in `try/catch/finally`, and always clear `isSubmitting` in `finally` to avoid stuck spinners and show thrown error messages.  
- Existing media preview (`MediaPreviewGrid`) remains the image gallery for `gallery`/`proof`/`evidence` kinds and is used by the detail page for image previews.

### Testing
- Attempted a headless UI capture using Playwright to hit `/internal/submissions`, but navigation failed with `ERR_EMPTY_RESPONSE` because the local dev server was not running, so the UI interaction test did not complete.  
- No automated unit or integration tests were executed against the modified components in this rollout; TypeScript builds and runtime checks should be performed in CI or locally with the dev server running to validate approve/reject flows and image previews.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c68600de883289a0fd5d44bf97422)