### PR TITLE
Implement retention cleanup for submission_media (dry-run + execute)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ npm run dev
 ## Map Layout
 
 - [Map layering rules (click-through prevention)](docs/map-layering.md)
+
+## Operations: Retention (submission media)
+
+Manual retention for submission media (proof/evidence expiry + unadopted gallery expiry):
+
+```bash
+# dry-run (list candidates)
+node --import tsx scripts/retention/submissionMedia.ts --dry-run
+
+# execute deletions
+node --import tsx scripts/retention/submissionMedia.ts --execute
+```
+
+Defaults are proof=90 days, evidence=180 days, gallery=365 days. Override with
+`RETENTION_PROOF_DAYS`, `RETENTION_EVIDENCE_DAYS`, `RETENTION_GALLERY_DAYS`, or
+`--proof-days`, `--evidence-days`, `--gallery-days`.

--- a/lib/db/retention.ts
+++ b/lib/db/retention.ts
@@ -1,0 +1,143 @@
+import { dbQuery } from "@/lib/db";
+import { hasColumn, tableExists } from "@/lib/internal-submissions";
+import type { SubmissionMediaKind } from "@/lib/storage/r2";
+
+type SubmissionMediaRetentionRow = {
+  id: number;
+  submissionId: string;
+  kind: SubmissionMediaKind;
+  mediaId: string | null;
+  r2Key: string | null;
+  url: string | null;
+  createdAt: string | null;
+  status: string | null;
+  publishedPlaceId: string | null;
+};
+
+type SubmissionMediaColumns = {
+  mediaId: boolean;
+  r2Key: boolean;
+  url: boolean;
+  createdAt: boolean;
+};
+
+const loadSubmissionMediaColumns = async (route: string) => {
+  const result = await dbQuery<{ column_name: string }>(
+    `
+      SELECT column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'submission_media'
+        AND column_name = ANY($1::text[])
+    `,
+    [["media_id", "r2_key", "url", "created_at"]],
+    { route },
+  );
+
+  const columns = new Set(result.rows.map((row) => row.column_name));
+  return {
+    mediaId: columns.has("media_id"),
+    r2Key: columns.has("r2_key"),
+    url: columns.has("url"),
+    createdAt: columns.has("created_at"),
+  };
+};
+
+const buildAdoptedClause = (hasStatus: boolean, hasPublishedPlaceId: boolean) => {
+  const clauses: string[] = [];
+  if (hasStatus) {
+    clauses.push("COALESCE(s.status = 'approved', false)");
+  }
+  if (hasPublishedPlaceId) {
+    clauses.push("COALESCE(s.published_place_id IS NOT NULL, false)");
+  }
+  if (!clauses.length) return null;
+  return clauses.length === 1 ? clauses[0] : `(${clauses.join(" OR ")})`;
+};
+
+export const findSubmissionMediaRetentionCandidates = async (params: {
+  route: string;
+  kind: SubmissionMediaKind;
+  before: Date;
+  requireUnadoptedGallery?: boolean;
+}) => {
+  const { route, kind, before, requireUnadoptedGallery } = params;
+  const warnings: string[] = [];
+
+  const hasSubmissionMediaTable = await tableExists(route, "submission_media");
+  if (!hasSubmissionMediaTable) {
+    warnings.push("submission_media table is missing");
+    return { rows: [] as SubmissionMediaRetentionRow[], warnings };
+  }
+
+  const columns = await loadSubmissionMediaColumns(route);
+  if (!columns.createdAt) {
+    warnings.push("submission_media.created_at column is missing");
+    return { rows: [] as SubmissionMediaRetentionRow[], warnings };
+  }
+
+  let joinClause = "";
+  let adoptedClause: string | null = null;
+  if (requireUnadoptedGallery) {
+    const hasSubmissionsTable = await tableExists(route, "submissions");
+    if (!hasSubmissionsTable) {
+      warnings.push("submissions table is missing; skipping gallery retention");
+      return { rows: [] as SubmissionMediaRetentionRow[], warnings };
+    }
+    const hasStatus = await hasColumn(route, "submissions", "status");
+    const hasPublishedPlaceId = await hasColumn(route, "submissions", "published_place_id");
+    adoptedClause = buildAdoptedClause(hasStatus, hasPublishedPlaceId);
+    if (!adoptedClause) {
+      warnings.push("submissions adoption columns missing; skipping gallery retention");
+      return { rows: [] as SubmissionMediaRetentionRow[], warnings };
+    }
+    joinClause = "LEFT JOIN submissions s ON s.id = sm.submission_id";
+  }
+
+  const filters = ["sm.kind = $1", "sm.created_at < $2"];
+  if (adoptedClause) {
+    filters.push(`NOT (${adoptedClause})`);
+  }
+
+  const { rows } = await dbQuery<SubmissionMediaRetentionRow>(
+    `
+      SELECT sm.id,
+        sm.submission_id AS "submissionId",
+        sm.kind,
+        ${columns.mediaId ? 'sm.media_id AS "mediaId",' : 'NULL::text AS "mediaId",'}
+        ${columns.r2Key ? 'sm.r2_key AS "r2Key",' : 'NULL::text AS "r2Key",'}
+        ${columns.url ? 'sm.url AS "url",' : 'NULL::text AS "url",'}
+        ${columns.createdAt ? 'sm.created_at AS "createdAt",' : 'NULL::timestamptz AS "createdAt",'}
+        ${adoptedClause ? 's.status AS "status",' : 'NULL::text AS "status",'}
+        ${adoptedClause ? 's.published_place_id AS "publishedPlaceId"' : 'NULL::text AS "publishedPlaceId"'}
+      FROM submission_media sm
+      ${joinClause}
+      WHERE ${filters.join(" AND ")}
+      ORDER BY sm.created_at ASC
+    `,
+    [kind, before.toISOString()],
+    { route },
+  );
+
+  return { rows, warnings };
+};
+
+export const deleteSubmissionMediaRetentionRows = async (params: {
+  route: string;
+  ids: number[];
+}) => {
+  const { route, ids } = params;
+  if (!ids.length) return;
+
+  await dbQuery(
+    `
+      DELETE FROM submission_media
+      WHERE id = ANY($1::bigint[])
+    `,
+    [ids],
+    { route },
+  );
+};
+
+export type { SubmissionMediaRetentionRow };
+

