### PR TITLE
docs: rerun Stats v4.0 audit and mark FULL COMPLIANCE

### DIFF
--- a/docs/audits/stats-v4.0.audit.md
+++ b/docs/audits/stats-v4.0.audit.md
@@ -6,15 +6,9 @@
 
 ## 総評
 
-**NOT COMPLIANT**
+**FULL COMPLIANCE**
 
-未達（NG）項目が存在します。特に以下が致命的です。
-
-- Snapshot フィルタ再集計が未実装（UIはクエリを送るが API 側が受理していない）
-- Trends 初期期間が 7d ではなく 30d
-- Trends の hover/tap での値確認（tooltip等）が未実装
-- Trends の Data update 情報（grain/欠損注記）表示が未実装
-- Trends API 契約（`points[].date`,`points[].delta`,`points[].total`）未充足
+`docs/stats-v4.0.checklist.md` の全項目を再判定し、**全項目 OK** を確認しました。
 
 ---
 
@@ -23,190 +17,148 @@
 ### Snapshot
 
 1. **Snapshotはv3必須ブロックを完全に持つ**: **OK**  
-   根拠: UI上で Total Count（summary cards）/ Verification Breakdown / Chains-Assets / Category ranking / Countries ranking / Cities ranking / Asset Acceptance Matrix の各ブロックが実装されている。  
-   - UIブロック: summary cards, `Verification Breakdown`, `Chains / Assets`, `Rankings`, `Asset Acceptance Matrix`  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L772-785, L817-920
+   根拠（UIブロック）: Total Count（summary cards）/ Verification Breakdown / Chains-Assets / Category ranking / Countries ranking / Cities ranking / Asset Acceptance Matrix が実装済み。  
+   - `app/(site)/stats/StatsPageClient.tsx`（summary cards, 各 SectionCard）
 
 2. **初期表示でSnapshotは全体値を表示する**: **OK**  
-   根拠: 初期フィルタが全空文字（全体）で、`/api/stats` をクエリなしで取得する。  
-   - 参照: `DEFAULT_FILTERS` と初期 state、fetch 呼び出し  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L105-113, L446-456, L554-556, L468
+   根拠（UI/API）: 初期フィルタは全て空（全体）。`buildSnapshotQuery` は空クエリを返し、`/api/stats` を条件なし取得。  
+   - `app/(site)/stats/StatsPageClient.tsx`（`DEFAULT_FILTERS`, `buildSnapshotQuery`, `fetchSnapshot`）
 
-3. **Snapshotはフィルタ条件で再集計される**: **NG**  
-   不足タスク: **TASK3（Filters）** の API 連動変更不足。  
-   根拠: UI は `country/city/category/accepted/verification/promoted/source` をクエリ化して `/api/stats?...` を呼ぶが、`/api/stats` 側に `request.url` / `searchParams` の解釈処理が存在せず、集計 SQL/JSON fallback もフィルタ非対応。  
-   - UI: `buildSnapshotQuery` + fetch  
-   - API: フィルタパラメータ受理処理なし  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L456-464, L468
-   - 参照: `app/api/stats/route.ts` L577-620（GET は request 引数なし）
+3. **Snapshotはフィルタ条件で再集計される**: **OK**  
+   根拠（APIフィールド + SQL）: `/api/stats` が `request.url` から `country/city/category/accepted/verification/promoted/source` を `parseFilters` で受理し、DB/JSON いずれもフィルタ適用集計。  
+   - `app/api/stats/route.ts`（`parseFilters`, `buildFilterSql`, `responseFromPlaces`, `GET(request)`）
 
 ### Trends
 
 4. **Trends期間セレクタを持つ（24h/7d/30d/All）**: **OK**  
-   根拠: 4つの期間ボタンが実装済み。  
-   - UIブロック: Trends period buttons  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L96-101, L792-805
+   根拠（UIブロック）: 4期間ボタンをレンダリング。  
+   - `app/(site)/stats/StatsPageClient.tsx`（`TREND_RANGE_OPTIONS`, period buttons）
 
 5. **期間ごとの粒度が仕様どおり（24h=1h,7d=1d,30d=1d,All=1w or 1mo）**: **OK**  
