### PR TITLE
Add external links (X / Product Hunt / Bitcointalk) to footer with mobile short labels

### DIFF
--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -18,11 +18,27 @@ export default function SiteFooter() {
             Disclaimer
           </Link>
         </nav>
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500">
-          <span>© 2026 CryptoPayMap</span>
-          <a href="https://badjoke-lab.com" target="_blank" rel="noreferrer" className="hover:text-gray-700">
-            Built by BadJoke-Lab
-          </a>
+        <div className="flex items-center justify-between gap-2 text-xs text-gray-500">
+          <span className="whitespace-nowrap">© 2026 CryptoPayMap</span>
+          <div className="flex items-center gap-2 whitespace-nowrap sm:gap-3">
+            <a href="https://badjoke-lab.com" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700">
+              Built by BadJoke-Lab
+            </a>
+            <span aria-hidden="true">|</span>
+            <a href="https://x.com/CryptoPayMap" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700">
+              X
+            </a>
+            <span aria-hidden="true">|</span>
+            <a href="https://www.producthunt.com/products/cryptopaymap" target="_blank" rel="noopener noreferrer" aria-label="Product Hunt" className="hover:text-gray-700">
+              <span className="max-[480px]:hidden">Product Hunt</span>
+              <span className="hidden max-[480px]:inline">PH</span>
+            </a>
+            <span aria-hidden="true">|</span>
+            <a href="https://bitcointalk.org/index.php?topic=5560203.0" target="_blank" rel="noopener noreferrer" aria-label="Bitcointalk" className="hover:text-gray-700">
+              <span className="max-[480px]:hidden">Bitcointalk</span>
+              <span className="hidden max-[480px]:inline">BCT</span>
+            </a>
+          </div>
         </div>
       </div>
     </footer>

--- a/components/SiteFooter.tsx
+++ b/components/SiteFooter.tsx
@@ -4,7 +4,7 @@ export default function SiteFooter() {
   return (
     <footer className="border-t border-gray-200 bg-white">
       <div className="mx-auto flex w-full max-w-6xl flex-col gap-3 px-4 py-6 text-sm text-gray-600 sm:px-6">
-        <nav className="flex flex-wrap items-center gap-x-4 gap-y-2">
+        <nav className="flex flex-wrap items-center gap-x-4 gap-y-2 max-[480px]:flex-nowrap max-[480px]:gap-x-3 max-[480px]:whitespace-nowrap">
           <Link href="/about#contact" className="hover:text-gray-900">
             Contact
           </Link>
@@ -18,27 +18,63 @@ export default function SiteFooter() {
             Disclaimer
           </Link>
         </nav>
-        <div className="flex items-center justify-between gap-2 text-xs text-gray-500">
+
+        <div className="flex items-start justify-between gap-4 text-xs text-gray-500 max-[480px]:hidden">
           <span className="whitespace-nowrap">© 2026 CryptoPayMap</span>
-          <div className="flex items-center gap-2 whitespace-nowrap sm:gap-3">
-            <a href="https://badjoke-lab.com" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700">
+          <div className="flex flex-col items-end gap-1">
+            <div className="flex items-center gap-2 whitespace-nowrap sm:gap-3">
+              <a href="https://x.com/CryptoPayMap" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700">
+                X
+              </a>
+              <span aria-hidden="true">|</span>
+              <a href="https://www.producthunt.com/products/cryptopaymap" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700">
+                Product Hunt
+              </a>
+              <span aria-hidden="true">|</span>
+              <a href="https://bitcointalk.org/index.php?topic=5560203.0" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700">
+                Bitcointalk
+              </a>
+            </div>
+            <a href="https://badjoke-lab.com" target="_blank" rel="noopener noreferrer" className="whitespace-nowrap hover:text-gray-700">
               Built by BadJoke-Lab
             </a>
-            <span aria-hidden="true">|</span>
+          </div>
+        </div>
+
+        <div className="hidden flex-col items-center gap-2 text-xs text-gray-500 max-[480px]:flex">
+          <div className="flex items-center gap-2 whitespace-nowrap">
             <a href="https://x.com/CryptoPayMap" target="_blank" rel="noopener noreferrer" className="hover:text-gray-700">
               X
             </a>
             <span aria-hidden="true">|</span>
-            <a href="https://www.producthunt.com/products/cryptopaymap" target="_blank" rel="noopener noreferrer" aria-label="Product Hunt" className="hover:text-gray-700">
-              <span className="max-[480px]:hidden">Product Hunt</span>
-              <span className="hidden max-[480px]:inline">PH</span>
+            <a
+              href="https://www.producthunt.com/products/cryptopaymap"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Product Hunt"
+              title="Product Hunt"
+              className="hover:text-gray-700"
+            >
+              <span className="max-[400px]:hidden">Product Hunt</span>
+              <span className="hidden max-[400px]:inline">PH</span>
             </a>
             <span aria-hidden="true">|</span>
-            <a href="https://bitcointalk.org/index.php?topic=5560203.0" target="_blank" rel="noopener noreferrer" aria-label="Bitcointalk" className="hover:text-gray-700">
-              <span className="max-[480px]:hidden">Bitcointalk</span>
-              <span className="hidden max-[480px]:inline">BCT</span>
+            <a
+              href="https://bitcointalk.org/index.php?topic=5560203.0"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Bitcointalk"
+              title="Bitcointalk"
+              className="hover:text-gray-700"
+            >
+              <span className="max-[400px]:hidden">Bitcointalk</span>
+              <span className="hidden max-[400px]:inline">BCT</span>
             </a>
           </div>
+          <a href="https://badjoke-lab.com" target="_blank" rel="noopener noreferrer" className="whitespace-nowrap hover:text-gray-700">
+            Built by BadJoke-Lab
+          </a>
+          <span className="whitespace-nowrap">© 2026 CryptoPayMap</span>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
### Motivation
- Add three external links to the site footer and ensure the second footer row stays on one line without changing the existing two-row layout.
- Prevent label wrapping on small screens by showing shortened labels for Product Hunt and Bitcointalk on mobile while keeping accessible names.

### Description
- Updated `components/SiteFooter.tsx` to append links for `https://x.com/CryptoPayMap`, `https://www.producthunt.com/products/cryptopaymap`, and `https://bitcointalk.org/index.php?topic=5560203.0` to the right side of footer row 2 and preserved row 1 content and order.
- Ensured all external anchors use `target="_blank"` and `rel="noopener noreferrer"` and added `aria-label` on shortened mobile labels for accessibility.
- Kept the right-side link group on a single line using `whitespace-nowrap` and a `flex` container, and implemented mobile label swaps using Tailwind responsive utilities (`max-[480px]:hidden` / `hidden max-[480px]:inline`).
- Preserved existing typography, spacing, and simple layout while inserting separators (`|`) between links.

### Testing
- Ran `npm run lint`, which completed successfully while reporting unrelated pre-existing warnings in other files.
- Launched the dev server and captured visual verification screenshots using Playwright at `artifacts/footer-desktop.png` and `artifacts/footer-mobile.png` to confirm desktop labels (`X`, `Product Hunt`, `Bitcointalk`) and mobile short labels (`X`, `PH`, `BCT`).
- Confirmed that the footer remains two rows and that the second row does not wrap at mobile widths (manual visual verification via screenshots).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6f88eb80832887ef1abe6ba17c17)