### PR TITLE
feat: expand /api/places to SummaryPlus; make detail fetch fallback-only

### DIFF
--- a/components/map/Drawer.tsx
+++ b/components/map/Drawer.tsx
@@ -93,8 +93,8 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
     const isRestricted =
       place.verification === "directory" || place.verification === "unverified";
     const canShowPhotos = photos.length > 0;
-    const canShowDescription =
-      !isRestricted && Boolean(place.description ?? place.about);
+    const descriptionText = place.description ?? place.about_short ?? place.about ?? null;
+    const canShowDescription = !isRestricted && Boolean(descriptionText);
     const shortAddress = [place.city, place.country].filter(Boolean).join(", ");
     const fullAddress = viewModel.fullAddress;
     const canShowWebsite = Boolean(viewModel.websiteLink);
@@ -184,7 +184,7 @@ const Drawer = forwardRef<HTMLDivElement, Props>(
             {canShowDescription && (
               <section className="cpm-drawer__section">
                 <h3 className="cpm-drawer__section-title">Description</h3>
-                <p className="cpm-drawer__body">{place.description ?? place.about}</p>
+                <p className="cpm-drawer__body">{descriptionText}</p>
               </section>
             )}
 

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -75,8 +75,8 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
       onStageChange?.(stage);
     }, [isOpen, onStageChange, stage]);
     const canShowPhotos = photos.length > 0;
-    const canShowDescription =
-      Boolean(renderedPlace && !isRestricted && (renderedPlace.description ?? renderedPlace.about));
+    const descriptionText = renderedPlace?.description ?? renderedPlace?.about_short ?? renderedPlace?.about ?? null;
+    const canShowDescription = Boolean(renderedPlace && !isRestricted && descriptionText);
     const fullAddress = viewModel.fullAddress;
     const shortAddress = [renderedPlace?.city, renderedPlace?.country].filter(Boolean).join(", ");
     const amenities = viewModel.amenities;
@@ -276,7 +276,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
                 <div className="cpm-bottom-sheet__section-head">
                   <h3 className="cpm-bottom-sheet__section-title">Description</h3>
                 </div>
-                <p className="cpm-bottom-sheet__body">{renderedPlace.description ?? renderedPlace.about}</p>
+                <p className="cpm-bottom-sheet__body">{descriptionText}</p>
               </section>
             )}
 

--- a/components/map/placeViewModel.ts
+++ b/components/map/placeViewModel.ts
@@ -81,6 +81,27 @@ const normalizeWebsiteLink = (place: Place) => {
   };
 };
 
+const normalizeSocialHref = (value: string, baseUrl: string) => {
+  if (/^https?:\/\//i.test(value)) {
+    return value;
+  }
+  const handle = value.replace(/^@/, "");
+  return `${baseUrl}${handle}`;
+};
+
+const normalizeSocialLabel = (value: string, prefixAt = true) => {
+  if (/^https?:\/\//i.test(value)) {
+    try {
+      const url = new URL(value);
+      return url.hostname.replace(/^www\./, "") + url.pathname;
+    } catch {
+      return value;
+    }
+  }
+  const handle = value.replace(/^@/, "");
+  return prefixAt ? `@${handle}` : handle;
+};
+
 const normalizeSocialLinks = (place: Place) => {
   const entries: { label: string; href: string; key: string }[] = [];
   const twitter = normalizeText(place.twitter) || normalizeText(place.social_twitter);
@@ -88,16 +109,25 @@ const normalizeSocialLinks = (place: Place) => {
   const facebook = normalizeText(place.facebook);
 
   if (twitter) {
-    const handle = twitter.replace(/^@/, "");
-    entries.push({ key: "twitter", label: `@${handle}`, href: `https://twitter.com/${handle}` });
+    entries.push({
+      key: "twitter",
+      label: normalizeSocialLabel(twitter, true),
+      href: normalizeSocialHref(twitter, "https://twitter.com/"),
+    });
   }
   if (instagram) {
-    const handle = instagram.replace(/^@/, "");
-    entries.push({ key: "instagram", label: `@${handle}`, href: `https://instagram.com/${handle}` });
+    entries.push({
+      key: "instagram",
+      label: normalizeSocialLabel(instagram, true),
+      href: normalizeSocialHref(instagram, "https://instagram.com/"),
+    });
   }
   if (facebook) {
-    const handle = facebook.replace(/^@/, "");
-    entries.push({ key: "facebook", label: handle, href: `https://facebook.com/${handle}` });
+    entries.push({
+      key: "facebook",
+      label: normalizeSocialLabel(facebook, false),
+      href: normalizeSocialHref(facebook, "https://facebook.com/"),
+    });
   }
 
   return Array.from(new Map(entries.map((entry) => [entry.href, entry])).values());

--- a/types/places.ts
+++ b/types/places.ts
@@ -29,5 +29,6 @@ export type Place = {
   updatedAt?: string;
   coverImage?: string | null;
   about?: string | null;
+  about_short?: string | null;
   paymentNote?: string | null;
 };


### PR DESCRIPTION
### Motivation
- Reduce UI flicker by returning the major fields the drawer/sheet needs from the list endpoint so the map can render immediately without always fetching heavy details. 
- Keep the two-phase API (list/detail) but make the detail endpoint a fallback for heavy payloads (images, long about text). 
- Preserve header/menu/logo and avoid UI structure changes; only supply more data in `/api/places` and make a conservative change to the Map client fetch behavior.

### Description
- Introduced `PlaceSummaryPlus` for `/api/places` and added these keys: `address_full`, `about_short`, `paymentNote`, `amenities`, `phone`, `website`, `twitter`, `instagram`, `facebook`, `coverImage`, while keeping existing keys `id,name,lat,lng,verification,category,city,country,accepted`.
- Implemented extraction/normalization rules in `app/api/places/route.ts`: `about_short` is truncated to 400 chars, `address_full` is synthesized from `address+city+country` when missing, `amenities` normalizes arrays/JSON/comma lists, and `coverImage` uses priority `coverImage > images[0] > photos[0] > media[0]` (only one cover image is returned in list responses; image arrays remain on detail endpoint).
- DB list query now pulls `places` columns (`address/about/amenities/payment_note`), `socials` (website/phone/twitter/instagram/facebook) and `media` (first media URL) and assembles `PlaceSummaryPlus`; JSON fallback is mapped to the same shape and `dryRun` was shape-updated.
- Map client change: auto detail fetch is no longer unconditional — it runs only when the selected place is missing summary-plus data (i.e. selected summary absent or all major SummaryPlus keys are empty); `Drawer` and `MobileBottomSheet` now prefer `description ?? about_short ?? about` so short text from the list appears immediately; social links normalization was improved to support both handle and full-URL formats.

### Testing
- `npm run build` was executed and ultimately succeeded after fixing a type mismatch during development (final `next build` completed successfully).
- Automated runtime checks: started dev server and fetched `/api/places?limit=1` to validate the returned keys, which returned the expected SummaryPlus shape (keys list verified).
- Headless UI smoke check using Playwright (script) visited `/map`, clicked a pin and produced a screenshot showing the drawer rendering from list-provided data (screenshot artifact produced).
- All automated runs above reported success (build succeeded, JSON shape check succeeded, Playwright script produced screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995c35ab6748328b25c9ca0dced9c6a)