### PR TITLE
Exclude Playwright specs from unit test compilation and fix unit test import

### DIFF
--- a/tests/submissions-multipart.test.ts
+++ b/tests/submissions-multipart.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { parseMultipartSubmission } from "@/lib/submissions/parseMultipart";
+import { parseMultipartSubmission } from "../lib/submissions/parseMultipart";
 import { emptyAcceptedMediaSummary, validateMultipartSubmission } from "@/lib/submissions/validateMultipart";
 
 const buildMultipartRequest = (form: FormData) =>

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -6,5 +6,5 @@
     "module": "CommonJS"
   },
   "include": ["tests/**/*.ts", "lib/stats/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/*.spec.ts", "**/*.spec.tsx", "tests/audit/**"]
 }


### PR DESCRIPTION
### Motivation
- `node --test` was executing compiled Playwright specs (e.g. `*.spec.ts`) from `.tmp-tests`, causing Playwright runner errors.  
- One unit test used the TS path alias `@/...` which `node --test` cannot resolve, causing module resolution failures during the unit test run.

### Description
- Updated `tsconfig.test.json` to exclude Playwright specs and audit tests by adding `"**/*.spec.ts"`, `"**/*.spec.tsx"`, and `"tests/audit/**"` to the `exclude` list so `tsc --project tsconfig.test.json` only emits unit tests to `.tmp-tests`.
- Modified `tests/submissions-multipart.test.ts` to import `parseMultipartSubmission` via a relative path (`../lib/submissions/parseMultipart`) instead of the `@/` TS path alias to ensure `node --test` can resolve the module.
- Left Playwright specs in the repository so they remain runnable via the Playwright test runner and did not change product behavior.

### Testing
- Ran `pnpm test`, which attempted to run the test suite but failed due to Corepack being unable to download the pinned `pnpm` distribution because of a network/proxy error (Corepack/network error), so suite results are inconclusive.
- Ran `pnpm build`, which likewise failed for the same Corepack/pnpm download network error, so build verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca8bc16e48328a0a1f2a2c5215b5d)