### PR TITLE
fix(mobile-map): HUD/menu/sheet behavior and viewport sizing on mobile

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const NAV_LINKS = [
   { label: 'Map', href: '/' },
@@ -24,6 +24,14 @@ const isActivePath = (pathname: string, href: string) => {
 export default function GlobalHeader() {
   const pathname = usePathname();
   const headerRef = useRef<HTMLElement | null>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [debugMode, setDebugMode] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = window.localStorage.getItem('cpm:debug-mode');
+    setDebugMode(stored === '1');
+  }, []);
 
   useEffect(() => {
     const header = headerRef.current;
@@ -44,6 +52,24 @@ export default function GlobalHeader() {
     observer.observe(header);
     return () => observer.disconnect();
   }, []);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isMenuOpen]);
+
+  const setDebugState = (enabled: boolean) => {
+    setDebugMode(enabled);
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('cpm:debug-mode', enabled ? '1' : '0');
+    window.dispatchEvent(new CustomEvent('cpm:debug-mode-change', { detail: enabled }));
+  };
 
   return (
     <header
@@ -82,14 +108,66 @@ export default function GlobalHeader() {
           })}
         </nav>
         <div className="md:hidden">
-          <Link
-            href="/"
+          <button
+            type="button"
+            onClick={() => setIsMenuOpen(true)}
             className="rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700"
           >
             Menu
-          </Link>
+          </button>
         </div>
       </div>
+      <div
+        className={`fixed inset-0 z-[120] bg-slate-950/35 transition-opacity duration-200 md:hidden ${
+          isMenuOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        aria-hidden={!isMenuOpen}
+        onClick={() => setIsMenuOpen(false)}
+      />
+      <aside
+        className={`fixed right-0 top-0 z-[130] flex h-dvh w-[min(88vw,360px)] flex-col bg-white shadow-2xl transition-transform duration-200 md:hidden ${
+          isMenuOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+        aria-hidden={!isMenuOpen}
+        aria-label="Menu"
+      >
+        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+          <div className="text-sm font-semibold text-gray-900">Menu</div>
+          <button
+            type="button"
+            className="rounded-full border border-gray-200 px-3 py-1 text-sm font-medium text-gray-700"
+            onClick={() => setIsMenuOpen(false)}
+          >
+            Close
+          </button>
+        </div>
+        <nav className="flex flex-1 flex-col gap-2 overflow-y-auto p-4">
+          <Link className="rounded-lg px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50" href="/about" onClick={() => setIsMenuOpen(false)}>
+            About
+          </Link>
+          <Link className="rounded-lg px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50" href="/submit" onClick={() => setIsMenuOpen(false)}>
+            Submit
+          </Link>
+          <Link className="rounded-lg px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50" href="/stats" onClick={() => setIsMenuOpen(false)}>
+            Stats
+          </Link>
+          <Link className="rounded-lg px-3 py-2 text-sm font-medium text-gray-800 hover:bg-gray-50" href="/about#credits" onClick={() => setIsMenuOpen(false)}>
+            Credits
+          </Link>
+          <div className="mt-4 rounded-xl border border-gray-200 p-3">
+            <div className="text-xs font-semibold uppercase tracking-wide text-gray-500">Debug</div>
+            <label className="mt-2 flex items-center justify-between gap-3 text-sm text-gray-700">
+              <span>Show DB status</span>
+              <input
+                type="checkbox"
+                checked={debugMode}
+                onChange={(event) => setDebugState(event.target.checked)}
+                className="h-4 w-4"
+              />
+            </label>
+          </div>
+        </nav>
+      </aside>
     </header>
   );
 }

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -11,6 +11,7 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   selectionStatus?: "idle" | "loading" | "error";
+  onStageChange?: (stage: SheetStage) => void;
 };
 
 type SheetStage = "peek" | "expanded";
@@ -92,7 +93,7 @@ const buildNavigationLinks = (place: Place | null) => {
 };
 
 const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
