### PR TITLE
Make internal approve/reject/promote tolerant and idempotent; add places/by-id and curl smoke test

### DIFF
--- a/app/api/places/by-id/route.ts
+++ b/app/api/places/by-id/route.ts
@@ -11,8 +11,16 @@ const decodePlaceId = (rawId: string) => {
   }
 };
 
-export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
-  const decoded = decodePlaceId(params.id);
+export async function GET(request: NextRequest) {
+  const rawId = request.nextUrl.searchParams.get("id");
+  if (!rawId) {
+    return NextResponse.json(
+      { error: "Missing place id", hint: "use /api/places/by-id?id=cpm:..." },
+      { status: 400 },
+    );
+  }
+
+  const decoded = decodePlaceId(rawId);
   if (!decoded.ok) {
     return NextResponse.json({ error: "Invalid place id" }, { status: 400 });
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -237,6 +237,7 @@ type SubmissionMedia = {
 
 ### 3.2 Query（all optional）
 
+* `q`（部分一致検索、未指定でも一覧を返す）
 * `country`
 * `city`
 * `category`

--- a/docs/api.md
+++ b/docs/api.md
@@ -448,6 +448,7 @@ Preconditions:
 
 * kind in (owner, community)
 * status == approved
+* report は promote 対象外（409）
 
 Side effects（概念）:
 
@@ -457,14 +458,20 @@ Side effects（概念）:
 
 Errors:
 
-* 409：not approved / wrong kind
+* 409：not approved / wrong kind / report
 * 400：payload不足
-* 500：反映失敗
+* 500：反映失敗（detail に原因を返す）
 
 Response（例）:
 
 ```json
-{ "placeId": "cpm:...", "promoted": true }
+{ "status": "promoted", "placeId": "cpm:...", "mode": "insert" }
+```
+
+Failure response（例）:
+
+```json
+{ "error": "Failed to promote submission", "detail": "Submission must be approved before promote", "code": "NOT_APPROVED" }
 ```
 
 ---
@@ -489,4 +496,3 @@ Response（例）:
 * [ ] `submission_media.url` は永続URL（署名URL禁止）
 * [ ] public gallery / internal proof,evidence の配信分離＋no-store
 * [ ] internal approve/reject/promote が動作（reportにpromoteなし）
-

--- a/docs/api.md
+++ b/docs/api.md
@@ -84,6 +84,7 @@ internal 系は **運営のみ**が触れる。
 | ------------------------------------------------------------- | ---------------------------------------------- |
 | `GET /api/places`                                             | 地図用の全店舗取得（軽量版）                                 |
 | `GET /api/places/[id]`                                        | 個別店舗詳細（Drawer用）                                |
+| `GET /api/places/by-id?id=...`                                | 個別店舗詳細（cpm/osm IDの安全取得）                     |
 | `GET /api/stats`                                              | v3 コア統計                                        |
 | `GET /api/filters/meta`                                       | UIフィルタ用メタデータ                                   |
 | `GET /api/search`                                             | v2.1 予定の検索API                                  |
@@ -251,6 +252,11 @@ type SubmissionMedia = {
 
 ## 4. GET `/api/places/[id]`（Drawer用）
 
+* Response：`PlaceDetail`
+
+## 4.1 GET `/api/places/by-id?id=...`
+
+* `id`: `cpm:...` / `osm:...` をクエリで指定
 * Response：`PlaceDetail`
 
 ---
@@ -483,5 +489,4 @@ Response（例）:
 * [ ] `submission_media.url` は永続URL（署名URL禁止）
 * [ ] public gallery / internal proof,evidence の配信分離＋no-store
 * [ ] internal approve/reject/promote が動作（reportにpromoteなし）
-
 

--- a/docs/dev/submit_smoke_test.md
+++ b/docs/dev/submit_smoke_test.md
@@ -1,36 +1,36 @@
 # submit smoke test (curl-only)
 
-`scripts/submit_smoke_test.sh` runs the owner/community/report submission → approve → promote (owner/community) → places verification flow using curl only. It works for both local and prod by switching `BASE_URL`.
+`scripts/cpm_submit_smoke_test.sh` runs the owner/community/report submission → approve → promote (owner/community) → places verification flow using curl only. It works for both local and prod by switching `BASE_URL`.
 
 ## Prerequisites
 
 * Internal basic auth credentials:
-  * `ADMIN_USER`
-  * `ADMIN_PASS`
+  * `INTERNAL_USER`
+  * `INTERNAL_PASS`
 
 ## Run (local)
 
 ```bash
 BASE_URL=http://localhost:3000 \
-ADMIN_USER=your_admin_user \
-ADMIN_PASS=your_admin_pass \
-scripts/submit_smoke_test.sh
+INTERNAL_USER=your_internal_user \
+INTERNAL_PASS=your_internal_pass \
+bash scripts/cpm_submit_smoke_test.sh
 ```
 
 ## Run (prod)
 
 ```bash
 BASE_URL=https://your-prod-domain.example \
-ADMIN_USER=your_admin_user \
-ADMIN_PASS=your_admin_pass \
-scripts/submit_smoke_test.sh
+INTERNAL_USER=your_internal_user \
+INTERNAL_PASS=your_internal_pass \
+bash scripts/cpm_submit_smoke_test.sh
 ```
 
 ## What the script checks
 
 * Owner flow: submit → approve → promote → places list includes the name → fetch by placeId.
 * Community flow: same as owner.
-* Report flow: submit → approve → confirm approved status via `GET /api/internal/submissions/:id`.
+* Report flow: submit → approve → confirm approved status via `GET /api/internal/submissions/:id`, and confirm promote is rejected with 409.
 
 ## Notes
 

--- a/docs/dev/submit_smoke_test.md
+++ b/docs/dev/submit_smoke_test.md
@@ -1,0 +1,38 @@
+# submit smoke test (curl-only)
+
+`scripts/submit_smoke_test.sh` runs the owner/community/report submission → approve → promote (owner/community) → places verification flow using curl only. It works for both local and prod by switching `BASE_URL`.
+
+## Prerequisites
+
+* Internal basic auth credentials:
+  * `ADMIN_USER`
+  * `ADMIN_PASS`
+
+## Run (local)
+
+```bash
+BASE_URL=http://localhost:3000 \
+ADMIN_USER=your_admin_user \
+ADMIN_PASS=your_admin_pass \
+scripts/submit_smoke_test.sh
+```
+
+## Run (prod)
+
+```bash
+BASE_URL=https://your-prod-domain.example \
+ADMIN_USER=your_admin_user \
+ADMIN_PASS=your_admin_pass \
+scripts/submit_smoke_test.sh
+```
+
+## What the script checks
+
+* Owner flow: submit → approve → promote → places list includes the name → fetch by placeId.
+* Community flow: same as owner.
+* Report flow: submit → approve → confirm approved status via `GET /api/internal/submissions/:id`.
+
+## Notes
+
+* The script uses `GET /api/places/by-id?id=...` to safely fetch place details with `cpm:...` IDs.
+* Internal endpoints accept empty bodies; the script sends no body for approve/promote.

--- a/lib/internal/submissions.ts
+++ b/lib/internal/submissions.ts
@@ -63,6 +63,7 @@ export type SubmissionActionResponse = {
   status?: string;
   placeId?: string;
   promoted?: boolean;
+  mode?: "insert" | "update";
 };
 
 type ApiResult<T> =

--- a/lib/places/detail.ts
+++ b/lib/places/detail.ts
@@ -1,0 +1,370 @@
+import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+import { places as fallbackPlaces } from "@/lib/data/places";
+import { normalizeAccepted, type PaymentAccept } from "@/lib/accepted";
+
+const allowedVerificationLevels = ["owner", "community", "directory", "unverified"] as const;
+
+type Verification = (typeof allowedVerificationLevels)[number];
+
+type Social = {
+  platform: string;
+  url: string | null;
+  handle: string | null;
+};
+
+type Media = {
+  url: string;
+};
+
+type FallbackPlace = (typeof fallbackPlaces)[number];
+
+type DbPlace = {
+  id: string;
+  name: string;
+  category: string | null;
+  country: string | null;
+  city: string | null;
+  lat: number;
+  lng: number;
+  address: string | null;
+  about: string | null;
+  amenities: string[] | string | null;
+  payment_note: string | null;
+  submitter_name: string | null;
+  hours: string | null;
+  verification: string | null;
+};
+
+const sanitizeVerification = (value: string | null): Verification => {
+  if (value && allowedVerificationLevels.includes(value as Verification)) {
+    return value as Verification;
+  }
+  return "unverified";
+};
+
+const normalizeAmenities = (raw: string[] | string | null): string[] => {
+  if (!raw) return [];
+
+  if (Array.isArray(raw)) {
+    return raw.map((value) => String(value)).filter(Boolean);
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.map((value) => String(value)).filter(Boolean);
+    }
+  } catch (error) {
+    console.warn("[places-detail] failed to parse amenities JSON", error);
+  }
+
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+};
+
+const normalizeHours = (raw: string[] | string | null): string[] | null => {
+  if (!raw) return null;
+
+  if (Array.isArray(raw)) {
+    const hours = raw.map((value) => String(value).trim()).filter(Boolean);
+    return hours.length ? hours : null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      const hours = parsed.map((value) => String(value).trim()).filter(Boolean);
+      return hours.length ? hours : null;
+    }
+  } catch (error) {
+    console.warn("[places-detail] failed to parse hours JSON", error);
+  }
+
+  const hours = raw
+    .split(/\r?\n|,/)
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return hours.length ? hours : null;
+};
+
+const normalizeAbout = (value: string | null, verification: Verification) => {
+  if (verification === "unverified") {
+    return "";
+  }
+  return value ?? "";
+};
+
+const normalizeImages = (media: Media[], verification: Verification) => {
+  if (verification === "directory" || verification === "unverified") {
+    return [] as string[];
+  }
+  return media.map((item) => item.url).filter(Boolean);
+};
+
+const pickContactFromSocials = (socials: Social[]) => {
+  const contact = {
+    website: null as string | null,
+    phone: null as string | null,
+    x: null as string | null,
+    instagram: null as string | null,
+    facebook: null as string | null,
+  };
+
+  for (const social of socials) {
+    const platform = social.platform.toLowerCase();
+    const value = social.url ?? social.handle;
+
+    switch (platform) {
+      case "website":
+        contact.website = value;
+        break;
+      case "phone":
+        contact.phone = value;
+        break;
+      case "x":
+      case "twitter":
+        contact.x = value;
+        break;
+      case "instagram":
+        contact.instagram = value;
+        break;
+      case "facebook":
+        contact.facebook = value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (!contact.website && !contact.phone && !contact.x && !contact.instagram && !contact.facebook) {
+    return null;
+  }
+
+  return contact;
+};
+
+const hasColumn = (route: string, table: string, column: string) =>
+  dbQuery<{ exists: boolean }>(
+    `SELECT EXISTS(
+       SELECT 1
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = $1
+         AND column_name = $2
+     ) AS exists`,
+    [table, column],
+    { route },
+  );
+
+const loadPlaceDetailFromDb = async (id: string, fallbackPlace?: FallbackPlace) => {
+  if (!hasDatabaseUrl()) return null;
+  const route = "api_places_id";
+
+  try {
+    const { rows: tableChecks } = await dbQuery<{ [key: string]: string | null }>(
+      `SELECT
+        to_regclass('public.places') AS places,
+        to_regclass('public.verifications') AS verifications,
+        to_regclass('public.payment_accepts') AS payment_accepts,
+        to_regclass('public.socials') AS socials,
+        to_regclass('public.media') AS media`,
+      [],
+      { route },
+    );
+
+    if (!tableChecks[0]?.places) {
+      return null;
+    }
+
+    const hasVerificationLevel = tableChecks[0]?.verifications
+      ? (await hasColumn(route, "verifications", "level")).rows[0]?.exists
+      : false;
+
+    const hasHours = (await hasColumn(route, "places", "hours")).rows[0]?.exists;
+    const hasAmenities = (await hasColumn(route, "places", "amenities")).rows[0]?.exists;
+    const hasPaymentNote = (await hasColumn(route, "places", "payment_note")).rows[0]?.exists;
+    const hasSubmitterName = (await hasColumn(route, "places", "submitter_name")).rows[0]?.exists;
+
+    const joinVerification = hasVerificationLevel ? "LEFT JOIN verifications v ON v.place_id = p.id" : "";
+
+    const verificationSelect = hasVerificationLevel
+      ? "COALESCE(v.level, 'unverified') AS verification"
+      : "'unverified'::text AS verification";
+
+    const hoursSelect = hasHours ? "p.hours" : "NULL::text AS hours";
+    const amenitiesSelect = hasAmenities ? "p.amenities" : "NULL::text[] AS amenities";
+    const paymentNoteSelect = hasPaymentNote ? "p.payment_note" : "NULL::text AS payment_note";
+    const submitterNameSelect = hasSubmitterName ? "p.submitter_name" : "NULL::text AS submitter_name";
+
+    const { rows: placeRows } = await dbQuery<DbPlace>(
+      `SELECT p.id, p.name, p.category, p.country, p.city, p.lat, p.lng, p.address, p.about, ${amenitiesSelect}, ${paymentNoteSelect},
+        ${submitterNameSelect}, ${hoursSelect},
+        ${verificationSelect}
+       FROM places p
+       ${joinVerification}
+       WHERE p.id = $1
+       LIMIT 1`,
+      [id],
+      { route },
+    );
+
+    if (!placeRows.length) {
+      return null;
+    }
+
+    const place = placeRows[0];
+    const verification = sanitizeVerification(place.verification);
+    const normalizedAmenities = hasAmenities
+      ? normalizeAmenities(place.amenities)
+      : fallbackPlace?.amenities ?? [];
+
+    const hasPreferredFlag =
+      tableChecks[0]?.payment_accepts
+        ? (await hasColumn(route, "payment_accepts", "is_preferred")).rows[0]?.exists
+        : false;
+
+    const payments: PaymentAccept[] = tableChecks[0]?.payment_accepts
+      ? (
+          await dbQuery<PaymentAccept>(
+            `SELECT asset, chain, ${hasPreferredFlag ? "is_preferred" : "NULL::boolean AS is_preferred"}
+             FROM payment_accepts
+             WHERE place_id = $1
+             ORDER BY ${hasPreferredFlag ? "is_preferred DESC NULLS LAST," : ""} id ASC`,
+            [id],
+            { route },
+          )
+        ).rows
+      : [];
+
+    const socials: Social[] = tableChecks[0]?.socials
+      ? (
+          await dbQuery<Social>(
+            `SELECT platform, url, handle
+             FROM socials
+             WHERE place_id = $1`,
+            [id],
+            { route },
+          )
+        ).rows
+      : [];
+
+    const media: Media[] = tableChecks[0]?.media
+      ? (
+          await dbQuery<Media>(
+            `SELECT url
+             FROM media
+             WHERE place_id = $1`,
+            [id],
+            { route },
+          )
+        ).rows
+      : [];
+
+    return {
+      id: place.id,
+      name: place.name,
+      category: place.category ?? "unknown",
+      verification,
+      lat: Number(place.lat),
+      lng: Number(place.lng),
+      country: place.country ?? "",
+      city: place.city ?? "",
+      about: normalizeAbout(place.about, verification),
+      about_short: normalizeAbout(place.about, verification),
+      hours: normalizeHours(place.hours),
+      amenities: normalizedAmenities,
+      paymentNote: hasPaymentNote ? place.payment_note : fallbackPlace?.paymentNote ?? null,
+      submitterName: hasSubmitterName ? place.submitter_name : fallbackPlace?.submitterName ?? null,
+      accepted: normalizeAccepted(payments, fallbackPlace?.accepted),
+      contact: pickContactFromSocials(socials),
+      images: normalizeImages(media, verification),
+      media: normalizeImages(media, verification),
+      address_full: place.address ?? null,
+      location: {
+        address1: place.address ?? null,
+        address2: null,
+        lat: Number(place.lat),
+        lng: Number(place.lng),
+      },
+      payments: payments.length
+        ? {
+            assets: normalizeAccepted(payments, fallbackPlace?.accepted),
+            pages: [],
+          }
+        : fallbackPlace?.accepted?.length
+          ? {
+              assets: normalizeAccepted([], fallbackPlace.accepted),
+              pages: [],
+            }
+          : null,
+      socials,
+    };
+  } catch (error) {
+    if (error instanceof DbUnavailableError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[places-detail] failed to load from database", message);
+    return null;
+  }
+};
+
+const loadFallbackPlace = (id: string) => {
+  const place = fallbackPlaces.find((item) => item.id === id);
+  if (!place) return undefined;
+
+  const verification = sanitizeVerification(place.verification);
+
+  return {
+    ...place,
+    verification,
+    about: normalizeAbout(place.about ?? null, verification),
+    about_short: normalizeAbout(place.about ?? null, verification),
+    amenities: place.amenities ?? [],
+    images: normalizeImages((place.images ?? []).map((url) => ({ url })), verification),
+    contact:
+      place.website || place.phone || place.twitter || place.instagram || place.facebook
+        ? {
+            website: place.website ?? null,
+            phone: place.phone ?? null,
+            x: place.twitter ?? null,
+            instagram: place.instagram ?? null,
+            facebook: place.facebook ?? null,
+          }
+        : null,
+    payments: place.accepted?.length
+      ? {
+          assets: normalizeAccepted([], place.accepted),
+          pages: [],
+        }
+      : null,
+    media: normalizeImages((place.images ?? []).map((url) => ({ url })), verification),
+  };
+};
+
+export const getPlaceDetail = async (id: string) => {
+  const fallbackPlace = loadFallbackPlace(id);
+  let dbPlace: Awaited<ReturnType<typeof loadPlaceDetailFromDb>> = null;
+  try {
+    dbPlace = await loadPlaceDetailFromDb(id, fallbackPlace);
+  } catch (error) {
+    if (error instanceof DbUnavailableError) {
+      throw error;
+    }
+    throw error;
+  }
+
+  if (dbPlace) {
+    return { place: dbPlace, source: "db" as const };
+  }
+
+  if (fallbackPlace) {
+    return { place: fallbackPlace, source: "fallback" as const };
+  }
+
+  return { place: null, source: null };
+};
+

--- a/lib/submissions.ts
+++ b/lib/submissions.ts
@@ -902,6 +902,7 @@ export const handleUnifiedSubmission = async (request: Request) => {
       normalized.payload.verificationRequest,
       parsedMultipart.value.filesByField,
       parsedMultipart.value.unexpectedFileFields,
+      body,
     );
     if (!multipartValidation.ok) {
       console.info(`[submissions] reject ip=${ip} reason=${multipartValidation.error.code}`);
@@ -915,6 +916,8 @@ export const handleUnifiedSubmission = async (request: Request) => {
       return new Response(
         JSON.stringify({
           submissionId: record.submissionId,
+          status: record.status,
+          suggestedPlaceId: record.suggestedPlaceId,
         }),
         { status: 201, headers: { "Content-Type": "application/json" } },
       );
@@ -1004,6 +1007,8 @@ if (error instanceof Error && error.message === "UPLOAD_FAILED") {
     return new Response(
       JSON.stringify({
         submissionId: record.submissionId,
+        status: record.status,
+        suggestedPlaceId: record.suggestedPlaceId,
       }),
       { status: 201, headers: { "Content-Type": "application/json" } },
     );

--- a/scripts/cpm_submit_smoke_test.sh
+++ b/scripts/cpm_submit_smoke_test.sh
@@ -54,6 +54,18 @@ json_value() {
   echo "$body" | sed -n "s/.*\"$key\":\"\\([^\"]*\\)\".*/\\1/p" | head -n 1
 }
 
+place_list_contains() {
+  local name="$1"
+  local list
+  list=$(request GET "$BASE_URL/api/places" --get --data-urlencode "limit=5000")
+  if echo "$list" | grep -q "$name"; then
+    return 0
+  fi
+  local fallback
+  fallback=$(request GET "$BASE_URL/api/places" --get --data-urlencode "q=$name" --data-urlencode "limit=5000")
+  echo "$fallback" | grep -q "$name"
+}
+
 RUN_ID="$(date +%s)"
 
 OWNER_NAME="smoke-owner-${RUN_ID}"
@@ -93,8 +105,7 @@ if [[ -z "$owner_place_id" ]]; then
   echo "$owner_promote" >&2
   exit 1
 fi
-owner_list=$(request GET "$BASE_URL/api/places" --get --data-urlencode "q=$OWNER_NAME")
-echo "$owner_list" | grep -q "$OWNER_NAME"
+place_list_contains "$OWNER_NAME"
 request GET "$BASE_URL/api/places/by-id" --get --data-urlencode "id=$owner_place_id" >/dev/null
 echo "owner flow: ok"
 
@@ -114,8 +125,7 @@ if [[ -z "$community_place_id" ]]; then
   echo "$community_promote" >&2
   exit 1
 fi
-community_list=$(request GET "$BASE_URL/api/places" --get --data-urlencode "q=$COMMUNITY_NAME")
-echo "$community_list" | grep -q "$COMMUNITY_NAME"
+place_list_contains "$COMMUNITY_NAME"
 request GET "$BASE_URL/api/places/by-id" --get --data-urlencode "id=$community_place_id" >/dev/null
 echo "community flow: ok"
 

--- a/scripts/submit_smoke_test.sh
+++ b/scripts/submit_smoke_test.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+ADMIN_USER="${ADMIN_USER:-}"
+ADMIN_PASS="${ADMIN_PASS:-}"
+COOKIE_JAR="${COOKIE_JAR:-/tmp/cpm_internal_cookie_$$.txt}"
+
+if [[ -z "$ADMIN_USER" || -z "$ADMIN_PASS" ]]; then
+  echo "Missing ADMIN_USER/ADMIN_PASS for internal auth." >&2
+  exit 1
+fi
+
+trap 'rm -f "$COOKIE_JAR"' EXIT
+
+internal_auth_args=(-u "${ADMIN_USER}:${ADMIN_PASS}" -c "$COOKIE_JAR" -b "$COOKIE_JAR")
+
+request() {
+  local method="$1"
+  local url="$2"
+  shift 2
+  local response
+  response=$(curl -sS -w "\n%{http_code}" -X "$method" "$url" "$@")
+  local status="${response##*$'\n'}"
+  local body="${response%$'\n'*}"
+  if [[ "$status" -lt 200 || "$status" -ge 300 ]]; then
+    echo "Request failed: $method $url ($status)" >&2
+    echo "$body" >&2
+    exit 1
+  fi
+  printf "%s" "$body"
+}
+
+json_value() {
+  local body="$1"
+  local key="$2"
+  echo "$body" | sed -n "s/.*\"$key\":\"\\([^\"]*\\)\".*/\\1/p" | head -n 1
+}
+
+RUN_ID="$(date +%s)"
+
+OWNER_NAME="smoke-owner-${RUN_ID}"
+COMMUNITY_NAME="smoke-community-${RUN_ID}"
+REPORT_NAME="smoke-report-${RUN_ID}"
+
+OWNER_PAYLOAD=$(cat <<EOF
+{"verificationRequest":"owner","name":"$OWNER_NAME","country":"JP","city":"Tokyo","address":"1-2-3","category":"cafe","contactEmail":"owner-$RUN_ID@example.com","ownerVerification":"domain","paymentUrl":"https://example.com/pay","acceptedChains":["BTC"],"lat":35.6895,"lng":139.6917,"termsAccepted":true}
+EOF
+)
+
+COMMUNITY_PAYLOAD=$(cat <<EOF
+{"verificationRequest":"community","name":"$COMMUNITY_NAME","country":"JP","city":"Osaka","address":"4-5-6","category":"restaurant","contactEmail":"community-$RUN_ID@example.com","acceptedChains":["BTC"],"communityEvidenceUrls":["https://example.com/evidence"],"lat":34.6937,"lng":135.5023}
+EOF
+)
+
+REPORT_PAYLOAD=$(cat <<EOF
+{"verificationRequest":"report","placeName":"$REPORT_NAME","reportReason":"Smoke test report","reportAction":"hide","contactEmail":"report-$RUN_ID@example.com"}
+EOF
+)
+
+echo "Running submit smoke test against $BASE_URL"
+
+owner_create=$(request POST "$BASE_URL/api/submissions" -F "payload=${OWNER_PAYLOAD};type=application/json")
+owner_id=$(json_value "$owner_create" "submissionId")
+owner_suggested=$(json_value "$owner_create" "suggestedPlaceId")
+if [[ -z "$owner_id" || -z "$owner_suggested" ]]; then
+  echo "Failed to extract owner submissionId/suggestedPlaceId" >&2
+  echo "$owner_create" >&2
+  exit 1
+fi
+request POST "$BASE_URL/api/internal/submissions/$owner_id/approve" "${internal_auth_args[@]}" >/dev/null
+owner_promote=$(request POST "$BASE_URL/api/internal/submissions/$owner_id/promote" "${internal_auth_args[@]}")
+owner_place_id=$(json_value "$owner_promote" "placeId")
+if [[ -z "$owner_place_id" ]]; then
+  echo "Failed to extract owner placeId" >&2
+  echo "$owner_promote" >&2
+  exit 1
+fi
+owner_list=$(request GET "$BASE_URL/api/places" --get --data-urlencode "q=$OWNER_NAME")
+echo "$owner_list" | grep -q "$OWNER_NAME"
+request GET "$BASE_URL/api/places/by-id" --get --data-urlencode "id=$owner_place_id" >/dev/null
+echo "owner flow: ok"
+
+community_create=$(request POST "$BASE_URL/api/submissions" -F "payload=${COMMUNITY_PAYLOAD};type=application/json")
+community_id=$(json_value "$community_create" "submissionId")
+community_suggested=$(json_value "$community_create" "suggestedPlaceId")
+if [[ -z "$community_id" || -z "$community_suggested" ]]; then
+  echo "Failed to extract community submissionId/suggestedPlaceId" >&2
+  echo "$community_create" >&2
+  exit 1
+fi
+request POST "$BASE_URL/api/internal/submissions/$community_id/approve" "${internal_auth_args[@]}" >/dev/null
+community_promote=$(request POST "$BASE_URL/api/internal/submissions/$community_id/promote" "${internal_auth_args[@]}")
+community_place_id=$(json_value "$community_promote" "placeId")
+if [[ -z "$community_place_id" ]]; then
+  echo "Failed to extract community placeId" >&2
+  echo "$community_promote" >&2
+  exit 1
+fi
+community_list=$(request GET "$BASE_URL/api/places" --get --data-urlencode "q=$COMMUNITY_NAME")
+echo "$community_list" | grep -q "$COMMUNITY_NAME"
+request GET "$BASE_URL/api/places/by-id" --get --data-urlencode "id=$community_place_id" >/dev/null
+echo "community flow: ok"
+
+report_create=$(request POST "$BASE_URL/api/submissions" -F "payload=${REPORT_PAYLOAD};type=application/json")
+report_id=$(json_value "$report_create" "submissionId")
+if [[ -z "$report_id" ]]; then
+  echo "Failed to extract report submissionId" >&2
+  echo "$report_create" >&2
+  exit 1
+fi
+request POST "$BASE_URL/api/internal/submissions/$report_id/approve" "${internal_auth_args[@]}" >/dev/null
+report_detail=$(request GET "$BASE_URL/api/internal/submissions/$report_id" "${internal_auth_args[@]}")
+echo "$report_detail" | grep -q "\"status\":\"approved\""
+echo "report flow: ok"


### PR DESCRIPTION
### Motivation

- Ensure the full submission -> approve -> promote -> places reflection flow succeeds identically on PROD and LOCAL via curl-only smoke tests by removing fragile JSON/body and placeId handling.
- Eliminate sources of `500` on `promote` by surfacing detailed errors and making promotion idempotent so operator fixes can be validated locally before touching production.
- Guarantee `cpm:...` place IDs can be reliably retrieved by the API and used by the smoke test.

### Description

- Make internal endpoints tolerant of empty request bodies by adding `parseJsonBody` and returning a helpful hint on invalid JSON for `POST /api/internal/submissions/:id/approve`, `.../reject`, and `.../promote` (files: `app/api/internal/submissions/[id]/approve/route.ts`, `.../reject/route.ts`, `.../promote/route.ts`).
- Harden `promote` by: building deterministic `cpm:` fallback IDs when needed, preferring `suggested_place_id`/linked IDs, upserting into `places` (idempotent), and returning structured success and failure payloads with `detail` and `code` fields (file: `lib/submissions/promote.ts`).
- Add safe place lookup routes and loader: extract place detail logic to `lib/places/detail.ts`, replace the heavyweight `app/api/places/[id]/route.ts` with a decoder-aware handler, and add `GET /api/places/by-id?id=...` to fetch `cpm:`/`osm:` IDs via query (files: `app/api/places/[id]/route.ts`, `app/api/places/by-id/route.ts`, `lib/places/detail.ts`).
- Improve submission responses and validations by returning `status` and `suggestedPlaceId` on create, and passing original multipart `body` into multipart validation so conditional rules work (file: `lib/submissions.ts`).
- Surface client-side shape change by adding `mode` to the internal action type (file: `lib/internal/submissions.ts`).
- Add a curl-only smoke test script `scripts/submit_smoke_test.sh` plus docs `docs/dev/submit_smoke_test.md` that perform owner/community/report flows against `BASE_URL` with `ADMIN_USER/ADMIN_PASS` and use `GET /api/places/by-id?id=...` for `cpm:` IDs.

### Testing

- No automated test suite was executed as part of this change; instead a curl-only smoke test script was added at `scripts/submit_smoke_test.sh` to be run against local and prod environments with environment variables `BASE_URL`, `ADMIN_USER`, and `ADMIN_PASS` and it exits non-zero on any failure.
- Static/manual verification: changed endpoints include structured error payloads and new `placeId`/`mode` shapes so the smoke test can assert end-to-end success; please run `BASE_URL=... ADMIN_USER=... ADMIN_PASS=... scripts/submit_smoke_test.sh` to validate in each environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698882ddceb88328bed51d12043a29ab)