### PR TITLE
Add /map?place deep-link support and minimal place JSON-LD + related links

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -153,6 +153,8 @@ export default function MapClient() {
   const isMobilePlaceOpen = mounted && isPlaceOpen && Boolean(selectedPlaceId);
   const drawerMode: "full" = "full";
 
+  const selectedPlaceParam = searchParams.get("place") ?? searchParams.get("select");
+
   const invalidateMapSize = useCallback(() => {
     const map = mapInstanceRef.current;
     if (!map) return;
@@ -305,9 +307,8 @@ export default function MapClient() {
     if (!hasHydratedFiltersRef.current) return;
     const nextQuery = buildQueryFromFilters(filters);
     const nextParams = new URLSearchParams(nextQuery.replace("?", ""));
-    const selectParam = searchParams.get("select");
-    if (selectParam) {
-      nextParams.set("select", selectParam);
+    if (selectedPlaceParam) {
+      nextParams.set("place", selectedPlaceParam);
     }
     const nextQueryWithSelection = nextParams.toString();
     const currentQuery = searchParams.toString() ? `?${searchParams.toString()}` : "";
@@ -315,7 +316,7 @@ export default function MapClient() {
     if (normalizedQuery !== currentQuery) {
       router.replace(`${pathname}${normalizedQuery}`, { scroll: false });
     }
-  }, [filters, pathname, router, searchParams]);
+  }, [filters, pathname, router, searchParams, selectedPlaceParam]);
 
   useEffect(() => {
     let isMounted = true;
@@ -774,7 +775,7 @@ export default function MapClient() {
   }, [filters]);
 
   useEffect(() => {
-    const selectParam = searchParams.get("select");
+    const selectParam = selectedPlaceParam;
     if (skipNextSelectionRef.current) {
       if (!selectParam) {
         skipNextSelectionRef.current = false;
@@ -786,22 +787,24 @@ export default function MapClient() {
     }
     if (selectParam) {
       if (selectParam !== selectedPlaceIdRef.current) {
-        drawerReasonRef.current = `search-param:${selectParam}`;
+        drawerReasonRef.current = `query-param:${selectParam}`;
         setSelectedPlaceId(selectParam);
       }
       setIsPlaceOpen(true);
     }
-if (!selectionHydrated) {
+    if (!selectionHydrated) {
       setSelectionHydrated(true);
     }
-  }, [searchParams, selectionHydrated]);
+  }, [selectedPlaceParam, selectionHydrated]);
 
   useEffect(() => {
     if (!selectionHydrated) return;
     const params = new URLSearchParams(searchParams.toString());
     if (selectedPlaceId) {
-      params.set("select", selectedPlaceId);
+      params.set("place", selectedPlaceId);
+      params.delete("select");
     } else {
+      params.delete("place");
       params.delete("select");
     }
     const nextQuery = params.toString();


### PR DESCRIPTION
### Motivation
- Provide a reliable deep-link from `/place/[id]` to `/map` so `/map?place=...` auto-opens the place drawer and degrades to the normal map when not available.
- Improve basic SEO for place pages by emitting minimal, non-speculative JSON-LD (`LocalBusiness` + `BreadcrumbList`).
- Surface minimal internal navigation on place pages with same-country and same-category links where available.

### Description
- Map client: extended query handling in `components/map/MapClient.tsx` to read both new `place` and legacy `select` query params, auto-open the drawer when present, and keep URL sync normalized to use `place` while removing `select` on updates.
- Place page: added minimal SEO JSON-LD to `app/place/[id]/page.tsx` (emits `LocalBusiness` with `name`, `url`, `category`, `address`, and `geo` only when present, plus a `BreadcrumbList`).
- Place page: added an internal related-links block using `lib/data/places` as a safe fallback to list up to 6 related places by same country and same category, hiding the block if no matches exist.
- Changes avoid fabricating values and keep logic conservative when fields are missing.

### Testing
- Ran `npm run lint` which completed successfully (only pre-existing warnings reported).
- Ran `npm test` which exercised the test suite but failed due to an existing test-environment issue (`Cannot find module '@/lib/db'`) unrelated to the added logic.
- Verified deep-link behavior with automated browser checks (Playwright): visiting `/map?place=<id>` sets the map `data-selected-place` to the expected place id and the drawer opens as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699eacda2c3c832896382bcaa4b10b5a)