### PR TITLE
Fix: unify stats source; remove stats_cache merge for parity

### DIFF
--- a/app/(site)/stats/StatsPageClient.tsx
+++ b/app/(site)/stats/StatsPageClient.tsx
@@ -38,6 +38,11 @@ type StatsResponse = {
     chains: string[];
     rows: Array<{ asset: string; total: number; counts: Record<string, number> }>;
   };
+  meta?: {
+    source: 'db_live';
+    population_id: 'places:map_visible:v1';
+    as_of: string;
+  };
   generated_at?: string;
   limited?: boolean;
 };


### PR DESCRIPTION
### Motivation
- Eliminate inconsistent mixing of `stats_cache` and live DB aggregates that caused cases where `total` matched but other metrics (countries/cities/rankings) diverged. 
- Ensure every `/api/stats` metric is computed from a single, well-defined mother population that matches Map visibility so results are consistent and auditable.

### Description
- Removed all `stats_cache` merge and cache-shape helpers and made `loadStatsFromDb` return the live aggregation directly via `fetchDbSnapshotV4`, removing branching that preferred or merged cached snapshots. 
- Unified population by building a single `filtered_places` CTE in `buildFilteredPlacesCte()` that always includes `getMapDisplayableWhereClauses("p")`, so totals/breakdowns/rankings/matrix are computed from the same set. 
- Added provenance metadata to responses and typings: `meta.source = "db_live"`, `meta.population_id = "places:map_visible:v1"`, and `meta.as_of` (ISO timestamp), and updated the stats client type to accept the new `meta` contract. 
- Fixed type-return shapes from DB snapshot code (converted `fetchDbSnapshotV4` to return a full `StatsApiResponse` and materialized `chains` map) and replaced JSON-fallback responses to include the new `meta` fields.

### Testing
- `npm run -s build` completed successfully and TypeScript checks passed, with unrelated Next.js warnings (Linter warnings about `<img>`/script usage). 
- `npm run -s test:stats` failed due to an existing test environment module resolution issue (`Cannot find module '@/lib/db'`) that is unrelated to this change. 
- `pnpm -s lint` could not run in this environment due to package manager bootstrap/network errors (corepack attempted to download `pnpm` and failed), so lint was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d616a932483288a9f7625c09788d3)