### PR TITLE
fix: normalize sheet links (navigate=maps only) across place shapes

### DIFF
--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -44,23 +44,6 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
       return () => document.removeEventListener("keydown", handleKeyDown);
     }, [isOpen, onClose]);
 
-    const navigationLinks = useMemo(() => {
-      if (!place) return [] as { label: string; href: string; key: string }[];
-      const destination = `${place.lat},${place.lng}`;
-      return [
-        {
-          key: "google-maps",
-          label: "Google Maps",
-          href: `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(destination)}`,
-        },
-        {
-          key: "apple-maps",
-          label: "Apple Maps",
-          href: `http://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
-        },
-      ];
-    }, [place]);
-
     const viewModel = useMemo(() => getPlaceViewModel(place), [place]);
 
     if (!place) {
@@ -114,8 +97,10 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
       !isRestricted && Boolean(place.description ?? place.about);
     const shortAddress = [place.city, place.country].filter(Boolean).join(", ");
     const fullAddress = viewModel.fullAddress;
-    const canShowLinks = viewModel.socialLinks.length > 0;
-    const canShowNavigation = !isRestricted && navigationLinks.length > 0;
+    const canShowWebsite = Boolean(viewModel.websiteLink);
+    const canShowSocial = viewModel.socialLinks.length > 0;
+    const canShowPhone = Boolean(viewModel.phoneLink);
+    const canShowNavigation = viewModel.navigateLinks.length > 0;
     const canShowFullAddress = Boolean(fullAddress);
     const amenities = viewModel.amenities;
     const paymentNote = viewModel.paymentNote;
@@ -208,9 +193,25 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
               </section>
             )}
 
-            {canShowLinks && (
+            {canShowWebsite && (
               <section className="cpm-drawer__section">
-                <h3 className="cpm-drawer__section-title">Links</h3>
+                <h3 className="cpm-drawer__section-title">Website</h3>
+                <div className="cpm-drawer__links">
+                  <a
+                    className="cpm-drawer__link"
+                    href={viewModel.websiteLink!.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {viewModel.websiteLink!.label}
+                  </a>
+                </div>
+              </section>
+            )}
+
+            {canShowSocial && (
+              <section className="cpm-drawer__section">
+                <h3 className="cpm-drawer__section-title">SNS</h3>
                 <div className="cpm-drawer__links">
                   {viewModel.socialLinks.map((social) => (
                     <a
@@ -227,11 +228,22 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
               </section>
             )}
 
+            {canShowPhone && (
+              <section className="cpm-drawer__section">
+                <h3 className="cpm-drawer__section-title">Phone</h3>
+                <div className="cpm-drawer__links">
+                  <a className="cpm-drawer__link" href={viewModel.phoneLink!.href}>
+                    {viewModel.phoneLink!.label}
+                  </a>
+                </div>
+              </section>
+            )}
+
             {canShowNavigation && (
               <section className="cpm-drawer__section">
                 <h3 className="cpm-drawer__section-title">Navigate</h3>
                 <div className="cpm-drawer__nav">
-                  {navigationLinks.map((link) => (
+                  {viewModel.navigateLinks.map((link) => (
                     <a
                       key={link.key}
                       className="cpm-drawer__nav-link"

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -52,6 +52,24 @@ const placeToPin = (place: Place): Pin => ({
   verification: place.verification,
 });
 
+const mergePlaceSummaryAndDetail = (summary: Place | null, detail: Place | null): Place | null => {
+  if (!summary && !detail) return null;
+  if (!summary) return detail;
+  if (!detail) return summary;
+
+  const merged = { ...summary } as Place & Record<string, unknown>;
+  const detailRecord = detail as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(detailRecord)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === "string" && value.trim().length === 0) continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    merged[key] = value;
+  }
+
+  return merged as Place;
+};
+
 export default function MapClient() {
   const router = useRouter();
   const pathname = usePathname();
@@ -615,7 +633,10 @@ export default function MapClient() {
     [places, selectedPlaceId],
   );
   const shouldLoadSelectedPlaceDetail = Boolean(selectedPlaceId) && isPlaceOpen;
-  const selectedPlaceForDrawer = selectedPlaceDetail ?? selectedPlace;
+  const selectedPlaceForDrawer = useMemo(
+    () => mergePlaceSummaryAndDetail(selectedPlace, selectedPlaceDetail),
+    [selectedPlace, selectedPlaceDetail],
+  );
 
   useEffect(() => {
     if (!selectedPlaceId || !shouldLoadSelectedPlaceDetail) {

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -34,23 +34,6 @@ const VERIFICATION_LABELS: Record<Place["verification"], string> = {
   unverified: "Unverified",
 };
 
-const buildNavigationLinks = (place: Place | null) => {
-  if (!place) return [] as { label: string; href: string; key: string }[];
-  const destination = `${place.lat},${place.lng}`;
-  return [
-    {
-      key: "google-maps",
-      label: "Google Maps",
-      href: `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(destination)}`,
-    },
-    {
-      key: "apple-maps",
-      label: "Apple Maps",
-      href: `http://maps.apple.com/?daddr=${encodeURIComponent(destination)}`,
-    },
-  ];
-};
-
 const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
   ({ place, isOpen, onClose, selectionStatus = "idle", onStageChange }, ref) => {
     const [stage, setStage] = useState<SheetStage>("peek");
@@ -80,7 +63,6 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
     }, [isOpen, place]);
 
     const viewModel = useMemo(() => getPlaceViewModel(renderedPlace), [renderedPlace]);
