### PR TITLE
Fix MobileBottomSheet placeholder handle touch swipe regression

### DIFF
--- a/components/map/MobileBottomSheet.tsx
+++ b/components/map/MobileBottomSheet.tsx
@@ -144,7 +144,12 @@ const MobileBottomSheet = forwardRef<HTMLDivElement, Props>(
             className="cpm-bottom-sheet__panel"
             style={{ height: sheetHeight, transform: `translateY(${isVisible ? "0" : "100%"})` }}
           >
-            <div className="cpm-bottom-sheet__handle">
+            <div
+              className="cpm-bottom-sheet__handle"
+              onTouchStart={handleTouchStart}
+              onTouchMove={handleTouchMove}
+              onTouchEnd={handleTouchEnd}
+            >
               <span className="cpm-bottom-sheet__handle-bar" aria-hidden />
             </div>
             <header className="cpm-bottom-sheet__header">


### PR DESCRIPTION
### Motivation
- The bottom-sheet handle in the placeholder render branch did not have touch handlers attached, which prevented swipe expand/collapse while the placeholder (e.g. "Loading place details...") was shown.

### Description
- Add `onTouchStart={handleTouchStart}`, `onTouchMove={handleTouchMove}`, and `onTouchEnd={handleTouchEnd}` to the placeholder-state handle element in `components/map/MobileBottomSheet.tsx`, matching the normal branch and keeping all other UX semantics unchanged.
- Verification: reproduce by throttling network or forcing the placeholder state; select a pin and immediately swipe while `Loading place details...` is displayed, and confirm the swipe now works the same as in the normal state.

### Testing
- Ran `npm run lint`, which completed successfully with pre-existing warnings and no new errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b090d29008328adfdb5b47725575d)