### PR TITLE
Polish discover v0.1: mobile UX, per-section retry, and client caching

### DIFF
--- a/components/discover/sections/ActivityFeedSection.tsx
+++ b/components/discover/sections/ActivityFeedSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { DiscoverActivityItem, DiscoverActivityTab } from '@/lib/discover/types';
 import {
   LimitedDataNote,
@@ -12,6 +12,7 @@ import {
   TabButton,
   fetchDiscover,
   formatTimeLabel,
+  formatTimeTitle,
   renderAssetList,
   useBreakpoint,
 } from './shared';
@@ -37,86 +38,124 @@ export default function ActivityFeedSection() {
   const [items, setItems] = useState<DiscoverActivityItem[]>([]);
   const [limited, setLimited] = useState(false);
   const [limitedReason, setLimitedReason] = useState<string | undefined>();
+  const [retrying, setRetrying] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const breakpoint = useBreakpoint();
 
   const limit = breakpoint === 'mobile' ? 6 : 8;
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (force = false) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
-      const payload = await fetchDiscover<DiscoverActivityItem[]>(`/api/discover/activity?tab=${activeTab}&limit=${limit}`);
+      const cacheKey = `activity:${activeTab}:${limit}`;
+      const payload = await fetchDiscover<DiscoverActivityItem[]>(`/api/discover/activity?tab=${activeTab}&limit=${limit}`, {
+        cacheKey,
+        signal: controller.signal,
+        force,
+      });
+      if (controller.signal.aborted) return;
       setItems(payload.data);
       setLimited(payload.limited);
       setLimitedReason(payload.reason);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setError(err instanceof Error ? err.message : 'Unable to load activity feed');
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) {
+        setLoading(false);
+        setRetrying(false);
+      }
     }
   }, [activeTab, limit]);
 
   useEffect(() => {
     load();
+    return () => abortRef.current?.abort();
   }, [load]);
+
+  useEffect(() => () => {
+    if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+  }, []);
+
+  const handleRetry = () => {
+    if (retrying) return;
+    setRetrying(true);
+    retryTimeoutRef.current = setTimeout(() => load(true), 300);
+  };
+
+  const activeIndex = activityTabs.findIndex((tab) => tab.key === activeTab);
+
+  const onTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+    const current = activityTabs.findIndex((tab) => tab.key === activeTab);
+    if (event.key === 'Home') return setActiveTab(activityTabs[0].key);
+    if (event.key === 'End') return setActiveTab(activityTabs[activityTabs.length - 1].key);
+    const delta = event.key === 'ArrowRight' ? 1 : -1;
+    const next = (current + delta + activityTabs.length) % activityTabs.length;
+    setActiveTab(activityTabs[next].key);
+  };
 
   return (
     <SectionShell title="Activity Feed" description="Recent directory updates by source and verification type.">
-      <div className="mb-4 flex gap-2 overflow-x-auto pb-1">
+      <div className="mb-4 flex gap-2 overflow-x-auto pb-1" role="tablist" aria-label="Activity feed tabs" onKeyDown={onTabKeyDown}>
         {activityTabs.map((tab) => (
-          <TabButton key={tab.key} active={activeTab === tab.key} onClick={() => setActiveTab(tab.key)}>
+          <TabButton
+            key={tab.key}
+            active={activeTab === tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            id={`activity-tab-${tab.key}`}
+            controls={`activity-panel-${tab.key}`}
+          >
             {tab.label}
           </TabButton>
         ))}
       </div>
 
-      {loading ? <SimpleSkeletonRows rows={4} /> : null}
+      {loading ? <SimpleSkeletonRows rows={4} rowClassName="h-[92px]" /> : null}
       {error ? (
         <SectionError
           summary="We could not load activity updates."
           details={error}
-          onRetry={load}
+          onRetry={handleRetry}
+          retrying={retrying}
         />
       ) : null}
       {!loading && !error && items.length === 0 ? <SectionEmpty message="No recent updates yet." /> : null}
 
       {!loading && !error && items.length > 0 ? (
         <>
-          <div className="hidden space-y-3 sm:block">
+          <div
+            id={`activity-panel-${activityTabs[activeIndex]?.key ?? 'added'}`}
+            role="tabpanel"
+            aria-labelledby={`activity-tab-${activityTabs[activeIndex]?.key ?? 'added'}`}
+            className="space-y-3"
+          >
             {items.map((item) => (
               <MapLink
                 key={item.placeId}
                 href={`/map?place=${encodeURIComponent(item.placeId)}`}
                 className="block rounded-lg border border-gray-200 p-3 transition hover:border-gray-300 hover:bg-gray-50"
               >
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <p className="font-semibold text-gray-900">{item.name}</p>
-                  <span className={`rounded-full px-2 py-1 text-xs font-semibold ${verificationTone[item.verificationLevel]}`}>{item.verificationLevel}</span>
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <p className="min-w-0 flex-1 truncate font-semibold text-gray-900">{item.name}</p>
+                  <span className={`shrink-0 rounded-full px-2 py-1 text-xs font-semibold ${verificationTone[item.verificationLevel]}`}>{item.verificationLevel}</span>
                 </div>
-                <p className="text-sm text-gray-600">{item.city}, {item.country}</p>
-                <p className="mt-1 text-sm text-gray-700">{renderAssetList(item.assets, 3)}</p>
-                <p className="mt-1 text-xs text-gray-500">{formatTimeLabel(item.timeLabelISO)}</p>
-              </MapLink>
-            ))}
-          </div>
-
-          <div className="space-y-3 sm:hidden">
-            {items.map((item) => (
-              <MapLink
-                key={item.placeId}
-                href={`/map?place=${encodeURIComponent(item.placeId)}`}
-                className="block rounded-lg border border-gray-200 p-3"
-              >
-                <p className="font-semibold text-gray-900">{item.name}</p>
-                <p className="text-sm text-gray-600">{item.city}, {item.country}</p>
-                <p className="mt-1 text-sm text-gray-700">{renderAssetList(item.assets, 3)}</p>
-                <p className="mt-1 text-xs text-gray-500">{formatTimeLabel(item.timeLabelISO)}</p>
+                <p className="truncate text-sm text-gray-600">{item.city}, {item.country}</p>
+                <p className="mt-1 line-clamp-1 text-sm text-gray-700">{renderAssetList(item.assets, 3)}</p>
+                <p className="mt-1 text-xs text-gray-500" title={formatTimeTitle(item.timeLabelISO)}>{formatTimeLabel(item.timeLabelISO)}</p>
               </MapLink>
             ))}
           </div>
           {limited ? <LimitedDataNote reason={limitedReason} /> : null}
         </>
       ) : null}
+      {!loading && !error && items.length === 0 && limited ? <LimitedDataNote reason={limitedReason} /> : null}
     </SectionShell>
   );
 }

