### PR TITLE
HOTFIX: single-source menu state and prevent menu from closing BottomSheet/Filters

### DIFF
--- a/components/GlobalHeader.tsx
+++ b/components/GlobalHeader.tsx
@@ -69,16 +69,30 @@ export default function GlobalHeader() {
       return;
     }
 
-    if (isMenuOpen) {
-      document.documentElement.setAttribute('data-cpm-menu-open', '1');
-      return () => {
-        document.documentElement.removeAttribute('data-cpm-menu-open');
-      };
-    }
+    document.documentElement.dataset.cpmMenuOpen = isMenuOpen ? 'true' : 'false';
 
-    document.documentElement.removeAttribute('data-cpm-menu-open');
     return undefined;
   }, [isMenuOpen]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const syncMenuState = () => {
+      setIsMenuOpen(document.documentElement.dataset.cpmMenuOpen === 'true');
+    };
+
+    const observer = new MutationObserver(syncMenuState);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-cpm-menu-open'],
+    });
+
+    syncMenuState();
+
+    return () => observer.disconnect();
+  }, []);
 
   const setDebugState = (enabled: boolean) => {
     setDebugMode(enabled);
@@ -134,14 +148,14 @@ export default function GlobalHeader() {
         </div>
       </div>
       <div
-        className={`fixed inset-0 z-[10000] bg-slate-950/35 transition-opacity duration-200 md:hidden ${
+        className={`fixed inset-0 z-[20000] bg-slate-950/35 transition-opacity duration-200 md:hidden ${
           isMenuOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
         }`}
         aria-hidden={!isMenuOpen}
         onClick={() => setIsMenuOpen(false)}
       />
       <aside
-        className={`fixed right-0 top-0 z-[10001] flex h-dvh w-[min(88vw,360px)] flex-col bg-white shadow-2xl transition-transform duration-200 md:hidden ${
+        className={`fixed right-0 top-0 z-[20001] flex h-dvh w-[min(88vw,360px)] flex-col bg-white shadow-2xl transition-transform duration-200 md:hidden ${
           isMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
         aria-hidden={!isMenuOpen}

--- a/components/map/map.css
+++ b/components/map/map.css
@@ -259,8 +259,8 @@
 
 .cpm-map-root[data-menu-open="true"] .cpm-map-mobile-hud-stack,
 .cpm-map-root[data-filters-open="true"] .cpm-map-mobile-hud-stack,
-.cpm-map-mobile-filters[data-menu-open="1"] .cpm-map-mobile-hud-stack,
-.cpm-map-mobile-filters[data-filters-open="1"] .cpm-map-mobile-hud-stack {
+.cpm-map-mobile-filters[data-menu-open="true"] .cpm-map-mobile-hud-stack,
+.cpm-map-mobile-filters[data-filters-open="true"] .cpm-map-mobile-hud-stack {
   opacity: 0;
   pointer-events: none;
   transform: translateY(-4px);
@@ -271,7 +271,7 @@
   inset: 0;
   border: none;
   background: rgba(15, 23, 42, 0.32);
-  z-index: 20000;
+  z-index: 19000;
   pointer-events: auto;
 }
 
@@ -279,7 +279,7 @@
   position: fixed;
   right: 12px;
   bottom: calc(env(safe-area-inset-bottom) + 12px);
-  z-index: 20001;
+  z-index: 19001;
   max-height: 72vh;
   width: min(92vw, 420px);
   border-radius: 1rem;


### PR DESCRIPTION
### Motivation
- Fix mobile bugs where opening Filters only dimmed the screen and tapping pins caused place details to flicker or auto-close due to an out-of-sync menu state.
- Make `menuOpen` deterministic by using a single source of truth on the document element so different components can reliably observe menu state.
- Ensure BottomSheet (place details) and Filters are controlled by their own selection/visibility state instead of being force-closed by the menu.

### Description
- `GlobalHeader`: switch to a single authoritative flag using `document.documentElement.dataset.cpmMenuOpen = 'true' | 'false'` and add a `MutationObserver` to stay in sync with external updates, and raise menu z-index to `20000/20001` for backdrop/sheet stacking.
- `MapClient`: add explicit `isPlaceOpen` state and derive the mobile bottom sheet open state as `isMobilePlaceOpen = mounted && isPlaceOpen && Boolean(selectedPlaceId)`, initialize and sync `isMenuOpen` from `document.documentElement.dataset.cpmMenuOpen` via a `MutationObserver`, and stop gating mobile filters/bottom sheet on `isMenuOpen` so each sheet renders from its own state.
- Close Menu when opening Filters by writing `document.documentElement.dataset.cpmMenuOpen = 'false'` in the filters toggle so Menu and Filters are mutually exclusive at the document-dataset level.
- `map.css`: adjust selectors and z-indexes so Filters render above the map and below Menu (`19000/19001`), and ensure HUD hide rules use the `data-*` attribute values consistently (`"true"`/`"false"`).

### Testing
- Ran `npm run lint` which completed successfully (standard Next.js warnings unrelated to this fix were reported but non-blocking).
- Started the dev server and exercised flows via a Playwright mobile-emulation script that performed the following scenarios and succeeded: `Menu open` (HUD hidden), `Tap Filters` (Filters sheet visible and Menu closed), and `Tap a pin` (place details opens and remains open); screenshots were produced at `artifacts/menu-open-hud-hidden.png`, `artifacts/filters-open-visible.png`, and `artifacts/pin-tapped-place-details.png`.
- Dev sanity: application compiled and map interactions were validated in the mobile emulation and desktop dev server run (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908aea380c83289102f6988ec3996a)