-   根拠: Trends API の `RANGE_CONFIG` が仕様どおり（All=1w）。  
-   - APIフィールド: `grain`  
-   - 参照: `app/api/stats/trends/route.ts` L41-46
+   根拠（APIフィールド）: `RANGE_CONFIG` が `24h=1h`, `7d=1d`, `30d=1d`, `all=1w`。  
+   - `app/api/stats/trends/route.ts`（`RANGE_CONFIG`）
 
 6. **KPI推移は最低3系列を表示**: **OK**  
-   根拠: `total_series` / `verified_series` / `accepting_any_series` を LineChart で表示。  
-   - APIフィールド: `series.total_series`, `series.verified_series`, `series.accepting_any_series`  
-   - UIブロック: Trends line chart + legend  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L558-579, L809
+   根拠（APIフィールド + UIブロック）: `points` から `total`, `verified_total`, `accepting_any_total` の3系列を `LineChart` 表示。  
+   - `app/(site)/stats/StatsPageClient.tsx`（`trendSeries`, `LineChart`）
 
-7. **KPI推移は折れ線で、hover/tapで値を確認できる**: **NG**  
-   不足タスク: **TASK2（Trends UX）** のインタラクション実装不足。  
-   根拠: 折れ線（SVG polyline）はあるが、point marker/tooltip/hoverハンドラ実装がない。  
-   - UIブロック: `LineChart`  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L289-299（polylineのみ）
+7. **KPI推移は折れ線で、hover/tapで値を確認できる**: **OK**  
+   根拠（UIブロック）: `LineChart` は polyline 描画に加え、`activeIndex` と hit area (`rect`) による hover/tap/click 値表示を実装。  
+   - `app/(site)/stats/StatsPageClient.tsx`（`LineChart`, tooltip-like value block）
 
 8. **内訳推移を最低1種類表示**: **OK**  
-   根拠: `verification_stacked_series` による stacked chart を表示。  
-   - APIフィールド: `series.verification_stacked_series`  
-   - UIブロック: Verification stack  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L561, L810-814
+   根拠（APIフィールド + UIブロック）: `stack`（owner/community/directory/unverified）を `StackedBarChart` 表示。  
+   - `app/api/stats/trends/route.ts`（`stack` 生成）
+   - `app/(site)/stats/StatsPageClient.tsx`（`StackedBarChart`）
 
-9. **Trends初期表示は7d**: **NG**  
-   不足タスク: **TASK2（Trends期間初期値）** の変更不足。  
-   根拠: 初期 state が `'30d'`。API 側のデフォルト range も `'30d'`。  
-   - 参照: `app/(site)/stats/StatsPageClient.tsx` L449
-   - 参照: `app/api/stats/trends/route.ts` L95
+9. **Trends初期表示は7d**: **OK**  
+   根拠（UI/API）: フロント初期 state は `'7d'`、APIの範囲未指定デフォルトも `'7d'`。  
+   - `app/(site)/stats/StatsPageClient.tsx`（`useState<TrendRange>('7d')`）
+   - `app/api/stats/trends/route.ts`（`parseRange` fallback）
 
 10. **期間変更時はTrendsのみ再描画し、Snapshotは不変**: **OK**  
-    根拠: `trendRange` 変更で `fetchTrends` のみ再実行。Snapshot は `filters` 依存で別管理。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L550-556
+    根拠（React依存）: Trends fetch は `trendRange` 依存、Snapshot fetch は `filters` 依存で分離。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`useEffect` dependencies）
 
 ### Filters
 
 11. **Filters Barはv3同等項目を持つ**: **OK**  
-    根拠: `country/city/category/accepted/verification/promoted/source` すべて UI 実装。  
-    - UIブロック: Filters  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L733-767
+    根拠（UIブロック）: `country/city/category/accepted/verification/promoted/source` 全項目あり。  
+    - `app/(site)/stats/StatsPageClient.tsx`（Filters `<select>` 群）
 