-    const navigationLinks = useMemo(() => buildNavigationLinks(renderedPlace), [renderedPlace]);
     const photos = viewModel.media;
 
     const isRestricted =
@@ -297,10 +279,28 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
               </section>
             )}
 
+            {showDetails && viewModel.websiteLink && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Website</h3>
+                </div>
+                <div className="cpm-bottom-sheet__links">
+                  <a
+                    className="cpm-bottom-sheet__link"
+                    href={viewModel.websiteLink.href}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {viewModel.websiteLink.label}
+                  </a>
+                </div>
+              </section>
+            )}
+
             {showDetails && viewModel.socialLinks.length > 0 && (
               <section className="cpm-bottom-sheet__section">
                 <div className="cpm-bottom-sheet__section-head">
-                  <h3 className="cpm-bottom-sheet__section-title">Links</h3>
+                  <h3 className="cpm-bottom-sheet__section-title">SNS</h3>
                 </div>
                 <div className="cpm-bottom-sheet__links">
                   {viewModel.socialLinks.map((social) => (
@@ -318,13 +318,26 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
               </section>
             )}
 
-            {showDetails && !isRestricted && navigationLinks.length > 0 && (
+            {showDetails && viewModel.phoneLink && (
+              <section className="cpm-bottom-sheet__section">
+                <div className="cpm-bottom-sheet__section-head">
+                  <h3 className="cpm-bottom-sheet__section-title">Phone</h3>
+                </div>
+                <div className="cpm-bottom-sheet__links">
+                  <a className="cpm-bottom-sheet__link" href={viewModel.phoneLink.href}>
+                    {viewModel.phoneLink.label}
+                  </a>
+                </div>
+              </section>
+            )}
+
+            {showDetails && viewModel.navigateLinks.length > 0 && (
               <section className="cpm-bottom-sheet__section">
                 <div className="cpm-bottom-sheet__section-head">
                   <h3 className="cpm-bottom-sheet__section-title">Navigate</h3>
                 </div>
                 <div className="cpm-bottom-sheet__nav">
-                  {navigationLinks.map((link) => (
+                  {viewModel.navigateLinks.map((link) => (
                     <a
                       key={link.key}
                       className="cpm-bottom-sheet__nav-link"


### PR DESCRIPTION
### Motivation
- シート（モバイルBottomSheet / PC Drawer）内のリンク表示が場所の shape（summary vs detail / verification）でばらつき・欠落・重複していたため表示を正規化する。 
- `Navigate` を経路リンク（外部地図：Google/Apple）に限定し、`Website` / `SNS` / `Phone` を別枠で表示して混在を防ぐ。 
- summary と detail のフィールド差を吸収するため、表示データは `summary + detail` のマージを使って安定して描画する。

### Description
- `components/map/placeViewModel.ts` に表示用 viewModel を拡張し、`navigateLinks`（Google/Apple の directions URL）、`websiteLink`、`socialLinks`、`phoneLink` を生成する共通ロジックを追加し重複排除・正規化を行う（`https://` 補完、`tel:` 生成、@ハンドル処理など）。
- `components/map/Drawer.tsx` を更新して旧来の混在した `Links` を `Website` / `SNS` / `Phone` / `Navigate` の別枠に分割し、`Navigate` のロジックは viewModel に一本化して全クラスで同一条件に統一（verification による Navigate 除外分岐を撤廃）。
- `components/map/MobileBottomSheet.tsx` でも Drawer と同じ viewModel を使うようにし、ローカルの Navigate 生成を削除して表示を PC と同一構成に揃えた。 
- `components/map/MapClient.tsx` で表示用 place は `summary + detail` をマージした結果を渡すように変更し、detail の取得失敗時でも summary でフォールバック表示するようにした（UI 上の places 配列は置換しない）。

### Testing
- `rg` 検索で関連箇所を横断確認（`Navigate|Apple Maps|Google Maps|maps.apple|google.com/maps|website|twitter|instagram|facebook|tel:`）を実行し対象ファイルを特定（成功）。
- `npm run build` を実行してビルドを通過させた（`next build` の最適化・静的ページ生成を含め成功）。
- 開発サーバーを起動して `/api/places` を `curl` で確認しサンプルデータ取得に成功（フォールバック動作を確認）。
- Playwright を使ったスクリーンショットでデスクトップ（Drawer）とモバイル（BottomSheet）を確認し、`Website` / `SNS` / `Phone` / `Navigate` が両方で揃って表示されることを確認（スクリーンショット生成成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947a9e74688328b2ce30192074bc4b)