### PR TITLE
Unify page metadata conventions for SEO and add place metadata scaffold

### DIFF
--- a/app/(map)/map/page.tsx
+++ b/app/(map)/map/page.tsx
@@ -1,34 +1,13 @@
 import type { Metadata } from 'next';
 import MapClient from '@/components/map/MapClient';
+import { buildPageMetadata } from '@/lib/seo/metadata';
 
-export const metadata: Metadata = {
-  title: 'Map',
-  description: 'Browse the map to find places that accept cryptocurrency payments, with reliability levels for each listing.',
-  alternates: {
-    canonical: '/map',
-  },
-  openGraph: {
-    title: 'Map | CryptoPayMap',
-    description: 'Browse the map to find places that accept cryptocurrency payments, with reliability levels for each listing.',
-    url: '/map',
-    siteName: 'CryptoPayMap',
-    type: 'website',
-    images: [
-      {
-        url: '/og.png',
-        width: 1200,
-        height: 630,
-        alt: 'CryptoPayMap',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Map | CryptoPayMap',
-    description: 'Browse the map to find places that accept cryptocurrency payments, with reliability levels for each listing.',
-    images: ['/og.png'],
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Explore the crypto payment map',
+  description:
+    'Browse nearby crypto-accepting places on the interactive map with verification levels and listing context.',
+  path: '/map',
+});
 
 export default function MapPage() {
   return <MapClient />;

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,34 +1,13 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { buildPageMetadata } from '@/lib/seo/metadata';
 
-export const metadata: Metadata = {
-  title: 'Home',
-  description: 'CryptoPayMap helps you find places that accept cryptocurrency, with verification signals and transparent listing sources.',
-  alternates: {
-    canonical: '/',
-  },
-  openGraph: {
-    title: 'CryptoPayMap',
-    description: 'Find crypto-friendly places worldwide with map search, verification levels, and community-driven updates.',
-    url: '/',
-    siteName: 'CryptoPayMap',
-    type: 'website',
-    images: [
-      {
-        url: '/og.png',
-        width: 1200,
-        height: 630,
-        alt: 'CryptoPayMap',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'CryptoPayMap',
-    description: 'Find crypto-friendly places worldwide with map search, verification levels, and community-driven updates.',
-    images: ['/og.png'],
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Find crypto-friendly places worldwide',
+  description:
+    'Discover cafes, shops, and services that accept cryptocurrency, then review listing trust signals before you visit.',
+  path: '/',
+});
 
 export default function HomePage() {
   return (

--- a/app/(site)/stats/page.tsx
+++ b/app/(site)/stats/page.tsx
@@ -1,34 +1,13 @@
 import type { Metadata } from 'next';
 import StatsPageClient from './StatsPageClient';
+import { buildPageMetadata } from '@/lib/seo/metadata';
 
-export const metadata: Metadata = {
-  title: 'Stats',
-  description: 'Track CryptoPayMap growth with live counts and recent listing trends across verification levels.',
-  alternates: {
-    canonical: '/stats',
-  },
-  openGraph: {
-    title: 'Stats | CryptoPayMap',
-    description: 'Track CryptoPayMap growth with live counts and recent listing trends across verification levels.',
-    url: '/stats',
-    siteName: 'CryptoPayMap',
-    type: 'website',
-    images: [
-      {
-        url: '/og.png',
-        width: 1200,
-        height: 630,
-        alt: 'CryptoPayMap',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Stats | CryptoPayMap',
-    description: 'Track CryptoPayMap growth with live counts and recent listing trends across verification levels.',
-    images: ['/og.png'],
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Crypto listing and growth stats',
+  description:
+    'Review CryptoPayMap totals, verification mix, and listing trends to understand ecosystem coverage over time.',
+  path: '/stats',
+});
 
 export default function StatsPage() {
   return <StatsPageClient />;

--- a/app/(site)/submit/page.tsx
+++ b/app/(site)/submit/page.tsx
@@ -1,34 +1,13 @@
-import type { Metadata } from "next";
-import Link from "next/link";
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { buildPageMetadata } from '@/lib/seo/metadata';
 
-export const metadata: Metadata = {
-  title: 'Submit',
-  description: 'Submit a place or request updates as Owner Verified, Community Verified, or Report a listing.',
-  alternates: {
-    canonical: '/submit',
-  },
-  openGraph: {
-    title: 'Submit | CryptoPayMap',
-    description: 'Submit a place or request updates as Owner Verified, Community Verified, or Report a listing.',
-    url: '/submit',
-    siteName: 'CryptoPayMap',
-    type: 'website',
-    images: [
-      {
-        url: '/og.png',
-        width: 1200,
-        height: 630,
-        alt: 'CryptoPayMap',
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Submit | CryptoPayMap',
-    description: 'Submit a place or request updates as Owner Verified, Community Verified, or Report a listing.',
-    images: ['/og.png'],
-  },
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: 'Submit a place or listing update',
+  description:
+    'Send owner verification requests, community additions, or listing issue reports to keep CryptoPayMap accurate.',
+  path: '/submit',
+});
 
 const SubmitCard = ({
   title,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,9 @@ import './globals.css';
 import type { Metadata } from 'next';
 import Script from 'next/script';
 import { ReactNode } from 'react';
+import { DEFAULT_DESCRIPTION } from '@/lib/seo/metadata';
 
-const description = 'CryptoPayMap — find crypto-friendly places worldwide, with verification levels to judge listing reliability.';
+const description = DEFAULT_DESCRIPTION;
 const siteUrl = 'https://www.cryptopaymap.com';
 
 export const metadata: Metadata = {
@@ -13,9 +14,6 @@ export const metadata: Metadata = {
     template: '%s | CryptoPayMap',
   },
   description,
-  alternates: {
-    canonical: '/',
-  },
   icons: {
     icon: [
       { url: '/favicon.ico' },

--- a/app/place/[id]/page.tsx
+++ b/app/place/[id]/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next';
+import { buildPlaceMetadata } from '@/lib/seo/metadata';
+
+type PlacePageProps = {
+  params: { id: string };
+};
+
+export async function generateMetadata({ params }: PlacePageProps): Promise<Metadata> {
+  const { id } = params;
+  return buildPlaceMetadata({ id });
+}
+
+export default function PlaceDetailPlaceholderPage({ params }: PlacePageProps) {
+  const { id } = params;
+
+  return (
+    <main className="mx-auto flex min-h-[calc(100vh-9rem)] w-full max-w-4xl items-center px-4 py-10 sm:px-6 sm:py-14">
+      <section className="w-full rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-10">
+        <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">Place Detail (Preview)</p>
+        <h1 className="mt-3 text-3xl font-semibold text-gray-900 sm:text-5xl">Place ID: {id}</h1>
+        <p className="mt-5 max-w-2xl text-base text-gray-600 sm:text-lg">
+          Detailed place pages are being prepared in a follow-up task.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/lib/seo/metadata.ts
+++ b/lib/seo/metadata.ts
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next';
+
+const SITE_NAME = 'CryptoPayMap';
+const OG_IMAGE = '/og.png';
+
+export const DEFAULT_DESCRIPTION =
+  'CryptoPayMap helps you find places that accept cryptocurrency, with verification signals and transparent listing sources.';
+
+const buildOgTitle = (title: string) => `${title} | ${SITE_NAME}`;
+
+type PageMetadataInput = {
+  title: string;
+  description: string;
+  path: `/${string}` | '/';
+};
+
+export const buildPageMetadata = ({ title, description, path }: PageMetadataInput): Metadata => ({
+  title,
+  description,
+  alternates: {
+    canonical: path,
+  },
+  openGraph: {
+    title: buildOgTitle(title),
+    description,
+    url: path,
+    siteName: SITE_NAME,
+    type: 'website',
+    images: [
+      {
+        url: OG_IMAGE,
+        width: 1200,
+        height: 630,
+        alt: SITE_NAME,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: buildOgTitle(title),
+    description,
+    images: [OG_IMAGE],
+  },
+});
+
+type PlaceMetadataInput = {
+  id: string;
+  placeName?: string | null;
+};
+
+export const buildPlaceMetadata = ({ id, placeName }: PlaceMetadataInput): Metadata => {
+  const title = placeName?.trim().length ? `${placeName.trim()} details` : `Place ${id} details`;
+  return buildPageMetadata({
+    title,
+    description:
+      'Check this place’s verification level, supported crypto assets, and key listing details on CryptoPayMap.',
+    path: `/place/${id}`,
+  });
+};


### PR DESCRIPTION
### Motivation
- Establish a single, consistent way to build page metadata (title/description/canonical/OG/Twitter) across the site to improve SEO and avoid duplicate or hard-coded canonicals.
- Ensure page-level metadata is self-referential (canonical = page path) and provide a scaffold for detailed place pages to be implemented later.

### Description
- Add a shared metadata helper `lib/seo/metadata.ts` exposing `buildPageMetadata`, `buildPlaceMetadata`, and `DEFAULT_DESCRIPTION` to standardize OG/Twitter/title/description and `alternates.canonical` per page.
- Update the root layout `app/layout.tsx` to use `DEFAULT_DESCRIPTION` and remove the fixed `canonical: '/'` fallback so per-page canonicals remain self-referential.
- Convert core pages (`/` -> `app/(site)/page.tsx`, `/map` -> `app/(map)/map/page.tsx`, `/submit` -> `app/(site)/submit/page.tsx`, `/stats` -> `app/(site)/stats/page.tsx`) to use `buildPageMetadata` with unique titles/descriptions and `path`-based canonicals.
- Add a placeholder route and metadata scaffold for `/place/[id]` at `app/place/[id]/page.tsx` using `generateMetadata` and `buildPlaceMetadata` so place-specific metadata (and canonical) are ready for TASK6.

### Testing
- Ran `npm run lint`, which completed successfully (only existing non-blocking ESLint warnings remain) using `next lint`.
- Started the app with `npm run dev` and verified the dev server became ready on `http://localhost:3000`.
- Used Playwright to open `http://127.0.0.1:3000/place/demo-place-123` and capture a screenshot of the placeholder page, confirming the new `/place/[id]` route compiles and serves with generated metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e85fdb58c8328a920352f493455d3)