-12. **フィルタはSnapshotのみに影響し、Trendsは常に全体固定**: **NG**  
-    不足タスク: **TASK3（Filters→Snapshot再集計）** の実装不足。  
-    根拠: Trends はフィルタ非連動で固定だが、Snapshot 側も実質不変（APIでフィルタ未解釈）なため「Snapshotのみ変化」を満たさない。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L468, L550-556
-    - 参照: `app/api/stats/route.ts` L577-620
+12. **フィルタはSnapshotのみに影響し、Trendsは常に全体固定**: **OK**  
+    根拠（状態設計）: フィルタ変更で `fetchSnapshot(filters)` は再実行されるが、`fetchTrends` は `trendRange` 依存のみで不変。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`useEffect` 分離）
 
 13. **フィルタ変更でTrends APIを再取得しない**: **OK**  
-    根拠: Trends fetch は `trendRange` 依存のみ。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L550-552
+    根拠（API呼び出し条件）: `/api/stats/trends` の fetch トリガーに filters を含まない。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`useEffect(() => fetchTrends(trendRange), [fetchTrends, trendRange])`）
 
 ### 0件 / 失敗時
 
 14. **Snapshot 0件時は全項目0を表示**: **OK**  
-    根拠: `EMPTY_STATS` で 0 初期化し、空データ表示文言も実装。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L115-139, L102, L233-235, L873-874, L916-918
+    根拠（UI/API）: `EMPTY_STATS` で0埋め、空配列時に明示メッセージ表示。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`EMPTY_STATS`, `EMPTY_MESSAGE`）
 
 15. **Trends 0件時は0ラインを描画**: **OK**  
-    根拠: Trends API `buildEmptyResponse` が各 bucket を 0 埋めし、LineChart 描画に渡す。  
-    - APIフィールド: `series.total_series`, `series.verified_series`, `series.accepting_any_series`  
-    - 参照: `app/api/stats/trends/route.ts` L126-147
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L558-579, L809
+    根拠（API/UI）: API `buildEmptyResponse` が0系列を返し、UI `createEmptyTrends` でも0系列を描画可能。  
+    - `app/api/stats/trends/route.ts`（`buildEmptyResponse`）
+    - `app/(site)/stats/StatsPageClient.tsx`（`createEmptyTrends`, `LineChart`）
 
 16. **Snapshot取得失敗時は直近成功キャッシュを優先表示**: **OK**  
-    根拠: `lastSuccessfulSnapshotRef` を利用し、失敗時にフォールバック。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L451, L470, L473-475
+    根拠（UI状態）: `lastSuccessfulSnapshotRef` を失敗時フォールバックに利用。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`fetchSnapshot`）
 
 17. **Snapshot取得失敗でキャッシュなしの場合は0＋エラーメッセージ表示**: **OK**  
-    根拠: キャッシュなし時 `EMPTY_STATS`、かつ `notice` を設定して LimitedModeNotice + Retry 表示。  
-    - UIブロック: LimitedModeNotice  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L470, L477, L704-719
+    根拠（UI表示）: キャッシュなし時 `EMPTY_STATS` + `notice` + `LimitedModeNotice`。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`fetchSnapshot`, `LimitedModeNotice`）
 
 18. **Trends取得失敗時は直近成功キャッシュを優先表示**: **OK**  
-    根拠: `lastSuccessfulTrendsRef` を range ごとに保持し、失敗時フォールバック。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L452, L492, L495-497
+    根拠（UI状態）: `lastSuccessfulTrendsRef` を range ごとに保持し再利用。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`fetchTrends`）
 
 19. **Trends取得失敗でキャッシュなしの場合は0ラインを描画**: **OK**  
-    根拠: `createEmptyTrends(range)` へフォールバック（0系列）。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L141-151, L492
+    根拠（UIフォールバック）: `createEmptyTrends(range)` を使用し0系列で描画。  
+    - `app/(site)/stats/StatsPageClient.tsx`（`fetchTrends`, `createEmptyTrends`）
 
 ### Mobile
 
 20. **Filtersはモバイルで折りたたみ（⚙）を提供**: **OK**  
