### PR TITLE
Restore place metadata fields across DB, API, and drawer UI

### DIFF
--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -162,6 +162,9 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
     const canShowLinks = !isRestricted && socialLinks.length > 0;
     const canShowNavigation = !isRestricted && navigationLinks.length > 0;
     const canShowFullAddress = !isRestricted && Boolean(fullAddress);
+    const amenities = place.amenities ?? [];
+    const paymentNote = place.paymentNote;
+    const submitter = place.submitterName ?? place.updatedAt;
 
     return (
       <div
@@ -283,10 +286,37 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
               </section>
             )}
 
+            {!isRestricted && paymentNote && (
+              <section className="cpm-drawer__section">
+                <h3 className="cpm-drawer__section-title">Payment note</h3>
+                <p className="cpm-drawer__body">{paymentNote}</p>
+              </section>
+            )}
+
+            {!isRestricted && amenities.length > 0 && (
+              <section className="cpm-drawer__section">
+                <h3 className="cpm-drawer__section-title">Amenities</h3>
+                <div className="cpm-drawer__pill-row">
+                  {amenities.map((item) => (
+                    <span key={item} className="cpm-drawer__pill">
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </section>
+            )}
+
             {canShowFullAddress && (
               <section className="cpm-drawer__section">
                 <h3 className="cpm-drawer__section-title">Address</h3>
                 <p className="cpm-drawer__body">{fullAddress}</p>
+              </section>
+            )}
+
+            {!isRestricted && submitter && (
+              <section className="cpm-drawer__section">
+                <h3 className="cpm-drawer__section-title">Submitted by</h3>
+                <p className="cpm-drawer__muted">{submitter}</p>
               </section>
             )}
           </div>

--- a/migrations/compat_places_fields.sql
+++ b/migrations/compat_places_fields.sql
@@ -1,0 +1,9 @@
+-- Ensure places can store promoted submission metadata
+ALTER TABLE IF EXISTS public.places
+  ADD COLUMN IF NOT EXISTS payment_note TEXT;
+
+ALTER TABLE IF EXISTS public.places
+  ADD COLUMN IF NOT EXISTS amenities TEXT[];
+
+ALTER TABLE IF EXISTS public.places
+  ADD COLUMN IF NOT EXISTS submitter_name TEXT;


### PR DESCRIPTION
### Motivation

- Ensure promoted submissions fully populate `places` with the missing metadata columns (`payment_note`, `amenities`, `submitter_name`) so DB, API, and UI meet spec.
- Prevent runtime errors and inconsistent UX caused by these fields being absent downstream of promotion.

### Description

- Add a compatibility migration `migrations/compat_places_fields.sql` that adds `payment_note TEXT`, `amenities TEXT[]`, and `submitter_name TEXT` to `public.places`.
- Map promoted submission payload fields into `places` in `lib/submissions/promote.ts` by persisting `paymentNote`, `amenities`, and `submitterName` on `INSERT`/`UPDATE` for places.
- Extend the place detail API in `app/api/places/[id]/route.ts` to detect the new columns, normalize `amenities`, and return `paymentNote` and `submitterName` with safe fallbacks to JSON data.
- Surface the new fields in the desktop drawer UI in `components/map/Drawer.tsx` by rendering `Payment note`, `Amenities`, and `Submitted by` sections (the mobile sheet already displayed these fields).

### Testing

- Started the dev server and ran an automated Playwright smoke script that loaded a sample place and captured a drawer screenshot, confirming `Payment note`, `Amenities`, and `Submitted by` are visible in the desktop drawer (smoke succeeded).
- Attempted a production build via `npm run build`; Typecheck/compile passed but the build failed due to existing React hook lint errors and image lint warnings in unrelated components (`components/internal/SubmissionDetail.tsx` etc.), so the build is currently failing.
- Added the migration file `migrations/compat_places_fields.sql`; apply it against your DB with the repo's tooling (for example `tsx scripts/db_apply_sql.ts migrations/compat_places_fields.sql`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c6d451b3c8328aea913338c5282a1)