### PR TITLE
PR-B: Fix /map invalid place deep-link fallback behavior

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -762,8 +762,19 @@ export default function MapClient() {
       setSelectionNotice(null);
       return;
     }
+
+    if (selectedPlaceParam && selectedPlaceParam === selectedPlaceId) {
+      drawerReasonRef.current = `invalid-query-param:${selectedPlaceParam}`;
+      skipNextSelectionRef.current = true;
+      setSelectionNotice(null);
+      setSelectedPlaceId(null);
+      setIsPlaceOpen(false);
+      router.replace("/map", { scroll: false });
+      return;
+    }
+
     setSelectionNotice("Selected place is outside the current map area or filters.");
-  }, [places, placesStatus, selectedPlaceId]);
+  }, [places, placesStatus, router, selectedPlaceId, selectedPlaceParam]);
 
   useEffect(() => {
     if (!fetchPlacesRef.current) return;


### PR DESCRIPTION
### Motivation
- Prevent the map Drawer from remaining open when the URL contains an invalid `place` deep-link and ensure the UI falls back to the normal map state.

### Description
- Update `components/map/MapClient.tsx` to reconcile URL-driven selection after `places` load by detecting when `selectedPlaceParam === selectedPlaceId` but the ID is not present in the loaded `places` and then clearing `selectedPlaceId`, closing the drawer, setting `skipNextSelectionRef`, and calling `router.replace('/map', { scroll: false })` to remove the invalid query param.
- Add `selectedPlaceParam` and `router` to the effect dependency array so the effect runs correctly when those values change.

### Testing
- Ran `npm run lint` which completed with only existing non-blocking warnings and no new lint errors. 
- Ran `npm run test` which produced an unrelated failure due to test environment module resolution (`Cannot find module '@/lib/db'`) and is not caused by this change. 
- Started the dev server with `npm run dev` and executed a Playwright check which confirmed that `http://.../map?place=invalid-id` falls back to `http://.../map` and that a valid `?place=<id>` still opens the Drawer as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ecf68fab48328ac7540a0d3d16147)