### PR TITLE
Add normalized payload.payment_accepts support to submissions API

### DIFF
--- a/app/api/submissions/route.ts
+++ b/app/api/submissions/route.ts
@@ -90,7 +90,7 @@ export async function POST(request: Request) {
           error: "Invalid submission",
           errors: normalizedErrors ?? { body: "Invalid JSON payload" },
           hint:
-            "Use multipart form-data with a payload JSON field. Example: curl -F 'payload={\"kind\":\"owner\",\"name\":\"Example\",\"country\":\"US\",\"city\":\"Austin\",\"address\":\"100 Congress Ave\",\"category\":\"cafe\",\"acceptedChains\":[\"btc\"],\"ownerVerification\":\"domain\",\"contactEmail\":\"me@example.com\"}' $BASE/api/submissions",
+            "Use multipart form-data with a payload JSON field. Example: curl -F 'payload={\"kind\":\"owner\",\"name\":\"Example\",\"country\":\"US\",\"city\":\"Austin\",\"address\":\"100 Congress Ave\",\"category\":\"cafe\",\"acceptedChains\":[\"btc\"],\"payment_accepts\":[{\"asset_key\":\"USDT\",\"rail_key\":\"trc20\"}],\"ownerVerification\":\"domain\",\"contactEmail\":\"me@example.com\"}' $BASE/api/submissions",
         }),
         { status: 400, headers: { "Content-Type": "application/json" } },
       );

--- a/lib/rails.ts
+++ b/lib/rails.ts
@@ -1,0 +1,33 @@
+export const RAIL_KEY_DICTIONARY: Record<string, string> = {
+  bitcoin: "bitcoin",
+  btc: "bitcoin",
+  onchain: "bitcoin",
+  "bitcoin-mainnet": "bitcoin",
+  lightning: "lightning",
+  ln: "lightning",
+  "lightning-network": "lightning",
+  ethereum: "ethereum",
+  eth: "ethereum",
+  erc20: "ethereum",
+  solana: "solana",
+  sol: "solana",
+  spl: "solana",
+  tron: "tron",
+  trc20: "tron",
+  polygon: "polygon",
+  matic: "polygon",
+  bsc: "bsc",
+  bnb: "bsc",
+  "binance-smart-chain": "bsc",
+  base: "base",
+  arbitrum: "arbitrum",
+  optimism: "optimism",
+  liquid: "liquid",
+};
+
+export const normalizeRail = (railKey: string | undefined): string => {
+  if (!railKey) return "unknown";
+  const normalized = railKey.trim().toLowerCase();
+  if (!normalized) return "unknown";
+  return RAIL_KEY_DICTIONARY[normalized] ?? "custom";
+};

--- a/lib/submit/normalizePaymentAccepts.ts
+++ b/lib/submit/normalizePaymentAccepts.ts
@@ -1,0 +1,74 @@
+import { normalizeRail } from "@/lib/rails";
+
+export type PaymentAcceptInput = {
+  asset_key: string;
+  rail_key: string;
+  rail_raw?: string;
+};
+
+type SubmissionErrors = Record<string, string>;
+
+type NormalizePaymentAcceptsResult =
+  | { ok: true; value?: PaymentAcceptInput[] }
+  | { ok: false; errors: SubmissionErrors };
+
+const normalizeAssetKey = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/\s+/g, "").toUpperCase();
+};
+
+const normalizeString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+export const normalizePaymentAccepts = (value: unknown): NormalizePaymentAcceptsResult => {
+  if (value === undefined) {
+    return { ok: true, value: undefined };
+  }
+
+  if (!Array.isArray(value)) {
+    return { ok: false, errors: { payment_accepts: "Must be an array" } };
+  }
+
+  const errors: SubmissionErrors = {};
+  const normalizedRows: PaymentAcceptInput[] = [];
+
+  value.forEach((row, index) => {
+    if (!row || typeof row !== "object") {
+      errors[`payment_accepts[${index}]`] = "Must be an object";
+      return;
+    }
+
+    const paymentRow = row as Record<string, unknown>;
+    const assetKey = normalizeAssetKey(paymentRow.asset_key);
+    if (!assetKey) {
+      errors[`payment_accepts[${index}].asset_key`] = "Required";
+    }
+
+    const rawRailKey = normalizeString(paymentRow.rail_key);
+    const railKey = normalizeRail(rawRailKey);
+    const railRaw = normalizeString(paymentRow.rail_raw);
+
+    if (railKey === "custom" && !railRaw) {
+      errors[`payment_accepts[${index}].rail_raw`] = "Required when rail_key is custom";
+    }
+
+    if (assetKey) {
+      normalizedRows.push({
+        asset_key: assetKey,
+        rail_key: railKey,
+        ...(railKey === "custom" && railRaw ? { rail_raw: railRaw } : {}),
+      });
+    }
+  });
+
+  if (Object.keys(errors).length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, value: normalizedRows };
+};


### PR DESCRIPTION
### Motivation
- Allow submissions to include structured Asset×Rail rows via a new `payment_accepts` payload while preserving the existing `acceptedChains` flow and semantics.
- Normalize and validate incoming `payment_accepts` rows so stored submission JSON is consistent and safe to consume by downstream logic without requiring a DB migration.

### Description
- Added optional `payment_accepts?: PaymentAcceptInput[]` to the submission payload types and propagated it into submission payload building for both new and legacy schemas in `lib/submissions.ts`.
- Introduced `lib/rails.ts` with `RAIL_KEY_DICTIONARY` and `normalizeRail` to map/normalize known rail keys, return `unknown` for missing rails, and `custom` for unmapped rails.
- Added `lib/submit/normalizePaymentAccepts.ts` which normalizes `asset_key` (trim, remove spaces, uppercase), normalizes `rail_key` (trim, lowercase, dictionary mapping), defaults missing rails to `unknown`, and enforces `rail_raw` when a rail resolves to `custom`.
- Wired the new normalizer into `normalizeSubmission` and the legacy payload conversion path, and updated the dry-run submission hint in `app/api/submissions/route.ts` to show the new `payment_accepts` shape; existing `acceptedChains` behavior and DB schema are unchanged.

### Testing
- Ran type checks with `npx tsc --project tsconfig.test.json` which completed successfully.
- Ran a focused test file with `node --test .tmp-tests/tests/places-bbox.test.js` which passed.
- Ran the full stats test command `npm run test:stats` which produced a failure in the `.tmp-tests/tests/submissions-normalize.test.js` runtime due to a preexisting module-resolution issue for `@/lib/db` in the test harness and is unrelated to the `payment_accepts` logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da2889c4083288bd2b1f7dd285f90)