### PR TITLE
Enforce noindex/nofollow metadata for /internal routes

### DIFF
--- a/app/internal/layout.tsx
+++ b/app/internal/layout.tsx
@@ -6,6 +6,10 @@ export const metadata: Metadata = {
   robots: {
     index: false,
     follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
   },
 };
 


### PR DESCRIPTION
### Motivation
- Ensure any page under `/internal/*` is explicitly marked `noindex, nofollow` to prevent crawler contamination and accidental public indexing.

### Description
- Updated `app/internal/layout.tsx` to set `metadata.robots.index = false` and `metadata.robots.follow = false` and added a `googleBot` block with `index: false` and `follow: false` so Googlebot obeys the same policy; public root layout and page metadata remain unchanged.

### Testing
- Ran `npm run lint` which completed without errors, started the dev server and verified via HTTP fetch that `/internal/submissions` returns `<meta name="robots" content="noindex, nofollow"` while `/` and `/map` return `index, follow`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9c254f84832889c8135304c87861)