### PR TITLE
Stabilize mobile drawer behavior and move HUD to right-side stack

### DIFF
--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -98,15 +98,21 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
     const [renderedPlace, setRenderedPlace] = useState<Place | null>(null);
     const touchStartY = useRef<number | null>(null);
     const touchCurrentY = useRef<number | null>(null);
+    const previousPlaceIdRef = useRef<string | null>(null);
 
     useEffect(() => {
       if (place) {
+        previousPlaceIdRef.current = place.id;
         setRenderedPlace(place);
-        setStage("peek");
+        if (!isOpen) {
+          setStage("peek");
+        }
         return;
       }
 
       if (!isOpen) {
+        previousPlaceIdRef.current = null;
+        setStage("peek");
         const timeout = window.setTimeout(() => setRenderedPlace(null), 220);
         return () => window.clearTimeout(timeout);
       }

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -76,6 +76,37 @@
   color: #1d4ed8;
 }
 
+
+.cpm-map-button--compact {
+  padding: 6px 10px;
+  font-size: 0.75rem;
+  line-height: 1.1;
+}
+
+.cpm-map-filters-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cpm-map-places-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  max-width: 128px;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 6px 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #374151;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
+  pointer-events: auto;
+  white-space: nowrap;
+}
+
 .cpm-map-toast {
   max-width: 220px;
   border-radius: 12px;
@@ -201,25 +232,29 @@
 }
 
 .cpm-map-mobile-filters {
+  position: absolute;
+  top: calc(var(--header-height, 64px) + env(safe-area-inset-top) + 8px);
+  right: 12px;
   display: flex;
   flex-direction: column;
+  align-items: flex-end;
   gap: 10px;
   pointer-events: none;
 }
 
-.cpm-map-mobile-hud-row {
-  display: grid;
-  grid-template-columns: auto auto 1fr;
-  align-items: center;
+.cpm-map-mobile-hud-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 8px;
   pointer-events: none;
 }
 
-.cpm-map-mobile-hud-row > * {
+.cpm-map-mobile-hud-stack > * {
   pointer-events: auto;
 }
 
-html[data-cpm-menu-open="1"] .cpm-map-mobile-hud-row {
+html[data-cpm-menu-open="1"] .cpm-map-mobile-filters {
   display: none !important;
 }
 
@@ -263,4 +298,10 @@ html[data-cpm-menu-open="1"] .cpm-map-mobile-hud-row {
 .leaflet-container {
   position: relative;
   z-index: 0;
+}
+
+@media (max-width: 1023px) {
+  .cpm-map-overlay {
+    padding-top: 0;
+  }
 }


### PR DESCRIPTION
### Motivation
- Mobile users experienced unreliable BottomSheet/Drawer behavior (not opening, auto-closing, or rapidly switching content) and the HUD overlapped map controls on small screens. 
- The goal is to make pin selection deterministic, prevent automatic closes or rapid content flicker, and simplify loading indicators into the places pill.

### Description
- Centralized selection state on `selectedPlaceId` and made Drawer/BottomSheet `isOpen` depend on `Boolean(selectedPlaceId)`, removing automatic close behavior and avoiding clearing selection on places refetch. (changes in `components/map/MapClient.tsx`)
- Added short-repeat suppression for pin taps (`lastSelectedIdRef` + `lastSelectAtRef`) and stopped event propagation (`stopPropagation` + `preventDefault`) on marker clicks to prevent double events and background interactions. (changes in `components/map/MapClient.tsx`)
- Debounced `invalidateSize` into a single 100ms path to avoid repeated map invalidations, and constrained pointer-to-background auto-close on mobile so only explicit close actions close the sheet. (changes in `components/map/MapClient.tsx`)
- Reworked mobile HUD into a right-top vertical stack (Locate, Filters, Places pill with inline spinner) and hid the HUD while the menu is open via `data-cpm-menu-open`, plus added compact styles for the pill and buttons. (changes in `components/map/map.css` and `components/map/MapClient.tsx`)
- Adjusted `MobileBottomSheet` rendering/stage logic to avoid unnecessary stage resets when place data updates so the sheet doesn’t ‘jitter’ on data refresh. (changes in `components/map/MobileBottomSheet.tsx`)

### Testing
- Ran `npm run lint` which completed successfully (reports are warnings only). 
- Started the dev server and validated the app loads without runtime errors in development. 
- Executed an automated Playwright-based smoke script on a 360×800 viewport that captured screenshots and simulated pin click/menu open to verify the HUD position, BottomSheet opening and HUD hiding while menu is open, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f5027a31c832894cfc8d459601c4e)