### PR TITLE
Drawer/Sheet: show loading placeholder until place detail arrives

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -672,8 +672,9 @@ export default function MapClient() {
     [places, selectedPlaceId],
   );
   const shouldLoadSelectedPlaceDetail = Boolean(selectedPlaceId) && isPlaceOpen;
+  const isWaitingForSelectedPlaceDetail = shouldLoadSelectedPlaceDetail && !selectedPlaceDetail;
   const selectedPlaceForDrawer = useMemo(
-    () => mergePlaceSummaryAndDetail(selectedPlace, selectedPlaceDetail),
+    () => (selectedPlaceDetail ? mergePlaceSummaryAndDetail(selectedPlace, selectedPlaceDetail) : null),
     [selectedPlace, selectedPlaceDetail],
   );
 
@@ -780,7 +781,7 @@ if (!selectionHydrated) {
     return () => window.clearTimeout(timeout);
   }, [selectionNotice]);
 
-  const selectionStatus = selectedPlace ? "idle" : selectedPlaceDetailStatus;
+  const selectionStatus = isWaitingForSelectedPlaceDetail ? "loading" : selectedPlaceDetailStatus;
 
   const hasActiveFilters = useMemo(
     () =>

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -52,6 +52,8 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
         return;
       }
 
+      setRenderedPlace(null);
+
       if (!isOpen) {
         previousPlaceIdRef.current = null;
         setStage("peek");
@@ -74,7 +76,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
     }, [isOpen, onStageChange, stage]);
     const canShowPhotos = photos.length > 0;
     const canShowDescription =
-      renderedPlace && !isRestricted && (renderedPlace.description ?? renderedPlace.about);
+      Boolean(renderedPlace && !isRestricted && (renderedPlace.description ?? renderedPlace.about));
     const fullAddress = viewModel.fullAddress;
     const shortAddress = [renderedPlace?.city, renderedPlace?.country].filter(Boolean).join(", ");
     const amenities = viewModel.amenities;


### PR DESCRIPTION
### Motivation
- Prevent the Drawer/Sheet from rendering body sections based on summary data and then later popping in detail sections, by showing a loading/skeleton until the full detail is available.
- Keep header/menu/logo and overall UI unchanged; only tighten loading/placeholder behavior to avoid visual gaps.

### Description
- MapClient: add `isWaitingForSelectedPlaceDetail` and only compute `selectedPlaceForDrawer` when `selectedPlaceDetail` exists, so the Drawer/Sheet receives merged data only after detail load. (`components/map/MapClient.tsx`).
- MapClient: set `selectionStatus` to `loading` while `selectedPlaceId && isPlaceOpen && selectedPlaceDetail === null` to drive placeholder UI.
- MobileBottomSheet: clear stale `renderedPlace` immediately when a new selection is loading so the placeholder/loading state appears consistently, and normalize `canShowDescription` to a strict boolean to avoid truthy string behavior. (`components/map/MobileBottomSheet.tsx`).
- `mergePlaceSummaryAndDetail` is left intact; rendering is gated on detail completion instead of changing merge logic.

### Testing
- Ran `npm run build` and the build completed successfully with warnings only (no errors). (Succeeded)
- Launched the dev server and ran a Playwright script which navigated to `/map`, clicked a marker and captured a screenshot to validate the Drawer/Sheet shows the loading placeholder while detail loads (screenshot saved by the run). (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b8771d3083289f86920b7260e036)