### PR TITLE
Add submit audit harness and reporting (pnpm audit:submit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ artifacts/
 db-schema-*/
 docs.zip
 .DS_Store
+docs/audit/runs/*
+!docs/audit/runs/.gitkeep

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "db:check": "node scripts/db-check.mjs",
     "validate:data": "node --import tsx scripts/validate_data.ts",
     "test:map-smoke": "playwright test tests/map-smoke.spec.ts",
-    "test:map-smoke:headed": "playwright test tests/map-smoke.spec.ts --headed"
+    "test:map-smoke:headed": "playwright test tests/map-smoke.spec.ts --headed",
+    "audit:submit": "tsx scripts/audit/run-submit-audit.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.862.0",

--- a/scripts/audit/report.ts
+++ b/scripts/audit/report.ts
@@ -1,0 +1,225 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export type AuditCheckStatus = "OK" | "NG" | "WARN" | "INFO";
+
+export type AuditCheckItem = {
+  id: string;
+  title: string;
+  status: AuditCheckStatus;
+  details?: string[];
+  evidence?: string[];
+};
+
+export type AuditCheckGroup = {
+  id: string;
+  title: string;
+  items: AuditCheckItem[];
+};
+
+export type PlaywrightSummary = {
+  status: "success" | "failed" | "skipped";
+  exitCode: number | null;
+};
+
+export type AuditSummary = {
+  ok: number;
+  ng: number;
+  warn: number;
+  info: number;
+  total: number;
+};
+
+export type AuditReport = {
+  runId: string;
+  baseUrl: string;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  playwright: PlaywrightSummary;
+  summary: AuditSummary;
+  groups: AuditCheckGroup[];
+};
+
+const toStatusCounts = (groups: AuditCheckGroup[]): AuditSummary => {
+  const summary = { ok: 0, ng: 0, warn: 0, info: 0, total: 0 };
+  for (const group of groups) {
+    for (const item of group.items) {
+      summary.total += 1;
+      if (item.status === "OK") summary.ok += 1;
+      if (item.status === "NG") summary.ng += 1;
+      if (item.status === "WARN") summary.warn += 1;
+      if (item.status === "INFO") summary.info += 1;
+    }
+  }
+  return summary;
+};
+
+const fileExists = async (filePath: string): Promise<boolean> => {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const checkPaths = async (rootDir: string, targets: string[]) => {
+  const missing: string[] = [];
+  for (const target of targets) {
+    const fullPath = path.join(rootDir, target);
+    if (!(await fileExists(fullPath))) {
+      missing.push(target);
+    }
+  }
+  return missing;
+};
+
+export const collectSubmitAuditChecks = async (rootDir: string): Promise<AuditCheckGroup[]> => {
+  const submitRoutes = [
+    "app/submit/page.tsx",
+    "app/submit/done/page.tsx",
+    "app/submit/owner/page.tsx",
+    "app/submit/owner/confirm/page.tsx",
+    "app/submit/community/page.tsx",
+    "app/submit/community/confirm/page.tsx",
+    "app/submit/report/page.tsx",
+    "app/submit/report/confirm/page.tsx",
+  ];
+  const missingSubmitRoutes = await checkPaths(rootDir, submitRoutes);
+
+  const mediaRoutes = [
+    "app/api/media/submissions/[submissionId]/gallery/[mediaId]/route.ts",
+    "app/api/internal/media/submissions/[submissionId]/[kind]/[mediaId]/route.ts",
+  ];
+  const missingMediaRoutes = await checkPaths(rootDir, mediaRoutes);
+
+  const mappingDocs = [
+    "docs/audit/submit-db-map-checklist.md",
+    "docs/audit/submit-db-map-gaps.md",
+    "docs/audit/field-mapping-submit-db-api-ui.md",
+  ];
+  const missingMappingDocs = await checkPaths(rootDir, mappingDocs);
+
+  return [
+    {
+      id: "CHK-01",
+      title: "submit/DB/map checklist baseline",
+      items: [
+        {
+          id: "CHK-01-A",
+          title: "Submit route pages exist",
+          status: missingSubmitRoutes.length ? "NG" : "OK",
+          details: missingSubmitRoutes.length
+            ? ["Missing submit pages:", ...missingSubmitRoutes]
+            : ["All submit route pages are present."],
+        },
+      ],
+    },
+    {
+      id: "CHK-02",
+      title: "submit/db/map gap audit",
+      items: [
+        {
+          id: "CHK-02-A",
+          title: "Submission media delivery routes exist",
+          status: missingMediaRoutes.length ? "NG" : "OK",
+          details: missingMediaRoutes.length
+            ? ["Missing media routes:", ...missingMediaRoutes]
+            : ["All submission media routes are present."],
+        },
+      ],
+    },
+    {
+      id: "CHK-03",
+      title: "Submit field mapping coverage",
+      items: [
+        {
+          id: "CHK-03-A",
+          title: "Mapping documents are available",
+          status: missingMappingDocs.length ? "NG" : "OK",
+          details: missingMappingDocs.length
+            ? ["Missing mapping docs:", ...missingMappingDocs]
+            : ["All mapping documents are present."],
+        },
+      ],
+    },
+  ];
+};
+
+const formatGroupMarkdown = (group: AuditCheckGroup) => {
+  const lines: string[] = [];
+  lines.push(`## ${group.id}: ${group.title}`);
+  lines.push("");
+  for (const item of group.items) {
+    lines.push(`- **${item.id}** ${item.title} — ${item.status}`);
+    if (item.details?.length) {
+      for (const detail of item.details) {
+        lines.push(`  - ${detail}`);
+      }
+    }
+    if (item.evidence?.length) {
+      lines.push("  - Evidence:");
+      for (const evidence of item.evidence) {
+        lines.push(`    - ${evidence}`);
+      }
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+};
+
+export const buildSubmitAuditReport = (
+  baseUrl: string,
+  startedAt: Date,
+  finishedAt: Date,
+  playwright: PlaywrightSummary,
+  groups: AuditCheckGroup[],
+): AuditReport => {
+  const runId = startedAt.toISOString().replace(/[:.]/g, "-");
+  const summary = toStatusCounts(groups);
+  return {
+    runId,
+    baseUrl,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: finishedAt.getTime() - startedAt.getTime(),
+    playwright,
+    summary,
+    groups,
+  };
+};
+
+export const renderSubmitAuditMarkdown = (report: AuditReport): string => {
+  const lines: string[] = [];
+  lines.push(`# Submit Audit Report (${report.runId})`);
+  lines.push("");
+  lines.push(`- Base URL: ${report.baseUrl}`);
+  lines.push(`- Started: ${report.startedAt}`);
+  lines.push(`- Finished: ${report.finishedAt}`);
+  lines.push(`- Duration: ${report.durationMs} ms`);
+  lines.push(`- Playwright: ${report.playwright.status} (exit ${report.playwright.exitCode ?? "n/a"})`);
+  lines.push(
+    `- Summary: OK=${report.summary.ok} / NG=${report.summary.ng} / WARN=${report.summary.warn} / INFO=${report.summary.info} (total ${report.summary.total})`,
+  );
+  lines.push("");
+  for (const group of report.groups) {
+    lines.push(formatGroupMarkdown(group));
+  }
+  return lines.join("\n");
+};
+
+export const writeSubmitAuditReport = async (outputDir: string, report: AuditReport) => {
+  await fs.mkdir(outputDir, { recursive: true });
+  const latestMd = path.join(outputDir, "submit-audit-latest.md");
+  const latestJson = path.join(outputDir, "submit-audit-latest.json");
+  const stampMd = path.join(outputDir, `submit-audit-${report.runId}.md`);
+  const stampJson = path.join(outputDir, `submit-audit-${report.runId}.json`);
+  const markdown = renderSubmitAuditMarkdown(report);
+  const json = JSON.stringify(report, null, 2);
+
+  await fs.writeFile(latestMd, markdown, "utf8");
+  await fs.writeFile(latestJson, json, "utf8");
+  await fs.writeFile(stampMd, markdown, "utf8");
+  await fs.writeFile(stampJson, json, "utf8");
+};

--- a/scripts/audit/run-submit-audit.ts
+++ b/scripts/audit/run-submit-audit.ts
@@ -1,0 +1,70 @@
+import { spawn } from "child_process";
+import path from "path";
+
+import {
+  buildSubmitAuditReport,
+  collectSubmitAuditChecks,
+  writeSubmitAuditReport,
+} from "./report";
+
+const BASE_URL = (process.env.BASE_URL || "http://localhost:3000").replace(/\/$/, "");
+const OUTPUT_DIR = path.join(process.cwd(), "docs", "audit", "runs");
+
+const runCommand = (command: string, args: string[], env: NodeJS.ProcessEnv) =>
+  new Promise<number>((resolve) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      env,
+    });
+
+    child.on("exit", (code) => {
+      resolve(code ?? 1);
+    });
+
+    child.on("error", () => {
+      resolve(1);
+    });
+  });
+
+const runPlaywright = async () => {
+  const env = {
+    ...process.env,
+    BASE_URL,
+    PW_BASE_URL: BASE_URL,
+  };
+
+  const exitCode = await runCommand(
+    "pnpm",
+    ["exec", "playwright", "test", "tests/audit/submit-audit.spec.ts"],
+    env,
+  );
+
+  return {
+    status: exitCode === 0 ? "success" : "failed",
+    exitCode,
+  } as const;
+};
+
+const main = async () => {
+  const startedAt = new Date();
+  const playwright = await runPlaywright();
+  const groups = await collectSubmitAuditChecks(process.cwd());
+  const finishedAt = new Date();
+
+  const report = buildSubmitAuditReport(BASE_URL, startedAt, finishedAt, playwright, groups);
+  await writeSubmitAuditReport(OUTPUT_DIR, report);
+
+  console.log("\nSubmit audit summary:");
+  console.log(`Base URL: ${report.baseUrl}`);
+  console.log(
+    `Checks: OK=${report.summary.ok} NG=${report.summary.ng} WARN=${report.summary.warn} INFO=${report.summary.info}`,
+  );
+  console.log(`Playwright: ${report.playwright.status} (exit ${report.playwright.exitCode ?? "n/a"})`);
+  console.log(`Report: ${OUTPUT_DIR}/submit-audit-latest.md`);
+
+  const hasNg = report.summary.ng > 0;
+  const exitCode = hasNg || report.playwright.exitCode !== 0 ? 1 : 0;
+  process.exit(exitCode);
+};
+
+void main();

--- a/tests/audit/submit-audit.spec.ts
+++ b/tests/audit/submit-audit.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = (process.env.BASE_URL || process.env.PW_BASE_URL || "http://localhost:3000").replace(
+  /\/$/,
+  "",
+);
+
+const nowTag = () => new Date().toISOString().replace(/[:.]/g, "-");
+
+const buildOwnerPayload = () => ({
+  kind: "owner",
+  verificationRequest: "owner",
+  name: `Audit Owner Place ${nowTag()}`,
+  placeName: `Audit Owner Place ${nowTag()}`,
+  country: "US",
+  city: "New York",
+  address: "123 Example St",
+  category: "cafe",
+  acceptedChains: ["BTC"],
+  contactEmail: `audit-owner-${nowTag()}@example.com`,
+  contactName: "Audit Runner",
+  submitterName: "Audit Runner",
+  ownerVerification: "domain",
+  communityEvidenceUrls: ["https://example.com/owner-evidence-1"],
+  termsAccepted: true,
+});
+
+const buildCommunityPayload = () => ({
+  kind: "community",
+  verificationRequest: "community",
+  name: `Audit Community Place ${nowTag()}`,
+  placeName: `Audit Community Place ${nowTag()}`,
+  country: "US",
+  city: "Austin",
+  address: "456 Example Ave",
+  category: "restaurant",
+  acceptedChains: ["BTC", "USDT"],
+  contactEmail: `audit-community-${nowTag()}@example.com`,
+  contactName: "Audit Runner",
+  submitterName: "Audit Runner",
+  ownerVerification: "domain",
+  communityEvidenceUrls: ["https://example.com/community-1", "https://example.com/community-2"],
+  termsAccepted: true,
+});
+
+const buildReportPayload = () => ({
+  kind: "report",
+  verificationRequest: "report",
+  placeName: `Audit Report Place ${nowTag()}`,
+  reportReason: "Incorrect payment details",
+  reportAction: "hide",
+  reportDetails: "Audit runner created report submission.",
+});
+
+const submitPayload = async (request: any, payload: Record<string, unknown>) => {
+  const response = await request.post(`${BASE_URL}/api/submissions`, { data: payload });
+  expect(response.status(), `Unexpected status for payload kind ${payload.kind}`).toBeGreaterThanOrEqual(200);
+  expect(response.status(), `Unexpected status for payload kind ${payload.kind}`).toBeLessThan(500);
+};
+
+test.describe("Submit audit harness", () => {
+  test("create owner/community/report submissions", async ({ request }) => {
+    await submitPayload(request, buildOwnerPayload());
+    await submitPayload(request, buildCommunityPayload());
+    await submitPayload(request, buildReportPayload());
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide an automated audit harness to exercise the Submit flow end-to-end and produce machine-readable and human-readable audit reports without changing product behavior.  
- Enable a single developer-facing command `pnpm audit:submit` that runs Playwright to create submissions and a Node-based CHK collector to evaluate repo state and emit reports.  
- Persist audit outputs into `docs/audit/runs/` with both `submit-audit-latest.{md,json}` and timestamped copies so runs can be inspected later while keeping run artifacts out of commits.

### Description
- Added a report helper `scripts/audit/report.ts` that collects CHK groups, builds an `AuditReport`, renders Markdown/JSON, and writes `docs/audit/runs/submit-audit-latest.md`, `submit-audit-latest.json`, and timestamped copies.  
- Added an orchestrator `scripts/audit/run-submit-audit.ts` that runs Playwright (`tests/audit/submit-audit.spec.ts`) with `BASE_URL` (default `http://localhost:3000`, overridable via `BASE_URL` env), collects CHK results, writes the report, prints a summary, and exits with `0` for OK or `1` if any NG or Playwright failure.  
- Added a Playwright audit spec `tests/audit/submit-audit.spec.ts` that POSTs owner/community/report payloads to `/api/submissions` to exercise the submit API during the audit run.  
- Registered the script `audit:submit` in `package.json` (`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c936d0e208328ae7035a0b3785dc8)