### PR TITLE
Fix audit submit payloads and AUDIT_BASE_URL handling

### DIFF
--- a/scripts/audit/run-submit-audit.ts
+++ b/scripts/audit/run-submit-audit.ts
@@ -7,7 +7,7 @@ import {
   writeSubmitAuditReport,
 } from "./report";
 
-const BASE_URL = (process.env.BASE_URL || "http://localhost:3000").replace(/\/$/, "");
+const BASE_URL = (process.env.AUDIT_BASE_URL ?? "http://localhost:3000").replace(/\/$/, "");
 const OUTPUT_DIR = path.join(process.cwd(), "docs", "audit", "runs");
 
 const runCommand = (command: string, args: string[], env: NodeJS.ProcessEnv) =>
@@ -31,6 +31,7 @@ const runPlaywright = async () => {
     ...process.env,
     BASE_URL,
     PW_BASE_URL: BASE_URL,
+    AUDIT_BASE_URL: BASE_URL,
   };
 
   const exitCode = await runCommand(

--- a/tests/audit/submit-audit.spec.ts
+++ b/tests/audit/submit-audit.spec.ts
@@ -2,60 +2,74 @@ import { test, expect } from "@playwright/test";
 
 import { updateSubmissionIds } from "./submit-helpers";
 
-const BASE_URL = (process.env.BASE_URL || process.env.PW_BASE_URL || "http://localhost:3000").replace(
-  /\/$/,
-  "",
-);
+const BASE_URL = process.env.AUDIT_BASE_URL ?? "http://localhost:3000";
+
+const PROOF_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/6X2LhQAAAAASUVORK5CYII=";
 
 const nowTag = () => new Date().toISOString().replace(/[:.]/g, "-");
 
-const buildOwnerPayload = () => ({
-  kind: "owner",
-  verificationRequest: "owner",
-  name: `Audit Owner Place ${nowTag()}`,
-  placeName: `Audit Owner Place ${nowTag()}`,
-  country: "US",
-  city: "New York",
-  address: "123 Example St",
-  category: "cafe",
-  acceptedChains: ["BTC"],
-  contactEmail: `audit-owner-${nowTag()}@example.com`,
-  contactName: "Audit Runner",
-  submitterName: "Audit Runner",
-  ownerVerification: "domain",
-  communityEvidenceUrls: ["https://example.com/owner-evidence-1"],
-  termsAccepted: true,
-});
+const buildOwnerPayload = () => {
+  const tag = nowTag();
+  return {
+    kind: "owner",
+    desiredStatusLabel: "Owner Verified",
+    submitterName: "Audit Runner",
+    submitterEmail: `audit-owner-${tag}@example.com`,
+    placeName: `Audit Owner Place ${tag}`,
+    country: "US",
+    city: "New York",
+    address: "123 Example St",
+    ownerVerification: {
+      method: "domain",
+      domain: "example.com",
+    },
+    ownerPayment: {
+      paymentUrl: "https://example.com/pay",
+    },
+  };
+};
 
-const buildCommunityPayload = () => ({
-  kind: "community",
-  verificationRequest: "community",
-  name: `Audit Community Place ${nowTag()}`,
-  placeName: `Audit Community Place ${nowTag()}`,
-  country: "US",
-  city: "Austin",
-  address: "456 Example Ave",
-  category: "restaurant",
-  acceptedChains: ["BTC", "USDT"],
-  contactEmail: `audit-community-${nowTag()}@example.com`,
-  contactName: "Audit Runner",
-  submitterName: "Audit Runner",
-  ownerVerification: "domain",
-  communityEvidenceUrls: ["https://example.com/community-1", "https://example.com/community-2"],
-  termsAccepted: true,
-});
+const buildCommunityPayload = () => {
+  const tag = nowTag();
+  return {
+    kind: "community",
+    desiredStatusLabel: "Community Verified",
+    submitterName: "Audit Runner",
+    submitterEmail: `audit-community-${tag}@example.com`,
+    placeName: `Audit Community Place ${tag}`,
+    country: "US",
+    city: "Austin",
+    address: "456 Example Ave",
+    communityEvidenceUrls: ["https://example.com/community-1", "https://example.com/community-2"],
+  };
+};
 
-const buildReportPayload = () => ({
-  kind: "report",
-  verificationRequest: "report",
-  placeName: `Audit Report Place ${nowTag()}`,
-  reportReason: "Incorrect payment details",
-  reportAction: "hide",
-  reportDetails: "Audit runner created report submission.",
-});
+const buildReportPayload = () => {
+  const tag = nowTag();
+  return {
+    kind: "report",
+    desiredStatusLabel: "Report（Takedown/修正）",
+    submitterName: "Audit Runner",
+    submitterEmail: `audit-report-${tag}@example.com`,
+    placeName: `Audit Report Place ${tag}`,
+    reportWrongWhat: "Incorrect payment details",
+    reportEvidenceUrls: ["https://example.com/report-evidence"],
+    reportAction: "hide",
+  };
+};
 
-const submitPayload = async (request: any, payload: Record<string, unknown>) => {
-  const response = await request.post(`${BASE_URL}/api/submissions`, { data: payload });
+const submitPayload = async (
+  request: any,
+  payload: Record<string, unknown>,
+  files?: Record<string, { name: string; mimeType: string; buffer: Buffer }>,
+) => {
+  const response = await request.post(`${BASE_URL}/api/submissions`, {
+    multipart: {
+      payload: JSON.stringify(payload),
+      ...files,
+    },
+  });
   expect(response.status(), `Unexpected status for payload kind ${payload.kind}`).toBeGreaterThanOrEqual(200);
   expect(response.status(), `Unexpected status for payload kind ${payload.kind}`).toBeLessThan(500);
   const json = await response.json().catch(() => ({}));
@@ -68,7 +82,14 @@ const submitPayload = async (request: any, payload: Record<string, unknown>) => 
 
 test.describe("Submit audit harness", () => {
   test("create owner/community/report submissions", async ({ request }) => {
-    await submitPayload(request, buildOwnerPayload());
+    const proofBuffer = Buffer.from(PROOF_PNG_BASE64, "base64");
+    await submitPayload(request, buildOwnerPayload(), {
+      proof: {
+        name: "proof.png",
+        mimeType: "image/png",
+        buffer: proofBuffer,
+      },
+    });
     await submitPayload(request, buildCommunityPayload());
     await submitPayload(request, buildReportPayload());
   });


### PR DESCRIPTION
### Motivation
- The Playwright audit submit harness was sending JSON instead of `multipart/form-data` and used a hardcoded base URL, causing server `500` errors on valid minimal submissions and misleading logs.
- The audit runner should print and forward the actual `AUDIT_BASE_URL` so the Playwright run targets and the generated report reflect the configured environment.

### Description
- Updated `tests/audit/submit-audit.spec.ts` to build minimal payloads that match `docs/submissions.md` and to send requests as multipart with a `payload` field containing `JSON.stringify(payload)`.
- Added an in-memory deterministic 1x1 PNG (`PROOF_PNG_BASE64`) and attach it as `proof` for the `owner` submission; `community` and `report` submissions use minimal required URL fields only.
- The test payloads now include the expected minimal fields such as `kind`, `desiredStatusLabel`, `submitterName`, `submitterEmail`, `placeName`, `ownerVerification` / `ownerPayment` for owner, `communityEvidenceUrls` for community, and `reportWrongWhat` / `reportEvidenceUrls` / `reportAction` for report.
- Updated `scripts/audit/run-submit-audit.ts` to derive `BASE_URL` from `process.env.AUDIT_BASE_URL` and to forward `AUDIT_BASE_URL` (and `PW_BASE_URL`) into the Playwright environment so the summary and tests use the same configured URL.
- The existing submission-id recording logic (`updateSubmissionIds`) is used unchanged so successful responses still append `submissionId` to the `scripts/audit/out/submission-ids.json` artifact.

### Testing
- No automated test run was performed as part of this patch; the Playwright spec was updated but not executed in this change.
- Manual static validation was performed to ensure requests are sent with `multipart` and that `AUDIT_BASE_URL` is used and forwarded to the Playwright environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce390ec208328aa3439ef1203e83f)