### PR TITLE
fix: move locate control down to avoid zoom overlap on desktop

### DIFF
--- a/components/map/map.css
+++ b/components/map/map.css
@@ -323,3 +323,9 @@
     margin-top: calc(var(--cpm-header-h, 64px) + 8px);
   }
 }
+
+@media (min-width: 1024px) {
+  .cpm-map-controls {
+    margin-top: 72px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent the `.cpm-map-controls` (Locate button) from overlapping the Leaflet zoom control on desktop by moving the Locate control downward with a minimal, CSS-only change.

### Description
- Added a desktop-only media rule in `components/map/map.css` (`@media (min-width: 1024px)`) that sets `.cpm-map-controls { margin-top: 72px; }` to shift the Locate control downward; mobile behavior remains unchanged and no header/menu or logo changes were made.

### Testing
- Ran `npm run dev` and the app started successfully, captured Playwright screenshots for desktop before/after and mobile after, and ran `npm run build` which completed successfully with no build failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948a43990c8328a6a81e798671710b)