### PR TITLE
Refine donate CTA flow and temporarily disable hosted donations

### DIFF
--- a/app/(site)/donate/page.tsx
+++ b/app/(site)/donate/page.tsx
@@ -89,6 +89,8 @@ const SUPPORT_LINKS = [
   },
 ];
 
+const ENABLE_HOSTED_DONATIONS = false;
+
 export default function DonatePage() {
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 sm:py-12">
@@ -126,23 +128,27 @@ export default function DonatePage() {
         </div>
       </section>
 
-      <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
-        <h2 className="text-xl font-semibold text-gray-900">Card &amp; hosted donations</h2>
-        <p className="mt-2 text-sm text-gray-600">Prefer a traditional checkout? Use one of the hosted options.</p>
-        <div className="mt-4 flex flex-wrap gap-3">
-          {SUPPORT_LINKS.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              target="_blank"
-              rel="noreferrer"
-              className="rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white"
-            >
-              {link.label}
-            </a>
-          ))}
-        </div>
-      </section>
+      {ENABLE_HOSTED_DONATIONS ? (
+        <section className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="text-xl font-semibold text-gray-900">Card &amp; hosted donations</h2>
+          <p className="mt-2 text-sm text-gray-600">Prefer a traditional checkout? Use one of the hosted options.</p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            {SUPPORT_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white"
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </section>
+      ) : (
+        <p className="text-sm text-gray-500">Hosted donations are temporarily unavailable.</p>
+      )}
     </div>
   );
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -50,9 +50,7 @@ const FAQS = [
   },
   {
     question: 'Is it free to use and submit places?',
-    answerPrefix: 'Yes. Using CryptoPayMap and submitting updates are free. We’re currently supported by ',
-    answerLinkLabel: 'donations',
-    answerSuffix: '.',
+    answer: 'Yes. Using CryptoPayMap and submitting updates are free. We’re currently supported by donations.',
   },
 ] as const;
 
@@ -142,19 +140,7 @@ export default function HomePage() {
             {FAQS.map((faq) => (
               <details key={faq.question} className="rounded-xl border border-gray-200 bg-gray-50 p-4">
                 <summary className="cursor-pointer list-none text-base font-semibold text-gray-900">{faq.question}</summary>
-                <p className="mt-2 text-sm leading-6 text-gray-700">
-                  {'answer' in faq ? (
-                    faq.answer
-                  ) : (
-                    <>
-                      {faq.answerPrefix}
-                      <Link href="/donate" className="text-sky-700 underline underline-offset-2">
-                        {faq.answerLinkLabel}
-                      </Link>
-                      {faq.answerSuffix}
-                    </>
-                  )}
-                </p>
+                <p className="mt-2 text-sm leading-6 text-gray-700">{faq.answer}</p>
               </details>
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- Reduce visual "double CTA" on Home by separating FAQ informational text from the actionable Donate button and avoid showing a redundant `/donate` link inside the FAQ answer.
- Prevent user trust issues by temporarily hiding Stripe/Ko-fi hosted donation controls while keeping on-chain/crypto donation flows available.

### Description
- Removed the inline `/donate` link in the FAQ answer and made the FAQ answer plain text in `app/(site)/page.tsx` so the explanation remains but the immediate link is gone.
- Added a feature flag `ENABLE_HOSTED_DONATIONS = false` in `app/(site)/donate/page.tsx` and wrapped the Stripe/Ko-fi "Card & hosted donations" section behind this flag.
- When the flag is `false`, show a small fallback note: `Hosted donations are temporarily unavailable.` instead of the hosted buttons.
- Left the crypto address donation cards and `CopyButton` behavior unchanged so on-chain donations continue to work as before.

### Testing
- Ran `npm run lint` which completed successfully (lint warnings unrelated to these changes remain but the command returned success).
- Started the dev server (`npm run dev`) and confirmed pages compiled and served locally.
- Automated browser check using Playwright navigated to `/` and `/donate` and captured screenshots to verify the FAQ no longer contains the inline link and the hosted donations section shows the fallback note; the Playwright run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ee08b7d948328bb4f5445a31a9daa)