### PR TITLE
Tighten submit audit validation and exit behavior

### DIFF
--- a/scripts/audit/run-submit-audit.ts
+++ b/scripts/audit/run-submit-audit.ts
@@ -64,7 +64,7 @@ const main = async () => {
   console.log(`Report: ${OUTPUT_DIR}/submit-audit-latest.md`);
 
   const hasNg = report.summary.ng > 0;
-  const exitCode = hasNg ? 1 : 0;
+  const exitCode = report.playwright.exitCode !== 0 ? 1 : hasNg ? 1 : 0;
   process.exit(exitCode);
 };
 


### PR DESCRIPTION
### Motivation
- The submit-audit harness treated any HTTP status < 500 as success, allowing `400` responses to pass and leaving `submissionId` unset which causes the audit artifact check (`CHK-05`) to report NG.
- Payloads used by the harness omitted several required fields (e.g. owner verification details and accepted chains) which caused validation failures on the API.
- The audit runner did not fail when Playwright itself failed, masking test-run failures.

### Description
- Updated `tests/audit/submit-audit.spec.ts` to include required fields for each kind: `contactName`, `contactEmail`, `category`, `acceptedChains`, `ownerVerification`/`ownerVerificationDomain`, `termsAccepted` for owner/community, and `reportReason`/`reportDetails` for report submissions.
- Tightened response assertions in `tests/audit/submit-audit.spec.ts` so `submitPayload` now requires a `201` status and a non-empty `submissionId`, and includes the raw response body in the assertion message when failures occur.
- Adjusted `scripts/audit/run-submit-audit.ts` exit logic so the process exits non-zero when the Playwright run fails (`playwright.exitCode !== 0`), ensuring CI/run callers see Playwright failures immediately.
- Files changed: `tests/audit/submit-audit.spec.ts`, `scripts/audit/run-submit-audit.ts`.

### Testing
- No automated test suite was executed as part of this change.
- Recommended validation: run `AUDIT_BASE_URL=http://127.0.0.1:3000 pnpm audit:submit` and confirm it fails for APIs returning `400/500`, and passes and produces non-empty submission IDs when the API returns `201` for each flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dea709e808328aa2476e98bcbfdbf)