### PR TITLE
Fix 404 on /place/[id] for URL-encoded place IDs

### DIFF
--- a/app/place/[id]/page.tsx
+++ b/app/place/[id]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { places as fallbackPlaces } from '@/lib/data/places';
 import { getPlaceDetail } from '@/lib/places/detail';
 import { buildPlaceMetadata } from '@/lib/seo/metadata';
+import { safeDecode } from '@/lib/utils/safeDecode';
 
 type PlacePageProps = {
   params: { id: string };
@@ -20,7 +21,8 @@ const relatedLinksLimit = 6;
 const normalizeText = (value: string | null | undefined) => value?.trim().toLowerCase() ?? '';
 
 export async function generateMetadata({ params }: PlacePageProps): Promise<Metadata> {
-  const { id } = params;
+  const rawId = params.id;
+  const id = safeDecode(rawId);
   const { place } = await getPlaceDetail(id);
 
   return buildPlaceMetadata({
@@ -30,7 +32,8 @@ export async function generateMetadata({ params }: PlacePageProps): Promise<Meta
 }
 
 export default async function PlaceDetailPage({ params }: PlacePageProps) {
-  const { id } = params;
+  const rawId = params.id;
+  const id = safeDecode(rawId);
   const { place } = await getPlaceDetail(id);
 
   if (!place) {

--- a/lib/utils/safeDecode.ts
+++ b/lib/utils/safeDecode.ts
@@ -1,0 +1,8 @@
+export function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+


### PR DESCRIPTION
### Motivation
- `params.id` can be URL-encoded (e.g. `cpm%3Anewyork%3Acommunity-diner-1`) while the place lookup expects a decoded ID, causing valid places to return 404.
- Encoded tokens like `%3A` could leak into generated metadata titles/descriptions if not decoded.

### Description
- Add a safe decoding utility `lib/utils/safeDecode.ts` that returns `decodeURIComponent(value)` or falls back to the original value on error via `safeDecode`.
- Update `app/place/[id]/page.tsx` to read `rawId = params.id` and use `id = safeDecode(rawId)` in both `generateMetadata` and the page data fetch before calling `getPlaceDetail(id)`.
- Preserve existing `notFound()` behavior so IDs that remain unmatched after decoding still return 404 and existing `encodeURIComponent(place.id)` usage for links is unchanged.

### Testing
- Ran `npm run lint` which completed successfully and emitted only existing unrelated warnings.
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ecd5980788328b3cd5dc211641af6)