### PR TITLE
Stats: bucketize missing payment_accepts.chain as 'unknown' for top_chains and matrix

### DIFF
--- a/docs/audits/2026-02-24-stats-acceptance-chain-missing-audit.md
+++ b/docs/audits/2026-02-24-stats-acceptance-chain-missing-audit.md
@@ -1,0 +1,45 @@
+# Stats acceptance chain-missing audit (2026-02-24)
+
+## Context
+Production report indicated:
+- `total_places ≈ 980`
+- `top_chains_sum / matrix_sum ≈ 12`
+
+Root-cause hypothesis: many `payment_accepts` rows have `asset` populated but `chain` empty.
+
+## SQL used
+```sql
+WITH buckets AS (
+  SELECT
+    CASE
+      WHEN NULLIF(BTRIM(asset), '') IS NOT NULL AND NULLIF(BTRIM(chain), '') IS NULL THEN 'asset_present_chain_empty'
+      WHEN NULLIF(BTRIM(asset), '') IS NULL AND NULLIF(BTRIM(chain), '') IS NOT NULL THEN 'chain_present_asset_empty'
+      WHEN NULLIF(BTRIM(asset), '') IS NOT NULL AND NULLIF(BTRIM(chain), '') IS NOT NULL THEN 'both_present'
+      ELSE 'both_empty'
+    END AS bucket,
+    place_id
+  FROM payment_accepts
+)
+SELECT bucket, COUNT(*)::bigint AS row_count, COUNT(DISTINCT place_id)::bigint AS distinct_places
+FROM buckets
+GROUP BY bucket
+ORDER BY bucket;
+```
+
+```sql
+SELECT COUNT(DISTINCT place_id)::bigint AS places_asset_present_chain_empty
+FROM payment_accepts
+WHERE NULLIF(BTRIM(asset), '') IS NOT NULL
+  AND NULLIF(BTRIM(chain), '') IS NULL;
+```
+
+```sql
+SELECT COUNT(DISTINCT place_id)::bigint AS places_both_present
+FROM payment_accepts
+WHERE NULLIF(BTRIM(asset), '') IS NOT NULL
+  AND NULLIF(BTRIM(chain), '') IS NOT NULL;
+```
+
+## Recorded numbers
+- Could not execute in this container because `DATABASE_URL` is not configured.
+- API behavior change in this PR ensures missing-chain records are counted via `chain='unknown'`.

--- a/lib/stats/acceptance.ts
+++ b/lib/stats/acceptance.ts
@@ -1,0 +1,4 @@
+export const normalizeAcceptanceChainKey = (value: string | null | undefined) => {
+  const normalized = (value ?? "").trim();
+  return normalized || "unknown";
+};

--- a/tests/stats-acceptance-unknown.test.ts
+++ b/tests/stats-acceptance-unknown.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { normalizeAcceptanceChainKey } from "../lib/stats/acceptance";
+
+describe("normalizeAcceptanceChainKey", () => {
+  it("maps empty chain values to unknown", () => {
+    assert.equal(normalizeAcceptanceChainKey(""), "unknown");
+    assert.equal(normalizeAcceptanceChainKey("   "), "unknown");
+    assert.equal(normalizeAcceptanceChainKey(null), "unknown");
+  });
+
+  it("keeps existing chain values for top_chains and matrix rows", () => {
+    const topChains = [{ key: normalizeAcceptanceChainKey(""), count: 4 }];
+    const matrixRows = [{ asset: "btc", counts: { [normalizeAcceptanceChainKey("")]: 2 } }];
+
+    assert.equal(topChains[0]?.key, "unknown");
+    assert.equal(matrixRows[0]?.counts.unknown, 2);
+  });
+});


### PR DESCRIPTION
### Motivation
- Production snapshot showed total_places ≈ 980 but top_chains_sum / matrix_sum ≈ 12, caused by many `payment_accepts` rows having `asset` present but `chain` empty so they were dropped from chain-based aggregations. 
- Goal is to avoid a misleading collapse by counting missing `chain` as a deterministic `unknown` bucket rather than guessing or excluding rows. 
- This PR implements the conservative fix: treat empty/null/whitespace `chain` values as `unknown` in stats aggregations and expose an audit count in the API meta. 

### Description
- SQL aggregation changes: `top_chains` and `asset_acceptance_matrix` queries now use `COALESCE(NULLIF(BTRIM(pa.chain), ''), 'unknown')` so empty chains are grouped into an `unknown` bucket. (app/api/stats/route.ts)
- Matrix query no longer requires non-empty chain rows to be included when `asset` exists, so matrix rows for `unknown` chain are included. (app/api/stats/route.ts)
- API metadata additions: `meta.acceptance_chain_missing_places` (count of distinct places with asset but missing chain) and `meta.acceptance_unknown_chain_included: true` are added to responses for clarity and backward-compatible extension. (app/api/stats/route.ts)
- Runtime handling and UI polish: added `normalizeAcceptanceChainKey` helper and used it when parsing DB rows; updated Stats UI to render `unknown` as `Unknown` and added explanatory text near Chains/Assets and the Asset Acceptance Matrix. (lib/stats/acceptance.ts, app/(site)/stats/StatsPageClient.tsx)
- Audit + test: added an audit doc with the SQL used to inspect data shape under `docs/audits/`, and a small unit test verifying normalization behavior. (docs/audits/, tests/stats-acceptance-unknown.test.ts)

### Testing
- Focused unit test: ran `node --test --import tsx tests/stats-acceptance-unknown.test.ts` and it passed successfully (verifies missing-chain -> `unknown`).
- Lint: ran `npm run lint` and resolved UI unescaped-entity warnings; linter completed (warnings only). 
- Build: ran `npm run build` and a production build completed successfully.
- Full test suite: attempted `npm run test`, but exact DB-driven counts and some compiled tests could not be executed in this environment because `DATABASE_URL` is not configured and the test harness reported unrelated module-resolution issues (`@/lib/db`); these failures are environment-related and not caused by the changes in this PR.

Note: I could not run the audit SQL against a live DB in this container because `DATABASE_URL` is unset, so exact before/after counts (total_places, accepting_any_count, top_chains_sum, matrix_sum, unknown_chain_count) are not measured here; the PR includes the audit SQL in `docs/audits/` for someone with DB access to run and record exact numbers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d8baa51a88328aeb3af0fc4329d6d)