### PR TITLE
Add Home SEO block: payments, regions, verification, FAQ, and Donate CTA

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -2,6 +2,60 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { buildPageMetadata } from '@/lib/seo/metadata';
 
+const SUPPORTED_PAYMENTS = [
+  {
+    title: 'Coins',
+    items: ['Bitcoin (BTC)', 'Ethereum (ETH)'],
+  },
+  {
+    title: 'Bitcoin payments',
+    items: ['On-chain', 'Lightning'],
+  },
+  {
+    title: 'Stablecoins',
+    items: ['USDT', 'USDC'],
+  },
+  {
+    title: 'Networks',
+    items: ['Polygon', 'Arbitrum', 'Solana'],
+  },
+] as const;
+
+const REGIONS = [
+  'United States',
+  'France',
+  'Japan',
+  'Germany',
+  'Canada',
+  'UK',
+  'Singapore',
+  'Australia',
+] as const;
+
+const VERIFICATION_STEPS = [
+  'Unverified – imported from OpenStreetMap (not yet verified)',
+  'Community – updated/confirmed by the community',
+  'Owner verified – confirmed by the business owner',
+] as const;
+
+const FAQS = [
+  {
+    question: 'How reliable are listings on CryptoPayMap?',
+    answer:
+      'Each place includes verification status so you can quickly see whether a listing is imported, community-updated, or owner confirmed.',
+  },
+  {
+    question: 'Can I help improve the map?',
+    answer: 'Yes. You can submit new places and update existing listings to keep local information accurate.',
+  },
+  {
+    question: 'Is it free to use and submit places?',
+    answerPrefix: 'Yes. Using CryptoPayMap and submitting updates are free. We’re currently supported by ',
+    answerLinkLabel: 'donations',
+    answerSuffix: '.',
+  },
+] as const;
+
 export const metadata: Metadata = buildPageMetadata({
   title: 'Find crypto-friendly places worldwide',
   description:
@@ -11,7 +65,7 @@ export const metadata: Metadata = buildPageMetadata({
 
 export default function HomePage() {
   return (
-    <main className="mx-auto flex min-h-[calc(100vh-9rem)] w-full max-w-4xl items-center px-4 py-10 sm:px-6 sm:py-14">
+    <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
       <section className="w-full rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-10">
         <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">CryptoPayMap</p>
         <h1 className="mt-3 text-3xl font-semibold text-gray-900 sm:text-5xl">Find places that accept crypto</h1>
@@ -35,6 +89,85 @@ export default function HomePage() {
             className="rounded-full border border-gray-200 px-5 py-2.5 text-sm font-semibold text-gray-700"
           >
             Submit
+          </Link>
+        </div>
+      </section>
+
+      <section className="w-full rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-10" aria-label="Home SEO content">
+        <div>
+          <h2 className="text-2xl font-semibold text-gray-900">Supported payments</h2>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {SUPPORTED_PAYMENTS.map((group) => (
+              <div key={group.title} className="rounded-xl border border-gray-100 bg-gray-50 p-4">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-700">{group.title}</h3>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {group.items.map((item) => (
+                    <span key={item} className="rounded-full border border-gray-200 bg-white px-3 py-1 text-sm text-gray-700">
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-10">
+          <h2 className="text-2xl font-semibold text-gray-900">Browse by region</h2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {REGIONS.map((region) => (
+              <Link
+                key={region}
+                href="/discover"
+                className="rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                {region}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-10">
+          <h2 className="text-2xl font-semibold text-gray-900">How verification works</h2>
+          <ul className="mt-4 space-y-2 text-gray-700">
+            {VERIFICATION_STEPS.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mt-10">
+          <h2 className="text-2xl font-semibold text-gray-900">FAQ</h2>
+          <div className="mt-4 space-y-3">
+            {FAQS.map((faq) => (
+              <details key={faq.question} className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+                <summary className="cursor-pointer list-none text-base font-semibold text-gray-900">{faq.question}</summary>
+                <p className="mt-2 text-sm leading-6 text-gray-700">
+                  {'answer' in faq ? (
+                    faq.answer
+                  ) : (
+                    <>
+                      {faq.answerPrefix}
+                      <Link href="/donate" className="text-sky-700 underline underline-offset-2">
+                        {faq.answerLinkLabel}
+                      </Link>
+                      {faq.answerSuffix}
+                    </>
+                  )}
+                </p>
+              </details>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-10 rounded-xl border border-gray-200 bg-gray-50 p-4 sm:p-5">
+          <h2 className="text-lg font-semibold text-gray-900">Support this project</h2>
+          <p className="mt-1 text-sm text-gray-600">Help us keep CryptoPayMap free and up to date.</p>
+          <Link
+            href="/donate"
+            className="mt-3 inline-flex rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-white"
+          >
+            Donate
           </Link>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Improve the Home page SEO content and surface trust/donation signals without changing the existing Hero copy or CTA layout. 
- Provide clear verification wording (reflecting OSM imports), list supported payment types separately (Lightning as Bitcoin payments), and surface that the site is free and donation-supported.

### Description
- Added a new SEO block under the Hero in `app/(site)/page.tsx` containing `Supported payments`, `Browse by region`, `How verification works`, `FAQ`, and a small `Support this project` section with a `Donate` button linking to `/donate`.
- Introduced structured arrays/constants (`SUPPORTED_PAYMENTS`, `REGIONS`, `VERIFICATION_STEPS`, `FAQS`) to keep copy/links data-driven and easy to change.
- Implemented the verification copy exactly as required (`Unverified – imported from OpenStreetMap (not yet verified)`, `Community – updated/confirmed by the community`, `Owner verified – confirmed by the business owner`).
- Kept Hero markup and CTAs unchanged (only wrapped the page into a vertical layout and added the SEO block beneath it), and ensured Lightning appears only under `Bitcoin payments`.

### Testing
- Ran `npm run lint` which executed successfully (existing unrelated warnings remain). 
- Launched the dev server with `npm run dev -- --port 3000`, verified the page compiles and captured a full-page screenshot of `/` to confirm layout and appearance.
- Page changes were committed after verification (`app/(site)/page.tsx` modified; new content compiled successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699edd0f16308328905efd65e522b87b)