--- a/components/discover/sections/AssetExplorerSection.tsx
+++ b/components/discover/sections/AssetExplorerSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DiscoverAssetListItem, DiscoverAssetPanel } from '@/lib/discover/types';
 import { LimitedDataNote, MapLink, SectionEmpty, SectionError, SectionShell, SimpleSkeletonRows, fetchDiscover } from './shared';
 
@@ -12,6 +12,7 @@ export default function AssetExplorerSection() {
   const [assets, setAssets] = useState<DiscoverAssetListItem[]>([]);
   const [assetsLimited, setAssetsLimited] = useState(false);
   const [assetsLimitedReason, setAssetsLimitedReason] = useState<string | undefined>();
+  const [assetsRetrying, setAssetsRetrying] = useState(false);
 
   const [selectedAsset, setSelectedAsset] = useState('');
   const [panelLoading, setPanelLoading] = useState(false);
@@ -19,12 +20,19 @@ export default function AssetExplorerSection() {
   const [panel, setPanel] = useState<DiscoverAssetPanel>(EMPTY_PANEL(''));
   const [panelLimited, setPanelLimited] = useState(false);
   const [panelLimitedReason, setPanelLimitedReason] = useState<string | undefined>();
+  const [panelRetrying, setPanelRetrying] = useState(false);
 
-  const loadAssets = useCallback(async () => {
+  const panelAbortRef = useRef<AbortController | null>(null);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const loadAssets = useCallback(async (force = false) => {
     setAssetsLoading(true);
     setAssetsError(null);
     try {
-      const payload = await fetchDiscover<DiscoverAssetListItem[]>('/api/discover/assets');
+      const payload = await fetchDiscover<DiscoverAssetListItem[]>('/api/discover/assets', {
+        cacheKey: 'assets:list',
+        force,
+      });
       setAssets(payload.data);
       setAssetsLimited(payload.limited);
       setAssetsLimitedReason(payload.reason);
@@ -35,23 +43,36 @@ export default function AssetExplorerSection() {
       setAssetsError(err instanceof Error ? err.message : 'Unable to load asset list');
     } finally {
       setAssetsLoading(false);
+      setAssetsRetrying(false);
     }
   }, [selectedAsset]);
 
-  const loadPanel = useCallback(async (asset: string) => {
+  const loadPanel = useCallback(async (asset: string, force = false) => {
     if (!asset) return;
+    panelAbortRef.current?.abort();
+    const controller = new AbortController();
+    panelAbortRef.current = controller;
     setPanelLoading(true);
     setPanelError(null);
     try {
-      const payload = await fetchDiscover<DiscoverAssetPanel>(`/api/discover/assets/${encodeURIComponent(asset)}`);
+      const payload = await fetchDiscover<DiscoverAssetPanel>(`/api/discover/assets/${encodeURIComponent(asset)}`, {
+        cacheKey: `assets:panel:${asset}`,
+        signal: controller.signal,
+        force,
+      });
+      if (controller.signal.aborted) return;
       setPanel(payload.data);
       setPanelLimited(payload.limited);
       setPanelLimitedReason(payload.reason);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setPanelError(err instanceof Error ? err.message : 'Unable to load asset panel');
       setPanel(EMPTY_PANEL(asset));
     } finally {
-      setPanelLoading(false);
+      if (!controller.signal.aborted) {
+        setPanelLoading(false);
+        setPanelRetrying(false);
+      }
     }
   }, []);
 
@@ -63,9 +84,24 @@ export default function AssetExplorerSection() {
     if (selectedAsset) loadPanel(selectedAsset);
   }, [selectedAsset, loadPanel]);
 
-  const isLoading = assetsLoading || panelLoading;
-  const hasError = assetsError || panelError;
+  useEffect(() => () => {
+    panelAbortRef.current?.abort();
+    if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+  }, []);
+
   const activeAsset = selectedAsset || assets[0]?.asset || '';
+
+  const retryAssets = () => {
+    if (assetsRetrying) return;
+    setAssetsRetrying(true);
+    retryTimeoutRef.current = setTimeout(() => loadAssets(true), 300);
+  };
+
+  const retryPanel = () => {
+    if (panelRetrying || !activeAsset) return;
+    setPanelRetrying(true);
+    retryTimeoutRef.current = setTimeout(() => loadPanel(activeAsset, true), 300);
+  };
 
   return (
     <SectionShell title="Asset Explorer" description="Explore top countries, categories, and recent places by selected asset.">
@@ -75,38 +111,50 @@ export default function AssetExplorerSection() {
             type="button"
             key={asset.asset}
             onClick={() => setSelectedAsset(asset.asset)}
-            className={`rounded-full px-3 py-1.5 text-xs font-semibold sm:text-sm ${
+            className={`max-w-full rounded-full px-3 py-1.5 text-xs font-semibold sm:text-sm ${
               activeAsset === asset.asset ? 'bg-gray-900 text-white' : 'border border-gray-200 bg-white text-gray-700'
             }`}
+            title={asset.asset}
           >
-            {asset.asset}
+            <span className="block max-w-[120px] truncate">{asset.asset}</span>
           </button>
         ))}
       </div>
 
-      {isLoading ? <SimpleSkeletonRows rows={4} /> : null}
-      {hasError ? (
+      {assetsLoading ? <SimpleSkeletonRows rows={2} rowClassName="h-10" /> : null}
+      {assetsError ? (
         <SectionError
-          summary="Asset explorer is temporarily unavailable."
-          details={hasError}
-          onRetry={() => {
-            loadAssets();
-            if (activeAsset) loadPanel(activeAsset);
-          }}
+          summary="Asset list is temporarily unavailable."
+          details={assetsError}
+          onRetry={retryAssets}
+          retrying={assetsRetrying}
         />
       ) : null}
-      {!isLoading && !hasError && panel.recent5.length === 0 ? <SectionEmpty message="No places found for this asset." /> : null}
 
-      {!isLoading && !hasError && panel.recent5.length > 0 ? (
+      {panelLoading ? <div className="mt-3"><SimpleSkeletonRows rows={4} rowClassName="h-[56px]" /></div> : null}
+      {panelError ? (
+        <div className="mt-3">
+          <SectionError
+            summary="Asset details are temporarily unavailable."
+            details={panelError}
+            onRetry={retryPanel}
+            retrying={panelRetrying}
+          />
+        </div>
+      ) : null}
+
+      {!assetsLoading && !assetsError && !panelLoading && !panelError && panel.recent5.length === 0 ? <SectionEmpty message="No places found for this asset." /> : null}
+
+      {!panelLoading && !panelError && panel.recent5.length > 0 ? (
         <div className="grid gap-4 lg:grid-cols-3">
           <div className="rounded-lg border border-gray-200 p-3">
             <h3 className="text-sm font-semibold text-gray-900">Countries</h3>
             <ol className="mt-2 space-y-2 text-sm">
               {panel.countriesTop5.slice(0, 5).map((item, index) => (
                 <li key={item.countryCode}>
-                  <MapLink href={`/map?country=${encodeURIComponent(item.countryCode)}&asset=${encodeURIComponent(activeAsset)}`} className="flex justify-between rounded px-1 py-1 hover:bg-gray-50">
-                    <span>{index + 1}. {item.countryCode}</span>
-                    <span className="font-semibold">{item.total}</span>
+                  <MapLink href={`/map?country=${encodeURIComponent(item.countryCode)}&asset=${encodeURIComponent(activeAsset)}`} className="flex items-center justify-between gap-2 rounded px-1 py-1 hover:bg-gray-50">
+                    <span className="min-w-0 flex-1 truncate">{index + 1}. {item.countryCode}</span>
+                    <span className="shrink-0 font-semibold">{item.total}</span>
                   </MapLink>
                 </li>
               ))}
@@ -118,9 +166,9 @@ export default function AssetExplorerSection() {
             <ol className="mt-2 space-y-2 text-sm">
               {panel.categoriesTop5.slice(0, 5).map((item, index) => (
                 <li key={item.category}>
-                  <MapLink href={`/map?category=${encodeURIComponent(item.category)}&asset=${encodeURIComponent(activeAsset)}`} className="flex justify-between rounded px-1 py-1 hover:bg-gray-50">
-                    <span>{index + 1}. {item.category}</span>
-                    <span className="font-semibold">{item.total}</span>
+                  <MapLink href={`/map?category=${encodeURIComponent(item.category)}&asset=${encodeURIComponent(activeAsset)}`} className="flex items-center justify-between gap-2 rounded px-1 py-1 hover:bg-gray-50">
+                    <span className="min-w-0 flex-1 truncate">{index + 1}. {item.category}</span>
+                    <span className="shrink-0 font-semibold">{item.total}</span>
                   </MapLink>
                 </li>
               ))}
@@ -133,8 +181,8 @@ export default function AssetExplorerSection() {
               {panel.recent5.slice(0, 5).map((item) => (
                 <li key={item.placeId}>
                   <MapLink href={`/map?place=${encodeURIComponent(item.placeId)}`} className="block rounded px-1 py-1 hover:bg-gray-50">
-                    <p className="font-medium text-gray-900">{item.name}</p>
-                    <p className="text-xs text-gray-600">{item.city}, {item.country}</p>
+                    <p className="truncate font-medium text-gray-900">{item.name}</p>
+                    <p className="truncate text-xs text-gray-600">{item.city}, {item.country}</p>
                   </MapLink>
                 </li>
               ))}
@@ -142,7 +190,7 @@ export default function AssetExplorerSection() {
           </div>
         </div>
       ) : null}
-      {assetsLimited || panelLimited ? <LimitedDataNote reason={assetsLimitedReason || panelLimitedReason} /> : null}
+      {!assetsLoading && !assetsError && (assetsLimited || panelLimited) ? <LimitedDataNote reason={assetsLimitedReason || panelLimitedReason} /> : null}
     </SectionShell>
   );
 }

--- a/components/discover/sections/FeaturedCitiesSection.tsx
+++ b/components/discover/sections/FeaturedCitiesSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DiscoverFeaturedCity } from '@/lib/discover/types';
 import { LimitedDataNote, MapLink, SectionEmpty, SectionError, SectionShell, SimpleSkeletonRows, fetchDiscover, renderAssetList } from './shared';
 
@@ -10,12 +10,17 @@ export default function FeaturedCitiesSection() {
   const [items, setItems] = useState<DiscoverFeaturedCity[]>([]);
   const [limited, setLimited] = useState(false);
   const [limitedReason, setLimitedReason] = useState<string | undefined>();
+  const [retrying, setRetrying] = useState(false);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (force = false) => {
     setLoading(true);
     setError(null);
     try {
-      const payload = await fetchDiscover<DiscoverFeaturedCity[]>('/api/discover/featured-cities');
+      const payload = await fetchDiscover<DiscoverFeaturedCity[]>('/api/discover/featured-cities', {
+        cacheKey: 'cities:featured',
+        force,
+      });
       setItems(payload.data.slice(0, 6));
       setLimited(payload.limited);
       setLimitedReason(payload.reason);
@@ -23,6 +28,7 @@ export default function FeaturedCitiesSection() {
       setError(err instanceof Error ? err.message : 'Unable to load featured cities');
     } finally {
       setLoading(false);
+      setRetrying(false);
     }
   }, []);
 
@@ -30,40 +36,52 @@ export default function FeaturedCitiesSection() {
     load();
   }, [load]);
 
+  useEffect(() => () => {
+    if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+  }, []);
+
+  const handleRetry = () => {
+    if (retrying) return;
+    setRetrying(true);
+    retryTimeoutRef.current = setTimeout(() => load(true), 300);
+  };
+
   const barWidth = (value: number, total: number) => `${Math.max((value / Math.max(total, 1)) * 100, 8)}%`;
 
   return (
     <SectionShell title="Featured Crypto Cities" description="Top city clusters by active crypto-friendly places.">
-      {loading ? <SimpleSkeletonRows rows={3} /> : null}
-      {error ? <SectionError summary="Featured city cards are unavailable." details={error} onRetry={load} /> : null}
+      {loading ? <SimpleSkeletonRows rows={3} rowClassName="h-[152px]" /> : null}
+      {error ? <SectionError summary="Featured city cards are unavailable." details={error} onRetry={handleRetry} retrying={retrying} /> : null}
       {!loading && !error && items.length === 0 ? <SectionEmpty message="No cities available yet." /> : null}
 
       {!loading && !error && items.length > 0 ? (
-        <div className="-mx-4 flex snap-x gap-3 overflow-x-auto px-4 pb-1 sm:mx-0 sm:grid sm:snap-none sm:grid-cols-2 sm:overflow-visible sm:px-0 lg:grid-cols-3">
-          {items.map((city) => {
-            const totalVerification = city.verificationBreakdown.owner + city.verificationBreakdown.community + city.verificationBreakdown.directory + city.verificationBreakdown.unverified;
-            return (
-              <MapLink
-                key={`${city.countryCode}-${city.city}`}
-                href={`/map?country=${encodeURIComponent(city.countryCode)}&city=${encodeURIComponent(city.city)}`}
-                className="min-w-[82%] snap-start rounded-lg border border-gray-200 p-4 transition hover:bg-gray-50 sm:min-w-0"
-              >
-                <p className="font-semibold text-gray-900">{city.city}, {city.countryCode}</p>
-                <p className="text-sm text-gray-600">{city.totalPlaces} places</p>
-                <p className="mt-1 text-sm text-gray-700">Top: {city.topCategory}</p>
-                <p className="mt-1 text-sm text-gray-700">{renderAssetList(city.topAssets, 3)}</p>
-                <div className="mt-3 space-y-1">
-                  <div className="h-1.5 rounded bg-gray-100">
-                    <div className="h-1.5 rounded bg-emerald-500" style={{ width: barWidth(city.verificationBreakdown.owner, totalVerification) }} />
+        <div className="overflow-hidden">
+          <div className="-mx-4 flex snap-x snap-mandatory gap-3 overflow-x-auto px-4 pb-1 sm:mx-0 sm:grid sm:snap-none sm:grid-cols-2 sm:overflow-visible sm:px-0 lg:grid-cols-3">
+            {items.map((city) => {
+              const totalVerification = city.verificationBreakdown.owner + city.verificationBreakdown.community + city.verificationBreakdown.directory + city.verificationBreakdown.unverified;
+              return (
+                <MapLink
+                  key={`${city.countryCode}-${city.city}`}
+                  href={`/map?country=${encodeURIComponent(city.countryCode)}&city=${encodeURIComponent(city.city)}`}
+                  className="min-w-[83.333%] snap-start rounded-lg border border-gray-200 p-4 transition hover:bg-gray-50 sm:min-w-0"
+                >
+                  <p className="truncate font-semibold text-gray-900">{city.city}, {city.countryCode}</p>
+                  <p className="text-sm text-gray-600">{city.totalPlaces} places</p>
+                  <p className="mt-1 truncate text-sm text-gray-700">Top: {city.topCategory}</p>
+                  <p className="mt-1 line-clamp-1 text-sm text-gray-700">{renderAssetList(city.topAssets, 3)}</p>
+                  <div className="mt-3 space-y-1">
+                    <div className="h-1.5 rounded bg-gray-100">
+                      <div className="h-1.5 rounded bg-emerald-500" style={{ width: barWidth(city.verificationBreakdown.owner, totalVerification) }} />
+                    </div>
+                    <p className="text-xs text-gray-500">Owner {city.verificationBreakdown.owner} · Community {city.verificationBreakdown.community} · Directory {city.verificationBreakdown.directory} · Unverified {city.verificationBreakdown.unverified}</p>
                   </div>
-                  <p className="text-xs text-gray-500">Owner {city.verificationBreakdown.owner} · Community {city.verificationBreakdown.community} · Directory {city.verificationBreakdown.directory} · Unverified {city.verificationBreakdown.unverified}</p>
-                </div>
-              </MapLink>
-            );
-          })}
+                </MapLink>
+              );
+            })}
+          </div>
         </div>
       ) : null}
-      {limited ? <LimitedDataNote reason={limitedReason} /> : null}
+      {!loading && !error && limited ? <LimitedDataNote reason={limitedReason} /> : null}
     </SectionShell>
   );
 }

--- a/components/discover/sections/StoriesSection.tsx
+++ b/components/discover/sections/StoriesSection.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import type { DiscoverMonthlyStory, DiscoverStoryCard } from '@/lib/discover/types';
-import { LimitedDataNote, SectionEmpty, SectionError, SectionShell, SimpleSkeletonRows, TabButton, fetchDiscover, useBreakpoint } from './shared';
+import { LimitedDataNote, SectionEmpty, SectionError, SectionShell, SimpleSkeletonRows, TabButton, fetchDiscover, formatTimeLabel, formatTimeTitle, useBreakpoint } from './shared';
 
 type StoryTab = 'auto' | 'monthly';
 
@@ -34,12 +34,19 @@ export default function StoriesSection() {
   const [autoItems, setAutoItems] = useState<DiscoverStoryCard[]>([]);
   const [autoLimited, setAutoLimited] = useState(false);
   const [autoLimitedReason, setAutoLimitedReason] = useState<string | undefined>();
+  const [autoRetrying, setAutoRetrying] = useState(false);
 
   const [monthlyLoading, setMonthlyLoading] = useState(true);
   const [monthlyError, setMonthlyError] = useState<string | null>(null);
   const [monthlyItems, setMonthlyItems] = useState<DiscoverMonthlyStory[]>([]);
   const [monthlyLimited, setMonthlyLimited] = useState(false);
   const [monthlyLimitedReason, setMonthlyLimitedReason] = useState<string | undefined>();
+  const [monthlyRetrying, setMonthlyRetrying] = useState(false);
+
+  const autoAbortRef = useRef<AbortController | null>(null);
+  const monthlyAbortRef = useRef<AbortController | null>(null);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const modalRef = useRef<HTMLDivElement | null>(null);
 
   const breakpoint = useBreakpoint();
   const autoLimit = breakpoint === 'mobile' ? 3 : breakpoint === 'tablet' ? 4 : 6;
@@ -54,59 +61,138 @@ export default function StoriesSection() {
     return () => window.removeEventListener('keydown', onEsc);
   }, []);
 
-  const loadAuto = useCallback(async () => {
+  useEffect(() => {
+    if (!modal) return;
+    const focusable = modalRef.current?.querySelectorAll<HTMLElement>('button, a[href], [tabindex]:not([tabindex="-1"])');
+    const first = focusable?.[0];
+    const last = focusable?.[focusable.length - 1];
+    first?.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || !first || !last) return;
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      }
+      if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [modal]);
+
+  const loadAuto = useCallback(async (force = false) => {
+    autoAbortRef.current?.abort();
+    const controller = new AbortController();
+    autoAbortRef.current = controller;
     setAutoLoading(true);
     setAutoError(null);
     try {
-      const payload = await fetchDiscover<DiscoverStoryCard[]>('/api/discover/stories/auto');
+      const payload = await fetchDiscover<DiscoverStoryCard[]>('/api/discover/stories/auto', {
+        cacheKey: 'stories:auto',
+        signal: controller.signal,
+        force,
+      });
+      if (controller.signal.aborted) return;
       setAutoItems(payload.data);
       setAutoLimited(payload.limited);
       setAutoLimitedReason(payload.reason);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setAutoError(err instanceof Error ? err.message : 'Unable to load stories');
     } finally {
-      setAutoLoading(false);
+      if (!controller.signal.aborted) {
+        setAutoLoading(false);
+        setAutoRetrying(false);
+      }
     }
   }, []);
 
-  const loadMonthly = useCallback(async () => {
+  const loadMonthly = useCallback(async (force = false) => {
+    monthlyAbortRef.current?.abort();
+    const controller = new AbortController();
+    monthlyAbortRef.current = controller;
     setMonthlyLoading(true);
     setMonthlyError(null);
     try {
-      const payload = await fetchDiscover<{ hasContent: boolean; items: DiscoverMonthlyStory[] }>('/api/discover/stories/monthly');
+      const payload = await fetchDiscover<{ hasContent: boolean; items: DiscoverMonthlyStory[] }>('/api/discover/stories/monthly', {
+        cacheKey: 'stories:monthly',
+        signal: controller.signal,
+        force,
+      });
+      if (controller.signal.aborted) return;
       setMonthlyItems(payload.data.items);
       setMonthlyLimited(payload.limited);
       setMonthlyLimitedReason(payload.reason);
     } catch (err) {
+      if (controller.signal.aborted) return;
       setMonthlyError(err instanceof Error ? err.message : 'Unable to load monthly reports');
     } finally {
-      setMonthlyLoading(false);
+      if (!controller.signal.aborted) {
+        setMonthlyLoading(false);
+        setMonthlyRetrying(false);
+      }
     }
   }, []);
 
   useEffect(() => {
     loadAuto();
     loadMonthly();
+    return () => {
+      autoAbortRef.current?.abort();
+      monthlyAbortRef.current?.abort();
+    };
   }, [loadAuto, loadMonthly]);
+
+  useEffect(() => () => {
+    if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+  }, []);
 
   const visibleAutoItems = useMemo(() => autoItems.slice(0, autoLimit), [autoItems, autoLimit]);
   const visibleMonthlyItems = useMemo(() => monthlyItems.slice(0, monthlyLimit), [monthlyItems, monthlyLimit]);
 
+  const onTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+    event.preventDefault();
+    const order: StoryTab[] = ['auto', 'monthly'];
+    const current = order.indexOf(activeTab);
+    if (event.key === 'Home') return setActiveTab(order[0]);
+    if (event.key === 'End') return setActiveTab(order[order.length - 1]);
+    const delta = event.key === 'ArrowRight' ? 1 : -1;
+    const next = (current + delta + order.length) % order.length;
+    setActiveTab(order[next]);
+  };
+
+  const retryAuto = () => {
+    if (autoRetrying) return;
+    setAutoRetrying(true);
+    retryTimeoutRef.current = setTimeout(() => loadAuto(true), 300);
+  };
+
+  const retryMonthly = () => {
+    if (monthlyRetrying) return;
+    setMonthlyRetrying(true);
+    retryTimeoutRef.current = setTimeout(() => loadMonthly(true), 300);
+  };
+
   return (
     <>
       <SectionShell title="Stories" description="Snapshot narratives and monthly highlights from the map ecosystem.">
-        <div className="mb-4 flex gap-2">
-          <TabButton active={activeTab === 'auto'} onClick={() => setActiveTab('auto')}>Auto Stories</TabButton>
-          <TabButton active={activeTab === 'monthly'} onClick={() => setActiveTab('monthly')}>Monthly Report</TabButton>
+        <div className="mb-4 flex gap-2 overflow-x-auto" role="tablist" aria-label="Stories tabs" onKeyDown={onTabKeyDown}>
+          <TabButton active={activeTab === 'auto'} onClick={() => setActiveTab('auto')} id="stories-tab-auto" controls="stories-panel-auto">Auto Stories</TabButton>
+          <TabButton active={activeTab === 'monthly'} onClick={() => setActiveTab('monthly')} id="stories-tab-monthly" controls="stories-panel-monthly">Monthly Report</TabButton>
         </div>
 
         {activeTab === 'auto' ? (
-          <>
-            {autoLoading ? <SimpleSkeletonRows rows={3} /> : null}
-            {autoError ? <SectionError summary="Stories are currently unavailable." details={autoError} onRetry={loadAuto} /> : null}
+          <div id="stories-panel-auto" role="tabpanel" aria-labelledby="stories-tab-auto">
+            {autoLoading ? <SimpleSkeletonRows rows={3} rowClassName="h-[128px]" /> : null}
+            {autoError ? <SectionError summary="Stories are currently unavailable." details={autoError} onRetry={retryAuto} retrying={autoRetrying} /> : null}
             {!autoLoading && !autoError && visibleAutoItems.length === 0 ? <SectionEmpty message="Stories will appear as data grows." /> : null}
             {!autoLoading && !autoError && visibleAutoItems.length > 0 ? (
-              <div className="grid gap-3 md:grid-cols-1 lg:grid-cols-2">
+              <div className="grid gap-3 lg:grid-cols-2">
                 {visibleAutoItems.map((item) => (
                   <button
                     key={item.id}
@@ -120,48 +206,50 @@ export default function StoriesSection() {
                       mapHref: item.cta.kind === 'map' ? item.cta.href : '/map',
                     })}
                     className="rounded-lg border border-gray-200 p-4 text-left transition hover:bg-gray-50"
+                    aria-label={`Open story details: ${item.title}`}
                   >
-                    <p className="font-semibold text-gray-900">{item.title}</p>
-                    <p className="mt-1 text-sm text-gray-600">{item.summary}</p>
+                    <p className="line-clamp-2 font-semibold text-gray-900">{item.title}</p>
+                    <p className="mt-1 line-clamp-2 text-sm text-gray-600">{item.summary}</p>
                     <div className="mt-2 flex flex-wrap gap-1">
                       {item.badges.slice(0, 2).map((badge) => (
-                        <span key={badge} className="rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">{badge}</span>
+                        <span key={badge} className="max-w-full truncate rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-700">{badge}</span>
                       ))}
                     </div>
-                    <p className="mt-2 text-xs text-gray-500">{item.dateISO}</p>
+                    <p className="mt-2 text-xs text-gray-500" title={formatTimeTitle(item.dateISO)}>{formatTimeLabel(item.dateISO)}</p>
                   </button>
                 ))}
               </div>
             ) : null}
-            {autoLimited ? <LimitedDataNote reason={autoLimitedReason} /> : null}
-          </>
+            {!autoLoading && !autoError && autoLimited ? <LimitedDataNote reason={autoLimitedReason} /> : null}
+          </div>
         ) : (
-          <>
-            {monthlyLoading ? <SimpleSkeletonRows rows={2} /> : null}
-            {monthlyError ? <SectionError summary="Monthly reports are currently unavailable." details={monthlyError} onRetry={loadMonthly} /> : null}
+          <div id="stories-panel-monthly" role="tabpanel" aria-labelledby="stories-tab-monthly">
+            {monthlyLoading ? <SimpleSkeletonRows rows={2} rowClassName="h-[128px]" /> : null}
+            {monthlyError ? <SectionError summary="Monthly reports are currently unavailable." details={monthlyError} onRetry={retryMonthly} retrying={monthlyRetrying} /> : null}
             {!monthlyLoading && !monthlyError && visibleMonthlyItems.length === 0 ? <SectionEmpty message="Monthly reports will be published here." /> : null}
             {!monthlyLoading && !monthlyError && visibleMonthlyItems.length > 0 ? (
-              <div className="grid gap-3 md:grid-cols-1 lg:grid-cols-2">
+              <div className="grid gap-3 lg:grid-cols-2">
                 {visibleMonthlyItems.map((item) => (
                   <button
                     key={item.id}
                     type="button"
                     onClick={() => setModal({ kind: 'monthly', title: item.title, month: item.month, highlights: item.highlights })}
                     className="rounded-lg border border-gray-200 p-4 text-left transition hover:bg-gray-50"
+                    aria-label={`Open monthly story details: ${item.title}`}
                   >
-                    <p className="font-semibold text-gray-900">{item.title}</p>
+                    <p className="line-clamp-2 font-semibold text-gray-900">{item.title}</p>
                     <ul className="mt-2 list-disc space-y-1 pl-4 text-sm text-gray-600">
                       {item.highlights.slice(0, 3).map((highlight) => (
-                        <li key={highlight}>{highlight}</li>
+                        <li key={highlight} className="line-clamp-1">{highlight}</li>
                       ))}
                     </ul>
-                    <p className="mt-2 text-xs text-gray-500">{item.dateISO}</p>
+                    <p className="mt-2 text-xs text-gray-500" title={formatTimeTitle(item.dateISO)}>{formatTimeLabel(item.dateISO)}</p>
                   </button>
                 ))}
               </div>
             ) : null}
-            {monthlyLimited ? <LimitedDataNote reason={monthlyLimitedReason} /> : null}
-          </>
+            {!monthlyLoading && !monthlyError && monthlyLimited ? <LimitedDataNote reason={monthlyLimitedReason} /> : null}
+          </div>
         )}
       </SectionShell>
 
@@ -173,10 +261,10 @@ export default function StoriesSection() {
           aria-label={modal.title}
           onClick={() => setModal(null)}
         >
-          <div className="w-full max-w-lg rounded-xl bg-white p-5" onClick={(event) => event.stopPropagation()}>
+          <div ref={modalRef} className="w-full max-w-lg rounded-xl bg-white p-5" onClick={(event) => event.stopPropagation()}>
             <div className="flex items-start justify-between gap-3">
               <h3 className="text-lg font-semibold text-gray-900">{modal.title}</h3>
-              <button type="button" onClick={() => setModal(null)} className="rounded-full border border-gray-300 px-2 py-0.5 text-sm">×</button>
+              <button type="button" onClick={() => setModal(null)} aria-label="Close story modal" className="rounded-full border border-gray-300 px-2 py-0.5 text-sm">×</button>
             </div>
 
             {modal.kind === 'auto' ? (

--- a/components/discover/sections/TrendingCountriesSection.tsx
+++ b/components/discover/sections/TrendingCountriesSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { DiscoverTrendingCountry } from '@/lib/discover/types';
 import { LimitedDataNote, MapLink, SectionEmpty, SectionError, SectionShell, SimpleSkeletonRows, fetchDiscover } from './shared';
 
@@ -10,12 +10,17 @@ export default function TrendingCountriesSection() {
   const [items, setItems] = useState<DiscoverTrendingCountry[]>([]);
   const [limited, setLimited] = useState(false);
   const [limitedReason, setLimitedReason] = useState<string | undefined>();
+  const [retrying, setRetrying] = useState(false);
+  const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const load = useCallback(async () => {
+  const load = useCallback(async (force = false) => {
     setLoading(true);
     setError(null);
     try {
-      const payload = await fetchDiscover<DiscoverTrendingCountry[]>('/api/discover/trending-countries?window=30d');
+      const payload = await fetchDiscover<DiscoverTrendingCountry[]>('/api/discover/trending-countries?window=30d', {
+        cacheKey: 'trending:30d',
+        force,
+      });
       setItems(payload.data.slice(0, 5));
       setLimited(payload.limited);
       setLimitedReason(payload.reason);
@@ -23,6 +28,7 @@ export default function TrendingCountriesSection() {
       setError(err instanceof Error ? err.message : 'Unable to load trends');
     } finally {
       setLoading(false);
+      setRetrying(false);
     }
   }, []);
 
@@ -30,36 +36,45 @@ export default function TrendingCountriesSection() {
     load();
   }, [load]);
 
-  const shouldShowEmpty = !loading && !error && (items.length === 0 || limited);
+  useEffect(() => () => {
+    if (retryTimeoutRef.current) clearTimeout(retryTimeoutRef.current);
+  }, []);
+
+  const handleRetry = () => {
+    if (retrying) return;
+    setRetrying(true);
+    retryTimeoutRef.current = setTimeout(() => load(true), 300);
+  };
 
   return (
     <SectionShell title="Trending Countries" description="Top 5 by 30-day listing growth.">
-      {loading ? <SimpleSkeletonRows rows={5} /> : null}
+      {loading ? <SimpleSkeletonRows rows={5} rowClassName="h-11" /> : null}
       {error ? (
         <SectionError
           summary="Trend data is temporarily unavailable."
           details={error}
-          onRetry={load}
+          onRetry={handleRetry}
+          retrying={retrying}
         />
       ) : null}
-      {shouldShowEmpty ? <SectionEmpty message="No trend data yet." /> : null}
+      {!loading && !error && items.length === 0 ? <SectionEmpty message="No trend data yet." /> : null}
 
-      {!loading && !error && !shouldShowEmpty ? (
+      {!loading && !error && items.length > 0 ? (
         <ol className="space-y-2">
           {items.map((item, index) => (
             <li key={item.countryCode}>
               <MapLink
                 href={`/map?country=${encodeURIComponent(item.countryCode)}`}
-                className="flex items-center justify-between rounded-lg border border-gray-200 px-3 py-2 text-sm transition hover:bg-gray-50"
+                className="flex items-center justify-between gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm transition hover:bg-gray-50"
               >
-                <span className="font-medium text-gray-800">{index + 1}. {item.countryName ?? item.countryCode}</span>
-                <span className="font-semibold text-emerald-600">+{item.delta30d}</span>
+                <span className="min-w-0 flex-1 truncate font-medium text-gray-800">{index + 1}. {item.countryName ?? item.countryCode}</span>
+                <span className="shrink-0 font-semibold text-emerald-600">+{item.delta30d}</span>
               </MapLink>
             </li>
           ))}
         </ol>
       ) : null}
-      {limited ? <LimitedDataNote reason={limitedReason} /> : null}
+      {!loading && !error && limited ? <LimitedDataNote reason={limitedReason} /> : null}
     </SectionShell>
   );
 }

--- a/components/discover/sections/VerificationHubSection.tsx
+++ b/components/discover/sections/VerificationHubSection.tsx
@@ -42,7 +42,7 @@ export default function VerificationHubSection() {
             <p className="mt-1 text-sm text-gray-600">{item.summary}</p>
             <button
               type="button"
-              className="mt-2 text-xs font-semibold text-gray-700 underline"
+              className="mt-2 min-h-[36px] text-xs font-semibold text-gray-700 underline"
               onClick={() => setExpandedDesktop((prev) => (prev === item.key ? null : item.key))}
             >
               {expandedDesktop === item.key ? 'Less' : 'More'}
@@ -55,7 +55,7 @@ export default function VerificationHubSection() {
       <div className="space-y-2 sm:hidden">
         {verificationItems.map((item) => (
           <details key={item.key} className="rounded-lg border border-gray-200 bg-white p-3">
-            <summary className="cursor-pointer list-none font-semibold text-gray-900">{item.title}</summary>
+            <summary className="cursor-pointer list-none py-1 text-base font-semibold text-gray-900">{item.title}</summary>
             <p className="mt-2 text-sm text-gray-600">{item.summary}</p>
             <p className="mt-2 text-xs text-gray-600">{item.details}</p>
           </details>


### PR DESCRIPTION
### Motivation
- Stabilize mobile layouts (380/480/767) and remove horizontal scroll while keeping existing styling and section order.  
- Surface additive limited-state messaging per section without replacing empty/error states.  
- Harden per-section fetching with retry UX, abort/ignore stale responses, and short-lived client caching to reduce unnecessary network churn.

### Description
- Added shared discover primitives in `components/discover/sections/shared.tsx`: a short-lived in-memory cache (60s), enhanced `fetchDiscover` with cacheKey/ttl/signal/force, consistent skeleton sizing, `LimitedDataNote` with optional details disclosure, and time helpers (`formatTimeLabel`/`formatTimeTitle`).
- Activity Feed: per-tab cache key (`activity:<tab>:<limit>`), abort controller for stale requests, ARIA tab semantics and keyboard navigation, truncation/line-clamp fixes, retry button disabled state + 300ms debounce, and additive limited note rendering. (see `ActivityFeedSection.tsx`).
- Stories: abort controllers for auto/monthly, tab-specific cache keys (`stories:auto`, `stories:monthly`), retry debounce and disabled state per tab, modal accessibility (focus trap, ESC, close aria-label), keyboard tab switching, and truncation/clamping on mobile cards. (see `StoriesSection.tsx`).
- Featured Cities: contained carousel to avoid page-level horizontal scroll, snap-mandatory sizing (~1.2 cards visible), encoded map params, consistent skeleton height, and retry debouncing. (see `FeaturedCitiesSection.tsx`).
- Asset Explorer: separate list vs panel fetch lifecycles, panel abort handling, cache keys (`assets:list`, `assets:panel:<asset>`), pill truncation and max-width control, separate retry flows for list and panel, and additive limited note. (see `AssetExplorerSection.tsx`).
- Trending & Verification Hub: section-level caching for trending, row truncation to avoid overflow, larger tap targets for verification accordion on mobile, and preserved section content/order. (see `TrendingCountriesSection.tsx`, `VerificationHubSection.tsx`).

### Testing
- Ran lint with `npm run lint` and verified no new lint errors introduced; warnings unchanged from baseline (passed).  
- Built production artifacts with `npm run build` and observed a successful build (pages compiled and static generation completed).  
- Executed `npm run test:stats`; most unit checks passed but the suite failed in CI environment due to an unrelated module resolution issue in generated `.tmp-tests` (alias import in test harness) not caused by discover changes.  
- Launched the dev server and captured screenshots at multiple viewports using Playwright (screenshots produced): `artifacts/discover-380.png`, `artifacts/discover-480.png`, `artifacts/discover-768.png`, `artifacts/discover-1280.png` to validate no horizontal page scroll and layout stability on 380/480.  
- Automated retry/button state, aborts, and cache behavior validated locally by exercising tabs and rapid retry clicks to confirm disabled retry state and no duplicate network storms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f1065d0148328b49f90e29774f8bd)