### PR TITLE
Home: Minimal SEO hero with single H1 and 3 CTAs

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -32,43 +32,33 @@ export const metadata: Metadata = {
 
 export default function HomePage() {
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 py-12 sm:px-6 sm:py-16">
-      <section className="space-y-4">
+    <main className="mx-auto flex min-h-[calc(100vh-9rem)] w-full max-w-4xl items-center px-4 py-10 sm:px-6 sm:py-14">
+      <section className="w-full rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-10">
         <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">CryptoPayMap</p>
-        <h1 className="max-w-3xl text-3xl font-semibold text-gray-900 sm:text-5xl">
-          Find places that accept cryptocurrency payments
-        </h1>
-        <p className="max-w-2xl text-base text-gray-600 sm:text-lg">
-          Explore global locations, check listing verification levels, and help the directory stay current by
-          submitting updates.
-        </p>
-        <div className="flex flex-wrap gap-3 pt-2">
+        <h1 className="mt-3 text-3xl font-semibold text-gray-900 sm:text-5xl">Find places that accept crypto</h1>
+        <div className="mt-5 max-w-2xl space-y-3 text-base text-gray-600 sm:text-lg">
+          <p>Discover crypto-friendly cafes, shops, and services around the world.</p>
+          <p>Check trusted listing signals before visiting and compare options by area.</p>
+          <p>Help keep the map fresh by submitting new places and updates.</p>
+        </div>
+        <div className="mt-7 flex flex-wrap gap-3">
           <Link href="/map" className="rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white">
             Open Map
+          </Link>
+          <Link
+            href="/discover"
+            className="rounded-full border border-gray-200 px-5 py-2.5 text-sm font-semibold text-gray-700"
+          >
+            Discover
           </Link>
           <Link
             href="/submit"
             className="rounded-full border border-gray-200 px-5 py-2.5 text-sm font-semibold text-gray-700"
           >
-            Submit a place
+            Submit
           </Link>
         </div>
       </section>
-
-      <section className="grid gap-4 sm:grid-cols-3">
-        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-          <h2 className="text-base font-semibold text-gray-900">Verification labels</h2>
-          <p className="mt-2 text-sm text-gray-600">Understand whether each listing is owner-confirmed, community-reported, or directory-imported.</p>
-        </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-          <h2 className="text-base font-semibold text-gray-900">Fast filtering</h2>
-          <p className="mt-2 text-sm text-gray-600">Narrow the map by country, city, category, and accepted assets to quickly find relevant places.</p>
-        </div>
-        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-          <h2 className="text-base font-semibold text-gray-900">Community updates</h2>
-          <p className="mt-2 text-sm text-gray-600">Contribute new venues and report stale data so the map remains useful for everyone.</p>
-        </div>
-      </section>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a minimal SEO entrypoint on `/` that includes only the essentials for search indexing (one H1, short description, CTA links). 
- Keep the home page compact and non-LP-like so it fits within a single viewport on desktop/tablet/mobile. 
- Ensure each CTA routes to the required pages so visitors and crawlers can reach map, discovery, and submission flows.

### Description
- Replaced the previous home layout with a centered `main` hero that enforces a viewport-height min and compact max width for single-screen presentation. 
- Added a single `h1` and three short explanatory lines (2–5 lines total) to satisfy minimal SEO copy requirements. 
- Added three CTA `Link`s with the required destinations and labels: `Open Map -> /map`, `Discover -> /discover`, and `Submit -> /submit`. 
- Removed the lower feature-card section to keep the page minimal and updated the file `app/(site)/page.tsx` accordingly.

### Testing
- Ran `npm run lint`, which completed successfully (repository had unrelated existing warnings). 
- Launched the dev server with `npm run dev` and captured a screenshot of `/` using Playwright to visually validate the layout. 
- Executed a Playwright check that verified there is exactly one `h1` and that CTA hrefs are `/map`, `/discover`, and `/submit`, all of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e60b14f78832890f0e88df6a5a529)