### PR TITLE
chore: remove verification section (badge-only)

### DIFF
--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -168,11 +168,6 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
               </div>
             </section>
 
-            <section className="cpm-drawer__section">
-              <h3 className="cpm-drawer__section-title">Verification</h3>
-              <p className="cpm-drawer__body">{VERIFICATION_LABELS[place.verification]}</p>
-            </section>
-
             {canShowPhotos && (
               <section className="cpm-drawer__section">
                 <h3 className="cpm-drawer__section-title">Photos</h3>

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -256,15 +256,6 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
               </div>
             </section>
 
-            {showDetails && (
-              <section className="cpm-bottom-sheet__section">
-                <div className="cpm-bottom-sheet__section-head">
-                  <h3 className="cpm-bottom-sheet__section-title">Verification</h3>
-                </div>
-                <p className="cpm-bottom-sheet__body">{VERIFICATION_LABELS[renderedPlace.verification]}</p>
-              </section>
-            )}
-
             {showDetails && canShowPhotos && (
               <section className="cpm-bottom-sheet__section">
                 <div className="cpm-bottom-sheet__section-head">


### PR DESCRIPTION
### Motivation
- Remove duplicated "Verification" section rendered in the Drawer and BottomSheet body since the verification is already shown as a header badge. 
- Keep header/menu structure and logo asset unchanged and avoid UI redesign.

### Description
- Removed the body `Verification` section from `components/map/Drawer.tsx` (the `<section>` with title "Verification" and the paragraph rendering `VERIFICATION_LABELS[place.verification]`).
- Removed the body `Verification` section from `components/map/MobileBottomSheet.tsx` (the `<section>` guarded by `showDetails` that rendered `VERIFICATION_LABELS[renderedPlace.verification]`).
- Left header badge rendering untouched for both desktop and mobile so verification remains visible as a badge.
- Files modified: `components/map/Drawer.tsx`, `components/map/MobileBottomSheet.tsx`.

### Testing
- Ran `rg -n --hidden --no-heading "VERIFICATION|Verification" -S components app` to locate occurrences and verify removal of the duplicated body sections; succeeded.
- Ran `npm run build` and the Next.js production build completed successfully with only lint/warning messages; succeeded.
- Started the dev server with `npm run dev` and performed manual UI checks to confirm the Drawer and BottomSheet bodies no longer show the Verification section while the header badge remains; succeeded.
- Captured automated screenshots via a Playwright script for PC and mobile to validate the change; screenshots generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995b9a0dcc483289f8a344adb8431be)