### PR TITLE
Add debug-only mobile bottom sheet flicker instrumentation

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -152,8 +152,15 @@ export default function MapClient() {
 
   const isMobilePlaceOpen = mounted && isPlaceOpen && Boolean(selectedPlaceId);
   const drawerMode: "full" = "full";
+  const debugSheetEnabled = searchParams.get("debugSheet") === "1";
+  const debugNoHeightAnim = debugSheetEnabled && searchParams.get("noHeightAnim") === "1";
+  const debugNoTransformAnim = debugSheetEnabled && searchParams.get("noTransformAnim") === "1";
+  const debugNoInvalidate = debugSheetEnabled && searchParams.get("noInvalidate") === "1";
+  const debugNoPlaceholderExpand =
+    debugSheetEnabled && searchParams.get("noPlaceholderExpand") === "1";
 
   const invalidateMapSize = useCallback(() => {
+    if (debugNoInvalidate) return;
     const map = mapInstanceRef.current;
     if (!map) return;
     if (invalidateTimeoutRef.current !== null) {
@@ -166,7 +173,7 @@ export default function MapClient() {
         invalidateTimeoutRef.current = null;
       }, 120);
     });
-  }, []);
+  }, [debugNoInvalidate]);
 
   const toggleFilters = useCallback(() => {
     setFiltersOpen((previous) => {
@@ -1193,6 +1200,12 @@ if (!selectionHydrated) {
               onClose={() => closeDrawer("user")}
               ref={bottomSheetRef}
               selectionStatus={selectionStatus}
+              debugOptions={{
+                enabled: debugSheetEnabled,
+                noHeightAnim: debugNoHeightAnim,
+                noTransformAnim: debugNoTransformAnim,
+                noPlaceholderExpand: debugNoPlaceholderExpand,
+              }}
               onStageChange={() => {
                 invalidateMapSize();
               }}

--- a/components/map/MobileBottomSheet.css
+++ b/components/map/MobileBottomSheet.css
@@ -22,6 +22,30 @@
   touch-action: pan-y;
 }
 
+.cpm-bottom-sheet__panel--no-height-anim {
+  transition: transform 0.25s ease;
+}
+
+.cpm-bottom-sheet__panel--no-transform-anim {
+  transition: height 0.25s ease;
+}
+
+.cpm-bottom-sheet__panel--no-height-anim.cpm-bottom-sheet__panel--no-transform-anim {
+  transition: none;
+}
+
+.cpm-bottom-sheet__debug-hud {
+  margin: 8px 12px 0;
+  padding: 8px;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.95);
+  color: #e2e8f0;
+  font-size: 11px;
+  line-height: 1.35;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  word-break: break-word;
+}
+
 .cpm-bottom-sheet.open .cpm-bottom-sheet__panel {
   transform: translateY(0);
 }


### PR DESCRIPTION
### Motivation
- Instrument the mobile bottom sheet to determine the root cause of the flicker visible when transitioning from closed → pin selection without making UX fixes in this PR.  The instrumentation is gated behind a debug flag so normal users are unaffected.

### Description
- Add debug-only HUD, 3-frame RAF logging, and `ResizeObserver` metrics to `MobileBottomSheet` and surface computed `height`/`transform`/`transition`, `className`, `mountCount`/`panelMountCount`, `place.id`/`renderedPlace.id`, `stage`/`effectiveStage`, `showPlaceholder` and a timestamp when `debugSheet=1` is present in the URL.
- Add debug query switches parsed in `MapClient`: `debugSheet=1`, `noHeightAnim=1`, `noTransformAnim=1`, `noInvalidate=1`, and `noPlaceholderExpand=1`; pass `debugOptions` into `MobileBottomSheet` and guard `invalidateMapSize()` with `noInvalidate` so it is skipped only in debug mode.
- Add CSS helpers in `MobileBottomSheet.css` to selectively disable height/transform transitions and style the HUD (`.cpm-bottom-sheet__panel--no-height-anim`, `.cpm-bottom-sheet__panel--no-transform-anim`, `.cpm-bottom-sheet__debug-hud`).
- All instrumentation is debug-only and does not change default behavior unless `debugSheet=1` is used.

### Testing
- Built the app with `npm run build` which completed successfully after fixes to hook placement and produced the optimized build artifacts (build succeeded).
- Ran the dev server with `npm run dev` and executed a headless browser script (Playwright) against `http://127.0.0.1:3000/map?debugSheet=1` to capture the HUD and console 3-frame logs, producing `artifacts/debug-hud.png` and `artifacts/debug-console-logs.png` (screenshots captured successfully).
- Verified `invalidateMapSize()` is skipped when `noInvalidate=1` is set and `MobileBottomSheet` receives `debugOptions` from `MapClient` (manual instrumented checks during dev server run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996ed70ac1483288d106e74011ef154)