### PR TITLE
Require ownerVerification only for owner submissions

### DIFF
--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -346,9 +346,11 @@ export const normalizeSubmission = (raw: unknown): NormalizationResult => {
     if (!address) errors.address = "Required";
     if (!category) errors.category = "Required";
     if (!contactEmail) errors.contactEmail = "Required";
-    if (!ownerVerification) errors.ownerVerification = "Required";
-    if (ownerVerification && !["domain", "otp", "dashboard_ss"].includes(ownerVerification)) {
-      errors.ownerVerification = "Invalid owner verification";
+    if (kind === "owner") {
+      if (!ownerVerification) errors.ownerVerification = "Required";
+      if (ownerVerification && !["domain", "otp", "dashboard_ss"].includes(ownerVerification)) {
+        errors.ownerVerification = "Invalid owner verification";
+      }
     }
   }
 
@@ -391,7 +393,9 @@ export const normalizeSubmission = (raw: unknown): NormalizationResult => {
   validateLength(errors, "role", role, MAX_LENGTHS.role);
   validateLength(errors, "about", about, MAX_LENGTHS.about);
   validateLength(errors, "paymentNote", paymentNote, MAX_LENGTHS.paymentNote);
-  validateLength(errors, "ownerVerification", ownerVerification, MAX_LENGTHS.ownerVerification);
+  if (kind === "owner") {
+    validateLength(errors, "ownerVerification", ownerVerification, MAX_LENGTHS.ownerVerification);
+  }
   validateLength(errors, "reportAction", reportAction, MAX_LENGTHS.reportAction);
   validateLength(errors, "website", website, MAX_LENGTHS.website);
   validateLength(errors, "twitter", twitter, MAX_LENGTHS.twitter);

--- a/tests/submissions-normalize.test.ts
+++ b/tests/submissions-normalize.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeSubmission } from "../lib/submissions";
+
+test("normalizeSubmission allows community payload without ownerVerification", () => {
+  const result = normalizeSubmission({
+    kind: "community",
+    name: "Community Cafe",
+    country: "US",
+    city: "Austin",
+    address: "123 Example St",
+    category: "cafe",
+    contactEmail: "community@example.com",
+    acceptedChains: ["btc"],
+    communityEvidenceUrls: ["https://example.com/evidence"],
+  });
+
+  assert.equal(result.ok, true);
+});
+
+test("normalizeSubmission requires ownerVerification for owner payloads", () => {
+  const result = normalizeSubmission({
+    kind: "owner",
+    name: "Owner Cafe",
+    country: "US",
+    city: "Miami",
+    address: "456 Example Ave",
+    category: "cafe",
+    contactEmail: "owner@example.com",
+    acceptedChains: ["btc"],
+  });
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.errors.ownerVerification, "Required");
+  }
+});


### PR DESCRIPTION
### Motivation
- POST `/api/submissions` was rejecting `kind="community"` and `kind="report"` payloads because `ownerVerification` was being treated as required for all non-report kinds.

### Description
- Gate `ownerVerification` presence and allowed-value checks to only run when `kind === "owner"` in `lib/submissions.ts`.
- Gate the `ownerVerification` length validation to only run for `kind === "owner"` in `lib/submissions.ts`.
- Add unit tests `tests/submissions-normalize.test.ts` that assert a `community` payload without `ownerVerification` is valid and an `owner` payload without `ownerVerification` fails with `Required`.

### Testing
- Added unit tests in `tests/submissions-normalize.test.ts` covering the two acceptance cases (not executed due to environment restrictions). 
- Attempted to run `pnpm test` but the run failed because Corepack could not download `pnpm` (`corepack`/network/proxy error), so the automated test suite could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d5e8743948328abde0c9b0f8da72c)