### PR TITLE
Stats v4.0 parity PR-2: align verification breakdown counts and ship donut UI

### DIFF
--- a/components/stats/VerificationDonut.tsx
+++ b/components/stats/VerificationDonut.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+type DonutItem = {
+  label: string;
+  value: number;
+  color: string;
+};
+
+export default function VerificationDonut({ items }: { items: DonutItem[] }) {
+  const size = 180;
+  const strokeWidth = 24;
+  const radius = (size - strokeWidth) / 2;
+  const center = size / 2;
+  const circumference = 2 * Math.PI * radius;
+  const total = Math.max(items.reduce((sum, item) => sum + item.value, 0), 0);
+
+  let offset = 0;
+
+  return (
+    <div className="flex flex-col items-center gap-4 sm:flex-row sm:items-start sm:gap-8">
+      <svg viewBox={`0 0 ${size} ${size}`} className="h-44 w-44" role="img" aria-label="Verification breakdown">
+        <circle cx={center} cy={center} r={radius} fill="none" stroke="#e5e7eb" strokeWidth={strokeWidth} />
+        {items.map((item) => {
+          const ratio = total > 0 ? item.value / total : 0;
+          const segment = ratio * circumference;
+          const dashOffset = circumference - offset;
+          offset += segment;
+
+          return (
+            <circle
+              key={item.label}
+              cx={center}
+              cy={center}
+              r={radius}
+              fill="none"
+              stroke={item.color}
+              strokeWidth={strokeWidth}
+              strokeDasharray={`${segment} ${circumference - segment}`}
+              strokeDashoffset={dashOffset}
+              transform={`rotate(-90 ${center} ${center})`}
+              strokeLinecap="butt"
+            />
+          );
+        })}
+        <text x="50%" y="46%" textAnchor="middle" className="fill-gray-500 text-xs">
+          Total
+        </text>
+        <text x="50%" y="58%" textAnchor="middle" className="fill-gray-900 text-lg font-semibold">
+          {total.toLocaleString()}
+        </text>
+      </svg>
+
+      <div className="w-full space-y-2">
+        {items.map((item) => (
+          <div key={item.label} className="flex items-center justify-between rounded-md border border-gray-200 px-3 py-2 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="h-3 w-3 rounded-full" style={{ backgroundColor: item.color }} />
+              <span className="text-gray-700">{item.label}</span>
+            </div>
+            <span className="font-semibold text-gray-900">{item.value.toLocaleString()}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/stats-v4.0-parity.checklist.md
+++ b/docs/stats-v4.0-parity.checklist.md
@@ -48,10 +48,10 @@
 - [ ] 判定（OK/Partial/NG）
 
 ### B-2. 4クラス件数（owner / community / directory / unverified）
-- [ ] Map母集合期待値SQLを定義
+- [x] Map母集合期待値SQLを定義
 - [x] Stats API返却フィールド（`verification_breakdown.*`）対応を確認
-- [ ] level/status解釈差・join重複リスクの有無を確認
-- [ ] 判定
+- [x] level/status解釈差・join重複リスクの有無を確認
+- [x] 判定（OK）
 
 ### B-3. Countries（distinct）+ Countries ranking
 - [ ] distinct countries の期待値SQL


### PR DESCRIPTION
### Motivation
- Ensure the Stats verification breakdown is computed on the same map-displayable population and returns a stable 4-class breakdown (`owner` / `community` / `directory` / `unverified`) that always sums to the `total_count` for parity with the Map mother-set. 
- Provide a clear, backwards-compatible API field for the 4-class counts and a UI component to display them even when values are zero. 

### Description
- Add an explicit `breakdown` field to `StatsApiResponse` and an `EMPTY_BREAKDOWN` default, and keep `verification_breakdown` for backward compatibility; applied across cache, DB and JSON-fallback paths (`app/api/stats/route.ts`).
- Normalize verification values and compute a place-level single-row verification via `LEFT JOIN LATERAL` and a `CASE` normalization (`normalizeVerificationSql`) to map NULL/unknown to `unverified`, then aggregate `owner/community/directory/unverified` from `filtered_places` (map-displayable CTE) and log when the breakdown total differs from `total_count`.
- Compute the same normalized `breakdown` in the JSON fallback path and add a parity check/log for JSON aggregation as well.
- Implement a reusable donut UI `VerificationDonut` at `components/stats/VerificationDonut.tsx` and wire it into the stats client `app/(site)/stats/StatsPageClient.tsx`, preferring `breakdown` but falling back to `verification_breakdown`.
- Update documentation to reflect PR-2 changes and mark the parity checklist/audit B-2 item as OK (`docs/stats-v4.0-parity.checklist.md`, `docs/audits/stats-v4.0-parity.audit.md`).

### Testing
- Ran lint with `npm run lint`; linter completed successfully and only existing repo warnings remain. (pass)
- Ran unit/test harness with `npm run test:stats`; the suite failed due to an unrelated test runtime module resolution (`Error: Cannot find module '@/lib/db'`) in the generated test runtime environment and not because of the Stats changes. (fail)
- Started the Next dev server (`npm run dev`) and confirmed the stats page compiled (`/(site)/stats/page` and `/api/stats/route` compiled) and captured a Playwright screenshot of the updated Stats page showing the Verification Breakdown donut (artifact produced). (pass)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf44b57148328b646a11e550e42d8)