### PR TITLE
Add CI guard to prevent stats source/population regressions

### DIFF
--- a/.github/workflows/stats-source-guard.yml
+++ b/.github/workflows/stats-source-guard.yml
@@ -1,0 +1,24 @@
+name: Stats Source Guard
+
+on:
+  pull_request:
+    paths:
+      - "app/api/stats/**"
+      - "scripts/ci/check_stats_source.sh"
+      - ".github/workflows/stats-source-guard.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "app/api/stats/**"
+      - "scripts/ci/check_stats_source.sh"
+      - ".github/workflows/stats-source-guard.yml"
+
+jobs:
+  stats-source-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run stats source guard
+        run: bash scripts/ci/check_stats_source.sh

--- a/scripts/ci/check_stats_source.sh
+++ b/scripts/ci/check_stats_source.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROUTE_FILE="app/api/stats/route.ts"
+REQUIRED_POPULATION_ID='"places:map_visible:v1"'
+
+if [[ ! -f "$ROUTE_FILE" ]]; then
+  echo "ERROR: Missing $ROUTE_FILE"
+  exit 1
+fi
+
+if rg -n "stats_cache" "$ROUTE_FILE" >/dev/null; then
+  echo "ERROR: Forbidden source split detected. Remove stats_cache references from $ROUTE_FILE"
+  rg -n "stats_cache" "$ROUTE_FILE"
+  exit 1
+fi
+
+mapfile -t population_lines < <(rg -n 'population_id\s*:' "$ROUTE_FILE")
+
+if [[ ${#population_lines[@]} -eq 0 ]]; then
+  echo "ERROR: population_id field is missing in $ROUTE_FILE"
+  exit 1
+fi
+
+invalid_lines=()
+for line in "${population_lines[@]}"; do
+  if [[ "$line" != *"population_id"*"$REQUIRED_POPULATION_ID"* ]]; then
+    invalid_lines+=("$line")
+  fi
+done
+
+if [[ ${#invalid_lines[@]} -gt 0 ]]; then
+  echo "ERROR: population_id must be fixed to $REQUIRED_POPULATION_ID"
+  printf '%s\n' "${invalid_lines[@]}"
+  exit 1
+fi
+
+echo "OK: Stats source guard passed."


### PR DESCRIPTION
### Motivation
- Prevent accidental regressions where stats source logic is split again or the canonical stats population identifier drifts, causing “PR1 fixes it but PR2 reverts it” failures. 
- Ensure `app/api/stats/route.ts` always reports the agreed canonical population and never mixes sources.

### Description
- Add `scripts/ci/check_stats_source.sh` which fails if `app/api/stats/route.ts` contains any `stats_cache` references or if any `population_id:` assignment is not the fixed literal `"places:map_visible:v1"`.
- Add `.github/workflows/stats-source-guard.yml` to run the guard on PRs and pushes, limited to changes under `app/api/stats/**`, the guard script, and the workflow file itself.
- The guard is grep-based and reports offending lines to make regressions easy to diagnose.

### Testing
- Executed `bash scripts/ci/check_stats_source.sh` locally and it printed `OK: Stats source guard passed.` indicating the checks succeed against the current `app/api/stats/route.ts`.
- The workflow is configured to run automatically on PRs/pushes when relevant files change (no CI run was triggered here, only local script validation was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6794e0548328a797f04f4b785057)