--- a/lib/r2/submissionMediaRetention.ts
+++ b/lib/r2/submissionMediaRetention.ts
@@ -1,0 +1,35 @@
+import type { SubmissionMediaKind } from "@/lib/storage/r2";
+import { buildSubmissionMediaKey } from "@/lib/storage/r2";
+
+type SubmissionMediaIdentifier = {
+  submissionId: string;
+  kind: SubmissionMediaKind;
+  mediaId?: string | null;
+  r2Key?: string | null;
+  url?: string | null;
+};
+
+const extractMediaIdFromKey = (key?: string | null) => {
+  if (!key) return null;
+  const match = key.match(/\/([^/]+)\.webp$/);
+  return match ? match[1] : key;
+};
+
+const extractMediaIdFromUrl = (url?: string | null) => {
+  if (!url) return null;
+  const match = url.match(/\/([^/]+)$/);
+  return match ? match[1] : url;
+};
+
+export const resolveSubmissionMediaId = (item: SubmissionMediaIdentifier) =>
+  item.mediaId ?? extractMediaIdFromKey(item.r2Key) ?? extractMediaIdFromUrl(item.url);
+
+export const resolveSubmissionMediaKey = (item: SubmissionMediaIdentifier) => {
+  if (item.r2Key) return item.r2Key;
+
+  const mediaId = resolveSubmissionMediaId(item);
+  if (!mediaId) return null;
+
+  return buildSubmissionMediaKey(item.submissionId, item.kind, mediaId);
+};
+

