### PR TITLE
Remove placeholder backdrop from MobileBottomSheet

### DIFF
--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -140,14 +140,6 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
           : "Place details are unavailable right now.";
       return (
         <div className={`cpm-bottom-sheet ${isVisible ? "open" : ""}`} ref={ref}>
-          {isOpen ? (
-            <button
-              type="button"
-              className="cpm-bottom-sheet__backdrop"
-              aria-label="Close"
-              onClick={onClose}
-            />
-          ) : null}
           <div
             className="cpm-bottom-sheet__panel"
             style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}


### PR DESCRIPTION
### Motivation
- Remove the dimming backdrop that appears when selecting a pin on mobile by not rendering the placeholder backdrop element while keeping all other filter and submit behaviors intact.

### Description
- Removed the rendering of the placeholder backdrop element (`cpm-bottom-sheet__backdrop`) from `components/map/MobileBottomSheet.tsx` so the mobile pin-selection bottom sheet no longer shows the dim overlay when `isOpen && !renderedPlace`.

### Testing
- Ran `npm run lint -- --file components/map/MobileBottomSheet.tsx`, which completed successfully with a pre-existing `@next/next/no-img-element` warning; no new lint errors were introduced.
- Launched the dev server with `npm run dev` for visual verification, which started successfully. 
- Captured a mobile viewport screenshot via Playwright to verify the backdrop is no longer present (artifact produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0364895c83288dbe5ca949715c79)