### PR TITLE
Add gallery selection for submission promotion (publish only selected gallery media)

### DIFF
--- a/app/api/internal/submissions/[id]/promote/route.ts
+++ b/app/api/internal/submissions/[id]/promote/route.ts
@@ -20,12 +20,24 @@ export async function POST(request: Request, { params }: { params: { id: string 
   const { id } = params;
   const route = "api_internal_submissions_promote";
   const actor = resolveActorFromRequest(request, "internal");
+  let galleryMediaIds: string[] | undefined;
+
+  try {
+    const payload = await request.json();
+    if (payload && typeof payload === "object" && Array.isArray(payload.galleryMediaIds)) {
+      galleryMediaIds = payload.galleryMediaIds.filter((item: unknown) => typeof item === "string");
+    }
+  } catch {
+    galleryMediaIds = undefined;
+  }
 
   let client: Awaited<ReturnType<typeof getDbClient>> | null = null;
 
   try {
     client = await getDbClient(route);
-    const result = await promoteSubmission(route, client, actor, id);
+    const result = await promoteSubmission(route, client, actor, id, {
+      galleryMediaIds,
+    });
 
     if (!result.ok) {
       return NextResponse.json(result.body, { status: result.status });

--- a/components/internal/MediaPreviewGrid.tsx
+++ b/components/internal/MediaPreviewGrid.tsx
@@ -17,17 +17,26 @@ const groupByKind = (media: SubmissionMedia[]) => {
   }, {});
 };
 
+type MediaPreviewGridProps = {
+  submissionId: string;
+  media: SubmissionMedia[];
+  selectableKind?: string;
+  selectedMediaIds?: string[];
+  onToggleSelection?: (mediaId: string) => void;
+};
+
 export default function MediaPreviewGrid({
   submissionId,
   media,
-}: {
-  submissionId: string;
-  media: SubmissionMedia[];
-}) {
+  selectableKind,
+  selectedMediaIds = [],
+  onToggleSelection,
+}: MediaPreviewGridProps) {
   if (!media.length) {
     return <p className="text-sm text-gray-500">No media uploaded.</p>;
   }
 
+  const selectedSet = new Set(selectedMediaIds);
   const groups = groupByKind(media);
 
   return (
@@ -38,26 +47,42 @@ export default function MediaPreviewGrid({
           <div className="mt-3 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {items.map((item) => {
               const src = buildSubmissionMediaUrl(submissionId, item.kind, item.mediaId);
+              const isSelectable = selectableKind === item.kind && onToggleSelection;
+              const isSelected = selectedSet.has(item.mediaId);
               return (
-                <a
+                <div
                   key={`${item.kind}-${item.mediaId}`}
-                  className="group overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
-                  href={src}
-                  target="_blank"
-                  rel="noreferrer"
+                  className={`group overflow-hidden rounded-lg border bg-white shadow-sm ${
+                    isSelectable && isSelected ? "border-emerald-300 ring-1 ring-emerald-200" : "border-gray-200"
+                  }`}
                 >
-                  <div className="aspect-video w-full overflow-hidden bg-gray-50">
-                    <img
-                      src={src}
-                      alt={`${item.kind} ${item.mediaId}`}
-                      className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
-                    />
-                  </div>
-                  <div className="space-y-1 p-3 text-xs text-gray-600">
-                    <p className="font-semibold text-gray-700">{KIND_LABELS[item.kind] ?? item.kind}</p>
+                  <a href={src} target="_blank" rel="noreferrer">
+                    <div className="aspect-video w-full overflow-hidden bg-gray-50">
+                      <img
+                        src={src}
+                        alt={`${item.kind} ${item.mediaId}`}
+                        className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+                      />
+                    </div>
+                  </a>
+                  <div className="space-y-2 p-3 text-xs text-gray-600">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-semibold text-gray-700">{KIND_LABELS[item.kind] ?? item.kind}</p>
+                      {isSelectable ? (
+                        <label className="flex items-center gap-2 text-xs font-semibold text-emerald-700">
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500"
+                            checked={isSelected}
+                            onChange={() => onToggleSelection(item.mediaId)}
+                          />
+                          Promote
+                        </label>
+                      ) : null}
+                    </div>
                     <p className="break-all">{item.mediaId}</p>
                   </div>
-                </a>
+                </div>
               );
             })}
           </div>

--- a/components/internal/SubmissionActions.tsx
+++ b/components/internal/SubmissionActions.tsx
@@ -7,11 +7,17 @@ import { approveSubmission, promoteSubmission, rejectSubmission } from "@/lib/in
 
 type SubmissionActionsProps = {
   submission: SubmissionDetail;
+  selectedGalleryMediaIds: string[];
   onActionComplete: (message: { type: "success" | "error"; text: string; placeId?: string | null }) => void;
   onRefresh: () => void;
 };
 
-export default function SubmissionActions({ submission, onActionComplete, onRefresh }: SubmissionActionsProps) {
+export default function SubmissionActions({
+  submission,
+  selectedGalleryMediaIds,
+  onActionComplete,
+  onRefresh,
+}: SubmissionActionsProps) {
   const [reviewNote, setReviewNote] = useState("");
   const [rejectReason, setRejectReason] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -79,7 +85,7 @@ export default function SubmissionActions({ submission, onActionComplete, onRefr
     if (isSubmitting) return;
     setIsSubmitting(true);
     try {
-      const result = await promoteSubmission(submission.id);
+      const result = await promoteSubmission(submission.id, selectedGalleryMediaIds);
       if (result.ok) {
         onActionComplete({
           type: "success",

--- a/lib/internal/submissions.ts
+++ b/lib/internal/submissions.ts
@@ -169,7 +169,9 @@ export const rejectSubmission = async (
     body: JSON.stringify({ reject_reason: reason, ...(reviewNote ? { review_note: reviewNote } : {}) }),
   });
 
-export const promoteSubmission = async (submissionId: string) =>
+export const promoteSubmission = async (submissionId: string, galleryMediaIds: string[]) =>
   fetchJson<SubmissionActionResponse>(`/api/internal/submissions/${submissionId}/promote`, {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ galleryMediaIds }),
   });


### PR DESCRIPTION
### Motivation
- Implement a clear policy for how submitted gallery images are used when a submission is promoted so only chosen gallery items become public place media and internal-only items (proof/evidence) remain private.
- Ensure promote can only be performed for promotable kinds (`owner` / `community`) and only when `status === "approved"` while rejecting non-promotable kinds such as `report`.

### Description
- Add selectable gallery UI and selection state in the internal submission detail view by extending `MediaPreviewGrid` with `selectableKind`, `selectedMediaIds` and `onToggleSelection`, and initializing selection in `components/internal/SubmissionDetail.tsx`.
- Wire the selection into the promote action by passing `selectedGalleryMediaIds` from `SubmissionDetail` → `SubmissionActions`, and update the internal client call `lib/internal/submissions.ts` to POST `{ galleryMediaIds }` to the promote endpoint.
- Update the promote API to parse `galleryMediaIds` from request JSON in `app/api/internal/submissions/[id]/promote/route.ts` and forward it to `promoteSubmission`.
- Extend server-side promotion logic in `lib/submissions/promote.ts` to load available `submission_media` rows for kind `gallery`, validate requested gallery IDs against available media (rollback and return `400` on invalid ids), and sync only the selected gallery items into the public `media` table for the place while leaving proof/evidence out of any public media sync.
- The promotion validation and behavior preserve existing constraints: `promoteKindAllowed` remains `owner|community`, promotion requires `status === 'approved'`, and already-promoted submissions are rejected as before.

### Testing
- No automated tests were executed as part of this change.
- The change was implemented and committed; manual UI/runtime verification is expected in an integrated environment with a DB to validate `media` table sync and ensure `proof`/`evidence` do not appear in public place media.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c69dc70c48328a13ca191ade26db3)