### PR TITLE
HOTFIX: stabilize mobile HUD/filters/drawer and deterministic pin open

### DIFF
--- a/components/map/map.css
+++ b/components/map/map.css
@@ -233,18 +233,22 @@
 }
 
 .cpm-map-mobile-filters {
-  position: absolute;
-  top: calc(env(safe-area-inset-top) + 10px);
+  position: fixed;
+  top: calc(var(--cpm-header-h, 64px) + 8px);
   right: 12px;
+  width: min(100vw - 24px, 320px);
+  max-width: calc(100vw - 140px);
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 10px;
   pointer-events: none;
+  z-index: 240;
 }
 
 .cpm-map-mobile-hud-stack {
   display: flex;
+  width: 100%;
   flex-direction: column;
   align-items: flex-end;
   gap: 8px;
@@ -281,28 +285,28 @@ html[data-cpm-menu-open="1"] .cpm-map-mobile-filters {
 
 .cpm-map-mobile-filters__sheet {
   position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  left: 12px;
+  right: 12px;
+  top: calc(var(--cpm-header-h, 64px) + 8px);
   z-index: 10001;
   margin-inline: auto;
-  max-height: min(78vh, 640px);
-  width: 100%;
-  border-top-left-radius: 1rem;
-  border-top-right-radius: 1rem;
+  max-height: min(80dvh, 520px);
+  width: min(420px, calc(100vw - 24px));
+  border-radius: 1rem;
   background: #ffffff;
-  box-shadow: 0 -16px 32px rgba(15, 23, 42, 0.2);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.2);
   pointer-events: auto;
   display: flex;
   flex-direction: column;
   padding-bottom: env(safe-area-inset-bottom);
   transform: translateY(0);
+  overflow: hidden;
 }
 
 .cpm-map-mobile-filters__sheet-content {
   overflow-y: auto;
   padding: 1rem;
-  max-height: calc(min(78vh, 640px) - 56px - env(safe-area-inset-bottom));
+  max-height: calc(min(80dvh, 520px) - 56px - env(safe-area-inset-bottom));
 }
 
 @keyframes cpm-spin {
@@ -334,6 +338,6 @@ html[data-cpm-menu-open="1"] .cpm-map-mobile-filters {
   }
 
   .leaflet-top.leaflet-left {
-    margin-top: 56px;
+    margin-top: calc(var(--cpm-header-h, 64px) + 8px);
   }
 }


### PR DESCRIPTION
### Motivation
- Recent merges caused mobile UX regressions where the HUD overlapped the header/menu, the Filters toggle only produced a dim backdrop, place details briefly flashed on load, and single-pin taps did not reliably keep details open.
- The goal is to make place-details visibility deterministic, prevent hydration/transition flashes, ensure the mobile Filters sheet renders visibly, and avoid overlays covering the menu while preserving desktop behavior.

### Description
- Use `selectedPlaceId` (guarded by a `mounted` gate) as the single source of truth for open state via a new `isPlaceOpen = mounted && Boolean(selectedPlaceId)` and removed competing drawer toggles. (`components/map/MapClient.tsx`).
- Prevent initial flash by introducing `mounted` and only rendering drawer/sheet when mounted, and ensure closing is performed only via `setSelectedPlaceId(null)` to avoid race conditions. (`components/map/MapClient.tsx`).
- Make marker taps deterministic by always calling `setSelectedPlaceId(placeId)` on marker clicks and stopping event propagation/defaults so map click handlers do not immediately close the drawer. (`components/map/MapClient.tsx`).
- Ensure a selected id is only cleared if it no longer exists in the latest `places` list after fetch, preventing unexpected auto-closes during data refresh. (`components/map/MapClient.tsx`).
- Fix mobile Filters/HUD layout and stacking by converting mobile filters to a fixed, header-offset sheet with explicit dimensions, z-index, and visible close button, and hide HUD/filters when the global menu is open by observing `data-cpm-menu-open`. (`components/map/map.css`, `components/map/MapClient.tsx`).
- Keep the place-detail UI from overlapping the menu on mobile by hiding the mobile sheet while the menu is open and adjusting HUD positioning to respect header height and reserve right-side space. (`components/map/map.css`, `components/map/MapClient.tsx`).

### Testing
- Ran `npm run lint` which completed successfully with only non-blocking warnings about `<img>` usage and Next.js script guidance. (passed with warnings).
- Ran `npm run build` which produced a successful production build and type checks. (passed).
- Started the dev server and executed a Playwright script to capture desktop and mobile screenshots showing the filters sheet and desktop map, which completed and produced artifacts `desktop-map.png` and `mobile-filters.png`. (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fcef917908328af5ae0e98cb43fd7)