### PR TITLE
Align /api/stats population metadata with map population v2

### DIFF
--- a/app/(site)/stats/StatsPageClient.tsx
+++ b/app/(site)/stats/StatsPageClient.tsx
@@ -40,7 +40,7 @@ type StatsResponse = {
   };
   meta?: {
     source: 'db_live';
-    population_id: 'places:map_visible:v1';
+    population_id: 'places:map_population:v2';
     as_of: string;
   };
   generated_at?: string;

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -14,6 +14,8 @@ import { getMapDisplayableWhereClauses, isMapDisplayablePlace } from "@/lib/stat
 
 export const revalidate = 7200;
 
+const MAP_POPULATION_ID = "places:map_population:v2" as const;
+
 type StatsFilters = {
   country: string;
   city: string;
@@ -61,7 +63,7 @@ export type StatsApiResponse = {
   limited?: boolean;
   meta?: {
     source: "db_live";
-    population_id: "places:map_visible:v1";
+    population_id: typeof MAP_POPULATION_ID;
     as_of: string;
   };
 };
@@ -745,7 +747,7 @@ export async function GET(request: Request) {
       return NextResponse.json<StatsApiResponse>({
         ...responseFromPlaces(filters, jsonPlaces),
         ok: true,
-        meta: { source: "db_live", population_id: "places:map_visible:v1", as_of: new Date().toISOString() },
+        meta: { source: "db_live", population_id: MAP_POPULATION_ID, as_of: new Date().toISOString() },
       }, {
         headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("json", true) },
       });
@@ -765,7 +767,7 @@ export async function GET(request: Request) {
     return NextResponse.json<StatsApiResponse>({
       ...statsResponse,
       ok: true,
-      meta: { source: "db_live", population_id: "places:map_visible:v1", as_of: new Date().toISOString() },
+      meta: { source: "db_live", population_id: MAP_POPULATION_ID, as_of: new Date().toISOString() },
     }, {
       headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },
     });
@@ -789,7 +791,7 @@ export async function GET(request: Request) {
       return NextResponse.json<StatsApiResponse>({
         ...responseFromPlaces(filters, jsonPlaces),
         ok: true,
-        meta: { source: "db_live", population_id: "places:map_visible:v1", as_of: new Date().toISOString() },
+        meta: { source: "db_live", population_id: MAP_POPULATION_ID, as_of: new Date().toISOString() },
       }, {
         headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("json", true) },
       });

--- a/docs/audits/stats-v4.0-map-vs-stats-population.audit.md
+++ b/docs/audits/stats-v4.0-map-vs-stats-population.audit.md
@@ -227,3 +227,21 @@ ORDER BY side, reason, id;
 ## 5) 修正方針（根拠付き・1段落）
 
 修正対象は母集合定義ではなく、比較対象の取り方である。Mapの「画面内取得件数」をStatsの「全体母集合件数」と直接比較しない運用に揃えるべきで、必要なら Map 側に「全件母集合カウント専用API（`lat/lng not null` を同一述語でCOUNT）」を追加し、UI表示上も `in_view_count` と `population_total` を分離して明示するのが整合的である（根拠: 両者が同じ `getMapDisplayableWhereClauses` を参照している一方、Map実表示は `bbox/limit` を常時付与）。
+
+---
+
+## 6) TASK B 実装後の一致確認（population_id更新）
+
+実装内容（最小修正）:
+- `/api/stats` の母集合CTEは引き続き `getMapDisplayableWhereClauses("p")` を参照し、Mapと同一ソースを利用。
+- `meta.population_id` を `places:map_population:v2` に更新（旧 `v1` と識別可能）。
+
+比較表:
+
+| 観点 | 結果 | 根拠 |
+|---|---:|---|
+| Map母集合カウント（`isMapDisplayablePlace`） | 5 | `node --import tsx -e "...places.filter(isMapDisplayablePlace).length..."` |
+| `/api/stats` `total_places` | 5 | `curl http://localhost:3105/api/stats` |
+| `/api/stats` `meta.population_id` | `places:map_population:v2` | 同上 |
+
+上記により、TASK Aで確定した Map母集合（`lat/lng` 表示可能条件）と Stats母集合の一致、および population_id の更新を確認。


### PR DESCRIPTION
### Motivation
- Ensure the Stats API uses the exact same base population definition as the Map (map-displayable places) so all counts/rankings are comparable. 
- Surface a clear, distinguishable population identifier for this population so downstream tooling and audits can tell pre/post change results apart. 
- Make the minimal changes necessary to preserve existing filter behavior and avoid any API shape regressions. 

### Description
- Introduced a single `MAP_POPULATION_ID = "places:map_population:v2"` constant and updated all `/api/stats` success and JSON-fallback response paths to emit `meta.population_id = MAP_POPULATION_ID` instead of the previous literal. 
- Left the Stats population CTE logic untouched to continue sourcing the base predicate from `getMapDisplayableWhereClauses("p")`, keeping Map vs Stats mother-set semantics identical. 
- Updated the Stats client typing (`app/(site)/stats/StatsPageClient.tsx`) to accept the new `population_id` literal so the types remain aligned with the API. 
- Appended a short note to `docs/audits/stats-v4.0-map-vs-stats-population.audit.md` documenting the change and a brief post-change comparison demonstrating parity. 

### Testing
- Ran `npm run build` and the production build/TypeScript checks completed successfully. 
- Started the app and verified `GET /api/stats` returns a successful snapshot with `ok: true`, `meta.population_id: "places:map_population:v2"`, and required fields (e.g. `chains`) present via `curl`. 
- Verified the Map mother-set count by running `node --import tsx -e "...places.filter(isMapDisplayablePlace).length..."` and confirmed the returned value matches `/api/stats` `total_places` in the local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7267ba8083289ea61b2fa4eb406c)