### PR TITLE
Fix sitemap/robots internal exclusion consistency

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,5 +3,6 @@ Allow: /
 Disallow: /api/
 Disallow: /_next/
 Disallow: /internal
+Disallow: /internal/
 
 Sitemap: https://www.cryptopaymap.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -28,4 +28,5 @@
     <loc>https://www.cryptopaymap.com/map</loc>
     <lastmod>2026-02-02</lastmod>
   </url>
+  <!-- Dynamic /place/* detail pages are intentionally omitted from this static sitemap. -->
 </urlset>


### PR DESCRIPTION
### Motivation
- Ensure `robots.txt` and the static `sitemap.xml` consistently exclude internal routes and clarify the intended handling of dynamic detail pages (e.g. `/place/*`) after `/` became the home route.

### Description
- Add `Disallow: /internal/` to `public/robots.txt` and add a clarifying comment to `public/sitemap.xml` stating that dynamic `/place/*` detail pages are intentionally omitted from the static sitemap.

### Testing
- Ran `npm run lint` and started the dev server, then fetched `http://127.0.0.1:3000/robots.txt` and `http://127.0.0.1:3000/sitemap.xml` which returned HTTP 200 and verified the sitemap contains no `/internal` entries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9e1c180883289193492373ee53e1)