--- a/scripts/retention/submissionMedia.ts
+++ b/scripts/retention/submissionMedia.ts
@@ -1,0 +1,165 @@
+import { hasDatabaseUrl } from "@/lib/db";
+import {
+  deleteSubmissionMediaRetentionRows,
+  findSubmissionMediaRetentionCandidates,
+  type SubmissionMediaRetentionRow,
+} from "@/lib/db/retention";
+import { resolveSubmissionMediaId, resolveSubmissionMediaKey } from "@/lib/r2/submissionMediaRetention";
+import { deleteSubmissionMediaObject, type SubmissionMediaKind } from "@/lib/storage/r2";
+
+type RetentionConfig = {
+  kind: SubmissionMediaKind;
+  days: number;
+  requireUnadoptedGallery?: boolean;
+};
+
+const DEFAULT_RETENTION_DAYS: Record<SubmissionMediaKind, number> = {
+  proof: 90,
+  evidence: 180,
+  gallery: 365,
+};
+
+const parseBooleanFlag = (args: string[], flag: string) => args.includes(flag);
+
+const parseNumberOption = (args: string[], flag: string) => {
+  const index = args.indexOf(flag);
+  if (index === -1) return null;
+  const value = args[index + 1];
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseKinds = (args: string[]) => {
+  const index = args.indexOf("--kind");
+  if (index === -1) return null;
+  const raw = args[index + 1];
+  if (!raw) return null;
+  return raw.split(",").map((kind) => kind.trim()).filter(Boolean) as SubmissionMediaKind[];
+};
+
+const renderCandidate = (row: SubmissionMediaRetentionRow) => ({
+  id: row.id,
+  submissionId: row.submissionId,
+  kind: row.kind,
+  createdAt: row.createdAt,
+  mediaId: resolveSubmissionMediaId(row),
+  r2Key: row.r2Key,
+  url: row.url,
+  status: row.status,
+  publishedPlaceId: row.publishedPlaceId,
+});
+
+const buildConfigs = (args: string[]): RetentionConfig[] => {
+  const proofDays = parseNumberOption(args, "--proof-days") ?? Number(process.env.RETENTION_PROOF_DAYS);
+  const evidenceDays =
+    parseNumberOption(args, "--evidence-days") ?? Number(process.env.RETENTION_EVIDENCE_DAYS);
+  const galleryDays =
+    parseNumberOption(args, "--gallery-days") ?? Number(process.env.RETENTION_GALLERY_DAYS);
+
+  return [
+    {
+      kind: "proof",
+      days: Number.isFinite(proofDays) ? proofDays : DEFAULT_RETENTION_DAYS.proof,
+    },
+    {
+      kind: "evidence",
+      days: Number.isFinite(evidenceDays) ? evidenceDays : DEFAULT_RETENTION_DAYS.evidence,
+    },
+    {
+      kind: "gallery",
+      days: Number.isFinite(galleryDays) ? galleryDays : DEFAULT_RETENTION_DAYS.gallery,
+      requireUnadoptedGallery: true,
+    },
+  ];
+};
+
+const buildCutoff = (days: number) => new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+
+const runRetention = async () => {
+  const args = process.argv.slice(2);
+  const isDryRun = !parseBooleanFlag(args, "--execute");
+  const route = "retention_submission_media";
+
+  if (!hasDatabaseUrl()) {
+    console.error("[retention] DATABASE_URL is not configured");
+    process.exitCode = 1;
+    return;
+  }
+
+  const configuredKinds = parseKinds(args);
+  const configs = buildConfigs(args).filter((config) =>
+    configuredKinds ? configuredKinds.includes(config.kind) : true,
+  );
+
+  console.log(
+    `[retention] mode=${isDryRun ? "dry-run" : "execute"} kinds=${configs
+      .map((config) => config.kind)
+      .join(",")}`,
+  );
+
+  for (const config of configs) {
+    const cutoff = buildCutoff(config.days);
+    const { rows, warnings } = await findSubmissionMediaRetentionCandidates({
+      route,
+      kind: config.kind,
+      before: cutoff,
+      requireUnadoptedGallery: config.requireUnadoptedGallery,
+    });
+
+    warnings.forEach((warning) => {
+      console.warn(`[retention] ${config.kind}: ${warning}`);
+    });
+
+    console.log(
+      `[retention] ${config.kind}: cutoff=${cutoff.toISOString()} candidates=${rows.length}`,
+    );
+
+    if (!rows.length) {
+      continue;
+    }
+
+    if (isDryRun) {
+      rows.forEach((row) => {
+        console.log(`[retention] ${config.kind} candidate`, renderCandidate(row));
+      });
+      continue;
+    }
+
+    const deletedIds: number[] = [];
+    for (const row of rows) {
+      const mediaId = resolveSubmissionMediaId(row);
+      const key = resolveSubmissionMediaKey(row);
+      if (!key || !mediaId) {
+        console.warn(
+          `[retention] ${config.kind} skip id=${row.id} submission=${row.submissionId} missing key`,
+        );
+        continue;
+      }
+
+      try {
+        await deleteSubmissionMediaObject(key);
+        deletedIds.push(row.id);
+        console.log(
+          `[retention] ${config.kind} deleted r2 id=${row.id} submission=${row.submissionId} media=${mediaId}`,
+        );
+      } catch (error) {
+        console.error(
+          `[retention] ${config.kind} failed r2 delete id=${row.id} submission=${row.submissionId}`,
+          error,
+        );
+      }
+    }
+
+    if (deletedIds.length) {
+      await deleteSubmissionMediaRetentionRows({ route, ids: deletedIds });
+      console.log(`[retention] ${config.kind} deleted db rows=${deletedIds.length}`);
+    }
+  }
+};
+
+runRetention().catch((error) => {
+  console.error("[retention] failed", error);
+  process.exitCode = 1;
+});
+


### PR DESCRIPTION
### Motivation
- Implement retention behavior to remove expired `submission_media` objects from R2 and the DB to support free-tier operation and reduce storage/leakage risk.
- Provide a simple manual tool for operators to list candidates (dry-run) and perform deletions (execute), including special handling for unadopted `gallery` items.

### Description
- Add DB helpers in `lib/db/retention.ts` to detect expired `submission_media` rows, optionally filter out adopted gallery items, and delete rows by id via `findSubmissionMediaRetentionCandidates` and `deleteSubmissionMediaRetentionRows`.
- Add R2 key/id resolution helpers in `lib/r2/submissionMediaRetention.ts` with `resolveSubmissionMediaId` and `resolveSubmissionMediaKey` to derive keys from `media_id`, `r2_key`, or `url`.
- Add the retention CLI script `scripts/retention/submissionMedia.ts` that supports dry-run (`--dry-run` default) and execute (`--execute`) modes, per-kind retention days with env/flag overrides, logs candidates and deletion results, and calls `deleteSubmissionMediaObject` to remove R2 objects before deleting DB rows.
- Document usage and default retention periods in `README.md` with example commands and environment/flag overrides.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c83ef78b083289c4c282f38de0295)