### PR TITLE
Add submit audit report scaffolding and capture submission IDs

### DIFF
--- a/scripts/audit/run-submit-audit.ts
+++ b/scripts/audit/run-submit-audit.ts
@@ -48,22 +48,22 @@ const runPlaywright = async () => {
 const main = async () => {
   const startedAt = new Date();
   const playwright = await runPlaywright();
-  const groups = await collectSubmitAuditChecks(process.cwd());
+  const checks = await collectSubmitAuditChecks(process.cwd(), { playwright });
   const finishedAt = new Date();
 
-  const report = buildSubmitAuditReport(BASE_URL, startedAt, finishedAt, playwright, groups);
+  const report = buildSubmitAuditReport(BASE_URL, startedAt, finishedAt, playwright, checks);
   await writeSubmitAuditReport(OUTPUT_DIR, report);
 
   console.log("\nSubmit audit summary:");
   console.log(`Base URL: ${report.baseUrl}`);
   console.log(
-    `Checks: OK=${report.summary.ok} NG=${report.summary.ng} WARN=${report.summary.warn} INFO=${report.summary.info}`,
+    `Checks: OK=${report.summary.ok} NG=${report.summary.ng} UNKNOWN=${report.summary.unknown}`,
   );
   console.log(`Playwright: ${report.playwright.status} (exit ${report.playwright.exitCode ?? "n/a"})`);
   console.log(`Report: ${OUTPUT_DIR}/submit-audit-latest.md`);
 
   const hasNg = report.summary.ng > 0;
-  const exitCode = hasNg || report.playwright.exitCode !== 0 ? 1 : 0;
+  const exitCode = hasNg ? 1 : 0;
   process.exit(exitCode);
 };
 

--- a/tests/audit/submit-audit.spec.ts
+++ b/tests/audit/submit-audit.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+import { updateSubmissionIds } from "./submit-helpers";
+
 const BASE_URL = (process.env.BASE_URL || process.env.PW_BASE_URL || "http://localhost:3000").replace(
   /\/$/,
   "",
@@ -56,6 +58,12 @@ const submitPayload = async (request: any, payload: Record<string, unknown>) => 
   const response = await request.post(`${BASE_URL}/api/submissions`, { data: payload });
   expect(response.status(), `Unexpected status for payload kind ${payload.kind}`).toBeGreaterThanOrEqual(200);
   expect(response.status(), `Unexpected status for payload kind ${payload.kind}`).toBeLessThan(500);
+  const json = await response.json().catch(() => ({}));
+  const submissionId = (json as { submissionId?: string }).submissionId;
+  if (submissionId && typeof payload.kind === "string") {
+    const kind = payload.kind as "owner" | "community" | "report";
+    await updateSubmissionIds(kind, submissionId);
+  }
 };
 
 test.describe("Submit audit harness", () => {


### PR DESCRIPTION
### Motivation

- Provide a single command to run the submit-audit flow and generate both machine- and human-readable reports that summarize checks in CHK-style rows. 
- Surface Playwright run status and whether submission artifacts were created so the audit runner can distinguish OK/NG/UNKNOWN states.
- Make reports timestamped and write both a `latest` and a timestamped MD/JSON pair for audit runs.

### Description

- Reworked `scripts/audit/report.ts` to emit a flat list of `AuditCheckItem` checks with `id`, `title`, `status` (`OK|NG|UNKNOWN`), `layer`, `detail`, and `paths`, and to render Markdown and JSON outputs; added timestamped `runId` formatting and summary counting via `toStatusCounts`.
- Added artifact-aware checks: `collectSubmitAuditChecks` now reads `scripts/audit/out/submission-ids.json` (if present) and includes Playwright run and submission-id artifact checks in the report.
- Updated `scripts/audit/run-submit-audit.ts` to pass the Playwright summary into the collector, to write outputs to `docs/audit/runs` (`submit-audit-latest.md|.json` and timestamped files), and to exit with code `1` only when any `NG` checks are present (otherwise `0`).
- Updated the Playwright submit test `tests/audit/submit-audit.spec.ts` to persist submission IDs by calling `updateSubmissionIds(...)` after successful POST responses so the runner can detect created artifacts in `scripts/audit/out/submission-ids.json`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cd936f45083288486ece88e99137f)