### PR TITLE
fix(stats): prevent caching fallback stats responses

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -69,7 +69,8 @@ type CacheRow = {
   generated_at: string | Date | null;
 };
 
-const CACHE_CONTROL = "public, s-maxage=7200, stale-while-revalidate=600";
+const CACHE_CONTROL = "public, s-maxage=30, stale-while-revalidate=30";
+const FALLBACK_CACHE_CONTROL = "no-store";
 const TOP_CHAIN_LIMIT = 50;
 const TOP_RANKING_LIMIT = 10;
 const TOP_MATRIX_LIMIT = 20;
@@ -918,7 +919,7 @@ export async function GET(request: Request) {
     try {
       const jsonPlaces = await loadPlacesFromJsonFallback();
       return NextResponse.json<StatsApiResponse>(responseFromPlaces(filters, jsonPlaces), {
-        headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("json", true) },
+        headers: { "Cache-Control": FALLBACK_CACHE_CONTROL, ...buildDataSourceHeaders("json", true) },
       });
     } catch (jsonError) {
       console.error("[stats] failed to load JSON fallback", jsonError);


### PR DESCRIPTION
### Motivation
- Prevent JSON fallback responses from being cached so a temporary DB outage does not cause stale fallback data to be persisted after DB recovery.

### Description
- Reduce `CACHE_CONTROL` TTL from `s-maxage=7200, stale-while-revalidate=600` to `s-maxage=30, stale-while-revalidate=30` and add a `FALLBACK_CACHE_CONTROL = "no-store"` constant; use `FALLBACK_CACHE_CONTROL` for the DB->JSON fallback response so fallback results are served with `Cache-Control: no-store`.

### Testing
- Ran `npm run lint` (completed with existing warnings) and `npm run test` (failed due to unrelated test environment module resolution error: `Cannot find module '@/lib/db'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d4865d83883289a0929c16584e7d2)