### PR TITLE
Add hash-gated MobileBottomSheet debug HUD with event history sampling

### DIFF
--- a/components/map/MobileBottomSheet.css
+++ b/components/map/MobileBottomSheet.css
@@ -292,3 +292,31 @@
   border: none;
   background: rgba(15, 23, 42, 0.32);
 }
+
+.cpm-bottom-sheet__debug-hud {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  right: 8px;
+  max-height: 48vh;
+  overflow: auto;
+  padding: 8px;
+  background: rgba(15, 23, 42, 0.88);
+  color: #f8fafc;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 11px;
+  line-height: 1.35;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  pointer-events: none;
+  z-index: 3;
+}
+
+.cpm-bottom-sheet__debug-log {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.cpm-bottom-sheet__debug-log li {
+  margin: 2px 0;
+}

--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { forwardRef, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { Place } from "../../types/places";
 import { getPlaceViewModel } from "./placeViewModel";
@@ -16,6 +16,13 @@ type Props = {
 };
 
 type SheetStage = "peek" | "expanded";
+type DebugEventName = "open" | "close" | "setRenderedPlace" | "stageChange" | "rafSample" | "panelMount";
+
+type DebugEvent = {
+  at: number;
+  event: DebugEventName;
+  details: string;
+};
 
 const PEEK_HEIGHT = 35;
 const EXPANDED_HEIGHT = 88;
@@ -38,14 +45,59 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
   ({ place, isOpen, onClose, selectionStatus = "idle", onStageChange }, ref) => {
     const [stage, setStage] = useState<SheetStage>("peek");
     const [renderedPlace, setRenderedPlace] = useState<Place | null>(null);
+    const [debugEnabled, setDebugEnabled] = useState(false);
+    const [debugHistory, setDebugHistory] = useState<DebugEvent[]>([]);
+    const [panelMountCount, setPanelMountCount] = useState(0);
+    const [computedPanelHeight, setComputedPanelHeight] = useState("-");
+    const [computedPanelTransform, setComputedPanelTransform] = useState("-");
     const touchStartY = useRef<number | null>(null);
     const touchCurrentY = useRef<number | null>(null);
     const previousPlaceIdRef = useRef<string | null>(null);
+    const panelElementRef = useRef<HTMLDivElement | null>(null);
+    const rafFrameRef = useRef<number | null>(null);
+    const openSampleTimeoutRef = useRef<number | null>(null);
+    const isSamplingRef = useRef(false);
+    const mountCountRef = useRef(0);
+    const stageRef = useRef<SheetStage>("peek");
+    const lastPanelNodeRef = useRef<HTMLDivElement | null>(null);
+
+    const pushDebugEvent = (event: DebugEventName, details: string) => {
+      const at = typeof performance !== "undefined" ? performance.now() : Date.now();
+      setDebugHistory((prev) => {
+        const next = [...prev, { at, event, details }];
+        return next.slice(-50);
+      });
+    };
+
+    useEffect(() => {
+      const syncFromHash = () => {
+        setDebugEnabled(window.location.hash.includes("debugSheet"));
+      };
+
+      syncFromHash();
+      window.addEventListener("hashchange", syncFromHash);
+      return () => window.removeEventListener("hashchange", syncFromHash);
+    }, []);
+
+    useEffect(() => {
+      mountCountRef.current += 1;
+    }, []);
+
+    useEffect(() => {
+      if (!debugEnabled) {
+        setDebugHistory([]);
+        setComputedPanelHeight("-");
+        setComputedPanelTransform("-");
+      }
+    }, [debugEnabled]);
 
     useEffect(() => {
       if (place) {
         previousPlaceIdRef.current = place.id;
         setRenderedPlace(place);
+        if (debugEnabled) {
+          pushDebugEvent("setRenderedPlace", `renderedPlace.id=${place.id}`);
+        }
         if (!isOpen) {
           setStage("peek");
         }
@@ -53,6 +105,9 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
       }
 
       setRenderedPlace(null);
+      if (debugEnabled) {
+        pushDebugEvent("setRenderedPlace", "renderedPlace=null");
+      }
 
       if (!isOpen) {
         previousPlaceIdRef.current = null;
@@ -62,7 +117,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
       }
 
       return undefined;
-    }, [isOpen, place]);
+    }, [debugEnabled, isOpen, place]);
 
     const viewModel = useMemo(() => getPlaceViewModel(renderedPlace), [renderedPlace]);
     const photos = viewModel.media;
@@ -74,6 +129,65 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
       if (!isOpen) return;
       onStageChange?.(stage);
     }, [isOpen, onStageChange, stage]);