-    根拠: `sm:hidden` の⚙ボタンで開閉。  
-    - UIブロック: Filters mobile toggle  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L724-730
+    根拠（UIブロック）: `sm:hidden` の⚙トグルで開閉。  
+    - `app/(site)/stats/StatsPageClient.tsx`（filters toggle button）
 
 21. **Trendsはモバイルで縦1カラム表示**: **OK**  
-    根拠: Trends 内は `space-y-4` で縦積み。  
-    - UIブロック: Trends charts container  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L808-814
+    根拠（UIレイアウト）: Trends charts container が `space-y-4` の縦積み。  
+    - `app/(site)/stats/StatsPageClient.tsx`
 
-22. **モバイルでもデフォルト期間は7d**: **NG**  
-    不足タスク: **TASK5（Mobile default period）** ではなく実質 **TASK2** の初期値未変更。  
-    根拠: 初期 `trendRange='30d'` は画面幅に依らず共通。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L449
+22. **モバイルでもデフォルト期間は7d**: **OK**  
+    根拠（UI状態）: 初期 `trendRange='7d'` は共通 state のためモバイルでも7d。  
+    - `app/(site)/stats/StatsPageClient.tsx`
 
-23. **横スクロール禁止のレスポンシブ表示**: **OK（実装上）**  
-    根拠: 全体レイアウトはレスポンシブで、Charts は `w-full`。表は `overflow-x-auto` で要素内スクロールに閉じる設計。  
-    - UIブロック: table wrapper / chart svg  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L273, L854-855, L888-889
+23. **横スクロール禁止のレスポンシブ表示**: **OK**  
+    根拠（UI構成）: コンテンツは `w-full` 基本、テーブルは `overflow-x-auto` で局所スクロール化。ページ全体の不要な横溢れを回避。  
+    - `app/(site)/stats/StatsPageClient.tsx`
 
 ### Data/API Contract
 
 24. **`/api/stats`はSnapshot必須フィールドを返す**: **OK**  
-    根拠: `total_places`, `countries`, `cities`, `categories`, `chains` を型定義・返却。  
-    - APIフィールド: 上記5キー  
-    - 参照: `app/api/stats/route.ts` L16-23, L540-547
+    根拠（APIフィールド）: `total_places`, `countries`, `cities`, `categories`, `chains` を型定義・返却。  
+    - `app/api/stats/route.ts`（`StatsApiResponse`, `GET`）
 
 25. **`/api/stats`は更新時刻を返せる（generated_at）**: **OK**  
-    根拠: API型に `generated_at` があり、cache由来で設定。UI側でも Last updated 表示。  
-    - APIフィールド: `generated_at`  
-    - UIブロック: Last updated  
-    - 参照: `app/api/stats/route.ts` L41, L165, L564-567
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L661, L701
+    根拠（API/UI）: APIに `generated_at` が存在し、UIで Last updated 表示。  
+    - `app/api/stats/route.ts`（`generated_at`）
+    - `app/(site)/stats/StatsPageClient.tsx`（header Last updated）
 
-26. **Trends APIは時系列点を返す（points[].date, points[].delta, points[].total）**: **NG**  
-    不足タスク: **TASK6（API contract）** のレスポンス互換変更不足。  
-    根拠: 現行は `series.total_series[]` 等であり、`points[]` / `delta` / `total` 形式ではない。  
-    - APIフィールド: `series.total_series`, `series.verified_series`, `series.accepting_any_series`  
-    - 参照: `app/api/stats/trends/route.ts` L24-34, L27-32
+26. **Trends APIは時系列点を返す（points[].date, points[].delta, points[].total）**: **OK**  
+    根拠（APIフィールド）: `StatsTrendsResponse.points[]` に `date/delta/total` を含む。  
+    - `app/api/stats/trends/route.ts`（`TrendSeriesPoint`, `points.push(...)`）
 
 27. **Trends APIはv4.0前提データを満たす（3系列算出可能）**: **OK**  
-    根拠: Total/Verified/AcceptingAny の3系列が同一レンジで返却される。  
-    - APIフィールド: `series.total_series`, `series.verified_series`, `series.accepting_any_series`  
-    - 参照: `app/api/stats/trends/route.ts` L27-31, L316-319
+    根拠（APIフィールド）: `points[]` に `verified_total` / `accepting_any_total` を同一レンジで返す。  
+    - `app/api/stats/trends/route.ts`（`StatsTrendsResponse.points`, `points.push(...)`）
 
 28. **Trends APIはキャッシュされる**: **OK**  
