### PR TITLE
Simplify Asset Acceptance Matrix summary text

### DIFF
--- a/app/(site)/stats/StatsPageClient.tsx
+++ b/app/(site)/stats/StatsPageClient.tsx
@@ -973,11 +973,8 @@ export default function StatsPageClient() {
         <SectionCard
           eyebrow="Snapshot"
           title="Asset Acceptance Matrix"
-          description={`Asset × chain acceptance counts for network-specified accepts only (${acceptsWithChainCount.toLocaleString()}).`}
+          description={`Network-specified accepts: ${acceptsWithChainCount.toLocaleString()} (coverage ${networkCoveragePercent}; ${acceptsMissingChainCount.toLocaleString()} missing network)`}
         >
-          <p className="mb-3 text-xs text-gray-600">
-            Network-specified accepts only: {acceptsWithChainCount.toLocaleString()} (coverage {networkCoveragePercent}; missing network on {acceptsMissingChainCount.toLocaleString()} accepts rows).
-          </p>
           {matrixRows.length && matrixChains.length ? (
             <div className="overflow-hidden rounded-md border border-gray-200">
               <div className="overflow-x-auto">


### PR DESCRIPTION
### Motivation
- Remove duplicated explanatory text in the Asset Acceptance Matrix and show a single dynamic summary line with network-specified count, coverage percent, and missing network count while leaving aggregation and stats queries unchanged.

### Description
- Update the `SectionCard` description in `app/(site)/stats/StatsPageClient.tsx` to `Network-specified accepts: ${acceptsWithChainCount.toLocaleString()} (coverage ${networkCoveragePercent}; ${acceptsMissingChainCount.toLocaleString()} missing network)` and remove the redundant explanatory `<p>` paragraph above the matrix table.

### Testing
- Ran `npm run build` which completed successfully and captured the `/stats` page with a Playwright screenshot for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d95ed1f948328b96bc58fc84c3a0a)