+
+    useEffect(() => {
+      if (!debugEnabled) return;
+      pushDebugEvent("stageChange", `stage=${stage}`);
+    }, [debugEnabled, stage]);
+
+    useEffect(() => {
+      stageRef.current = stage;
+    }, [stage]);
+
+    useEffect(() => {
+      if (!debugEnabled) return;
+      pushDebugEvent(isOpen ? "open" : "close", `isOpen=${String(isOpen)}`);
+    }, [debugEnabled, isOpen]);
+
+    useEffect(() => {
+      if (!debugEnabled || !isOpen) return;
+
+      const panel = panelElementRef.current;
+      if (!panel) return;
+
+      isSamplingRef.current = true;
+      const startedAt = performance.now();
+
+      const sampleFrame = () => {
+        if (!isSamplingRef.current) {
+          return;
+        }
+        const style = window.getComputedStyle(panel);
+        const height = style.height;
+        const transform = style.transform;
+        setComputedPanelHeight(height);
+        setComputedPanelTransform(transform);
+        pushDebugEvent("rafSample", `height=${height}; transform=${transform}; effectiveStage=${stageRef.current}`);
+        rafFrameRef.current = window.requestAnimationFrame(sampleFrame);
+      };
+
+      sampleFrame();
+      openSampleTimeoutRef.current = window.setTimeout(() => {
+        isSamplingRef.current = false;
+        if (rafFrameRef.current !== null) {
+          window.cancelAnimationFrame(rafFrameRef.current);
+          rafFrameRef.current = null;
+        }
+        pushDebugEvent("rafSample", `stop: ${(performance.now() - startedAt).toFixed(1)}ms`);
+      }, 500);
+
+      return () => {
+        isSamplingRef.current = false;
+        if (openSampleTimeoutRef.current !== null) {
+          window.clearTimeout(openSampleTimeoutRef.current);
+          openSampleTimeoutRef.current = null;
+        }
+        if (rafFrameRef.current !== null) {
+          window.cancelAnimationFrame(rafFrameRef.current);
+          rafFrameRef.current = null;
+        }
+      };
+    }, [debugEnabled, isOpen]);
     const canShowPhotos = photos.length > 0;
     const descriptionText = renderedPlace?.description ?? renderedPlace?.about_short ?? renderedPlace?.about ?? null;
     const canShowDescription = Boolean(renderedPlace && !isRestricted && descriptionText);
@@ -123,15 +237,65 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
       touchCurrentY.current = null;
     };
 
-    if (!renderedPlace && !isOpen) {
-      return null;
-    }
-
     const showPlaceholder = isOpen && !renderedPlace;
     const effectiveStage = stage;
     const sheetHeight = effectiveStage === "expanded" ? `${EXPANDED_HEIGHT}vh` : `${PEEK_HEIGHT}vh`;
     const showDetails = effectiveStage === "expanded";
     const isVisible = isOpen && (Boolean(renderedPlace) || showPlaceholder);