-  ({ place, isOpen, onClose, selectionStatus = "idle" }, ref) => {
+  ({ place, isOpen, onClose, selectionStatus = "idle", onStageChange }, ref) => {
     const [stage, setStage] = useState<SheetStage>("peek");
     const [renderedPlace, setRenderedPlace] = useState<Place | null>(null);
     const touchStartY = useRef<number | null>(null);
@@ -123,6 +124,11 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
 
     const isRestricted =
       renderedPlace?.verification === "directory" || renderedPlace?.verification === "unverified";
+
+    useEffect(() => {
+      if (!isOpen) return;
+      onStageChange?.(stage);
+    }, [isOpen, onStageChange, stage]);
     const canShowPhotos =
       renderedPlace && (renderedPlace.verification === "owner" || renderedPlace.verification === "community")
         ? photos.length > 0

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -135,75 +135,6 @@
   background: #dc2626;
 }
 
-.cpm-map-empty {
-  position: absolute;
-  left: 50%;
-  top: 96px;
-  z-index: 55;
-  transform: translateX(-50%);
-  width: min(92%, 420px);
-  border-radius: 16px;
-  border: 1px solid #e5e7eb;
-  background: rgba(255, 255, 255, 0.96);
-  padding: 16px;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
-  pointer-events: auto;
-  text-align: left;
-}
-
-.cpm-map-empty__title {
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.cpm-map-empty__body {
-  margin-top: 6px;
-  font-size: 0.8125rem;
-  line-height: 1.4;
-  color: #475569;
-}
-
-.cpm-map-empty__actions {
-  margin-top: 12px;
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.cpm-map-empty__button {
-  appearance: none;
-  border: 1px solid transparent;
-  border-radius: 999px;
-  padding: 6px 12px;
-  background: #2563eb;
-  color: #ffffff;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.cpm-map-empty__button:hover {
-  background: #1d4ed8;
-}
-
-.cpm-map-empty__button:disabled {
-  cursor: progress;
-  background: #93c5fd;
-}
-
-.cpm-map-empty__button--secondary {
-  background: #ffffff;
-  color: #1f2937;
-  border-color: #e5e7eb;
-}
-
-.cpm-map-empty__button--secondary:hover {
-  background: #f1f5f9;
-  border-color: #cbd5f5;
-}
-
 .cpm-user-marker-icon {
   background: transparent;
   border: none;
@@ -242,8 +173,8 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: calc(env(safe-area-inset-top) + 16px + var(--cpm-header-h, 0px)) 16px
-    calc(env(safe-area-inset-bottom) + 16px);
+  padding: calc(env(safe-area-inset-top) + 12px) 12px
+    calc(env(safe-area-inset-bottom) + 12px);
   pointer-events: none;
 }
 
@@ -271,8 +202,24 @@
 .cpm-map-mobile-filters {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+  pointer-events: none;
+}
+
+.cpm-map-mobile-hud-row {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.cpm-map-mobile-hud-row > * {
   pointer-events: auto;
+}
+
+.cpm-map-mobile-filters__sheet-wrap {
+  pointer-events: none;
 }
 
 .cpm-map-mobile-filters__sheet {
@@ -347,8 +294,3 @@ button[data-testid="map-filters-toggle"]{ position:relative !important; z-index:
 
 /* CPM: bring locate button above Leaflet */
 .cpm-map-button{ position:relative !important; z-index:5000 !important; }
-
-
-/* CPM: prevent zero-height leaflet container (pins render) */
-.leaflet-container{ height:70vh !important; min-height:520px !important; }
-@media (max-width: 1024px){ .leaflet-container{ height:65vh !important; min-height:420px !important; } }


### PR DESCRIPTION
### Motivation

- Bring the mobile Map screen to the finalized spec by removing layout hacks that cause bottom gaps, consolidating the HUD into a single row, replacing the mobile `Menu` link with an interactive sheet, ensuring single-pin taps always open the mobile BottomSheet, and moving zero-result guidance into Filters while hiding the DB status in production.

### Description

- Reworked mobile header to use a button that opens a right-side slide-in Menu Sheet with `About/Submit/Stats/Credits` and a `Debug` toggle persisted to `localStorage` and broadcast via `cpm:debug-mode-change` (`components/GlobalHeader.tsx`).
- Updated map container sizing to use `calc(100dvh - var(--cpm-header-h))` and removed `.leaflet-container` fixed `vh/min-height` overrides to eliminate mobile Chrome address-bar gaps (`components/map/MapClient.tsx`, `components/map/map.css`).
- Redesigned mobile HUD to a single row (`Locate | Filters | N places`) with container `pointer-events: none` and interactive controls `pointer-events: auto`, and removed the large central Empty card in favor of guidance inside the Filters sheet (`components/map/MapClient.tsx`, `components/map/map.css`).
- Ensured `MobileBottomSheet` is always mounted on mobile and added a stage-change callback to call `map.invalidateSize({ pan: false })` after drawer/filter/sheet changes to prevent tile/positioning glitches (`components/map/MobileBottomSheet.tsx`, `components/map/MapClient.tsx`).
- Map DB status is now controlled by the Debug toggle (persisted) and therefore hidden by default unless Debug is enabled; map listens for storage/event changes to toggle display (`components/map/MapClient.tsx`, `components/GlobalHeader.tsx`).

### Testing

- Ran `npm run lint` which completed successfully but reported pre-existing repository warnings (Next.js script strategy and `<img>` usage); no new lint errors were introduced.
- Ran `npm run build` which completed successfully (production build generated) with the same unrelated warnings retained. 
- Launched the dev server and executed a Playwright script to capture a mobile screenshot at `360x800` which completed and produced `artifacts/mobile-map-after-fix.png` confirming the mobile layout and the Menu/BottomSheet behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2d46ce5c8328801620dc1a9c573c)