### PR TITLE
Clarify /stats chain coverage and restrict top_chains/matrix to network-specified accepts

### DIFF
--- a/docs/audits/2026-02-24-why-top-chains-not-equal-total-places.md
+++ b/docs/audits/2026-02-24-why-top-chains-not-equal-total-places.md
@@ -1,0 +1,3 @@
+# Why `top_chains` / matrix can be much smaller than `total_places`
+
+`total_places` is computed from the full map population (`places:map_population:v2`), while `top_chains` and `asset_acceptance_matrix` are intentionally computed only from `payment_accepts` rows that have both a non-empty `asset` and a specified non-empty `chain` (network); this means they describe the distribution of **network-specified accepts rows**, not all places, and the UI now shows acceptance coverage (`accepts_with_chain_count`, `accepts_missing_chain_count`, and `network_coverage`) so the gap is explicit rather than misleading.


### PR DESCRIPTION
### Motivation
- Top chains / Asset matrix totals could appear much smaller than `total_places`, which looked misleading without making the denominator explicit. 
- Preserve the existing population metrics (`total_places`, `accepting_any_count`) while making clear that Top chains / Matrix are derived only from accepts rows with a specified network. 
- Surface a small set of coverage indicators so the UI can explain the discrepancy instead of inflating counts with `unknown` chains.

### Description
- API: added acceptance coverage fields to `meta` (`accepts_with_chain_count`, `accepts_missing_chain_count`, `network_coverage`) while leaving `total_places` and `accepting_any_count` unchanged. 
- API: changed `top_chains` SQL to only count accepts with non-empty `chain`, and changed `asset_acceptance_matrix` to only include rows where both `asset` and `chain` are non-empty; added a dedicated `acceptance_coverage` query and wire its results into `meta`. 
- UI: updated `StatsPageClient.tsx` types and defaults, added a KPI row in the Chains/Assets section showing Accepting any (places), Network specified (accepts), Network missing (accepts), and Network coverage (%), and updated Top chains / Matrix headings to indicate they show network-specified accepts only. 
- Docs: added a brief audit note in `docs/audits/2026-02-24-why-top-chains-not-equal-total-places.md` explaining the difference between the population denominator and the network-specified accepts breakdown.

### Testing
- Ran `npm run build`; the production build completed successfully (type checks passed) with unrelated non-blocking Next/ESLint warnings. 
- Started the dev server (`npm run dev`) successfully to exercise the modified client page. 
- Executed a Playwright script to load `/stats` and capture a screenshot verifying the new KPI row and label text render on the page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d92186c388328bbcaa64a00116ade)