+
+    const handlePanelRef = useCallback((node: HTMLDivElement | null) => {
+      panelElementRef.current = node;
+      if (!node || !debugEnabled || node === lastPanelNodeRef.current) {
+        return;
+      }
+      lastPanelNodeRef.current = node;
+
+      setPanelMountCount((prev) => {
+        const next = prev + 1;
+        pushDebugEvent("panelMount", `panelMountCount=${next}`);
+        return next;
+      });
+
+      const style = window.getComputedStyle(node);
+      setComputedPanelHeight(style.height);
+      setComputedPanelTransform(style.transform);
+    }, [debugEnabled]);
+
+    const debugHud = debugEnabled ? (
+      <aside className="cpm-bottom-sheet__debug-hud" aria-hidden>
+        <div>isOpen: {String(isOpen)}</div>
+        <div>
+          stage / effectiveStage: {stage} / {effectiveStage}
+        </div>
+        <div>showPlaceholder: {String(showPlaceholder)}</div>
+        <div>
+          renderedPlace?: {String(Boolean(renderedPlace))} / {renderedPlace?.id ?? "-"}
+        </div>
+        <div>
+          place?: {String(Boolean(place))} / {place?.id ?? "-"}
+        </div>
+        <div>computed height: {computedPanelHeight}</div>
+        <div>computed transform: {computedPanelTransform}</div>
+        <div>mountCount: {mountCountRef.current}</div>
+        <div>panelMountCount: {panelMountCount}</div>
+        <div>lastEvent: {debugHistory[debugHistory.length - 1]?.event ?? "-"}</div>
+        <ol className="cpm-bottom-sheet__debug-log">
+          {debugHistory.map((entry, index) => (
+            <li key={`${entry.at}-${index}`}>
+              [t={entry.at.toFixed(1)}] {entry.event} -&gt; {entry.details}
+            </li>
+          ))}
+        </ol>
+      </aside>
+    ) : null;
+
+    if (!renderedPlace && !isOpen) {
+      return debugEnabled ? (
+        <div className="cpm-bottom-sheet" ref={ref}>
+          {debugHud}
+        </div>
+      ) : null;
+    }
 
     if (showPlaceholder) {
       const placeholderMessage =
@@ -150,6 +314,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
           ) : null}
           <div
             className="cpm-bottom-sheet__panel"
+            ref={handlePanelRef}
             style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}
           >
             <div className="cpm-bottom-sheet__handle">
@@ -179,6 +344,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
               </section>
             </div>
           </div>
+          {debugHud}
         </div>
       );
     }
@@ -191,6 +357,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
       <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
         <div
           className="cpm-bottom-sheet__panel"
+          ref={handlePanelRef}
           style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}
         >
           <div
@@ -399,6 +566,7 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
             )}
           </div>
         </div>
+        {debugHud}
       </div>
     );
 });


### PR DESCRIPTION
### Motivation
- Provide an in-screen debug HUD so mobile devices can capture what happened at the instant of a flicker without DevTools.
- The HUD should be opt-in via URL hash and never visible to normal users.
- Capture a short, recent event history and transient panel measurements to make transient stage/transform/height flips reproducible from screenshots.

### Description
- Added a hash-gated HUD to `MobileBottomSheet` that is enabled when the URL contains `#debugSheet` and hidden otherwise, with `hashchange` monitoring to toggle it at runtime.
- Implemented a 50-entry ring-buffer event log and `pushDebugEvent` for `open`, `close`, `setRenderedPlace`, `stageChange`, `panelMount`, and `rafSample` events, and display of the last event and the recent history in the HUD.
- Added 500ms `requestAnimationFrame` sampling starting when the sheet opens to record `height`, `transform`, and `effectiveStage` into the log to capture transient expanded/peek flips.
- Exposed debug fields in HUD (all monospace overlay, `pointer-events: none`): `isOpen`, `stage / effectiveStage`, `showPlaceholder`, `renderedPlace` presence + id, `place` presence + id, computed panel `height` / `transform`, `mountCount`, `panelMountCount`, and `lastEvent`.
- Files changed: `components/map/MobileBottomSheet.tsx` (logic + HUD + sampling + event buffer) and `components/map/MobileBottomSheet.css` (HUD styling, non-interactive overlay).
- Kept header/menu/logo untouched and the HUD is strictly gated so regular users won’t see it.

### Testing
- `npm run build` completed successfully and type/lint checks ran (build success reported).
- Started the app (`npm run start`) and executed a Playwright script to open `http://127.0.0.1:3000/map#debugSheet` and capture screenshots; artifacts were produced at `artifacts/hud-visible.png` and `artifacts/hud-history-after-pin-tap.png` demonstrating HUD rendering and captured history in this environment.
- Attempted `npx vercel --yes` to publish a Preview but it failed due to registry/npm access (403) in this environment, so no Vercel Preview URL was created.
- Note: unrelated project lint warnings remain in other files and runtime map data in this environment was limited, so a full real-world “close -> pin tap” reproduction was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699700b73fe88328a31fd1200bbe1909)