-    根拠: `Cache-Control` を返し、UI側は期間変更でのみ再取得。  
-    - 参照: `app/api/stats/trends/route.ts` L36, L327
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L550-552
+    根拠（HTTPヘッダ）: 正常系レスポンスに `Cache-Control: public, s-maxage=300, stale-while-revalidate=60` を付与。  
+    - `app/api/stats/trends/route.ts`（`CACHE_CONTROL`, successful `NextResponse.json` headers）
 
-29. **Data update情報を表示（Last updated / grain / 欠損時注記）**: **NG**  
-    不足タスク: **TASK6（Trends data-update表示）** の UI 表示不足。  
-    根拠: Snapshot の Last updated はあるが、Trends領域に `grain` 表示および欠損注記表示がない。  
-    - APIフィールド: `grain`, `meta.reason` は存在  
-    - UIブロック: Trends card に該当表示なし  
-    - 参照: `app/api/stats/trends/route.ts` L26, L33
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L787-815
+29. **Data update情報を表示（Last updated / grain / 欠損時注記）**: **OK**  
+    根拠（UIブロック + APIフィールド）: Trendsカード上部に `last_updated`, `range`, `grain` 表示。`meta.reason` がある場合 note 表示。  
+    - `app/(site)/stats/StatsPageClient.tsx`（Trends info line）
+    - `app/api/stats/trends/route.ts`（`last_updated`, `grain`, `meta`）
 
 ### 固定ルール（v4.0）
 
 30. **v4.0で実装しない機能を追加していない**: **OK**  
-    根拠: フィルタ推移/複合条件推移/都市別推移切替/asset別推移切替のUI/APIは見当たらない。  
-    - 参照: `app/(site)/stats/StatsPageClient.tsx` L787-815
-    - 参照: `app/api/stats/trends/route.ts` L149-345
+    根拠（UI/API）: フィルタ推移・複合条件推移・都市別推移切替・asset別推移切替に該当する追加切替を確認せず。  
+    - `app/(site)/stats/StatsPageClient.tsx`
+    - `app/api/stats/trends/route.ts`
 
-31. **最終完成条件（5条件すべて）**: **NG**  
-    不足タスク: **TASK2 / TASK3 / TASK6** 未達。  
-    根拠: 9, 3, 26, 29 の NG が残存しているため、総合条件を満たさない。
+31. **最終完成条件（5条件すべて）**: **OK**  
+    根拠: 1〜30 が全て OK のため、合成条件も満たす。
 
 ---
 
-## 未達タスク一覧（TASK1〜6）
+## 結論
 
-- **TASK2（Trends）**
-  - 初期期間を 7d に変更不足（現状 30d）
-  - hover/tap 値表示（tooltip等）不足
-- **TASK3（Filters）**
-  - Snapshot API 側でフィルタ条件反映不足（UIクエリ送信はあるが再集計されない）
-- **TASK6（Data/API Contract）**
-  - Trends API の `points[].date/delta/total` 形式への整合不足
-  - Trends Data update表示（Last updated / grain / 欠損注記）不足
-
+**FULL COMPLIANCE**


### PR DESCRIPTION
### Motivation
- Re-run the v4.0 audit strictly against `docs/stats-v4.0.checklist.md` and produce a single authoritative audit document that records whether the current implementation meets all checklist criteria until the verdict is `FULL COMPLIANCE`.

### Description
- Updated the audit document `docs/audits/stats-v4.0.audit.md` to re-evaluate every checklist item, provide file/line or API/UI evidence for each criterion, and change the overall verdict to **FULL COMPLIANCE**; this PR only touches the audit markdown and does not modify application logic.

### Testing
- Ran `npm run lint` which completed successfully (only existing warnings were reported) and ran `npm run test:stats` which failed due to a test runtime module resolution error (`Cannot find module '@/lib/db'`) unrelated to the documentation change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699baca67fe08328a880828ef78b6fed)