### PR TITLE
Fix Discover mobile overflow and tab labels per v0.1 audit

### DIFF
--- a/components/discover/sections/ActivityFeedSection.tsx
+++ b/components/discover/sections/ActivityFeedSection.tsx
@@ -18,7 +18,7 @@ import {
 } from './shared';
 
 const activityTabs: Array<{ key: DiscoverActivityTab; label: string }> = [
-  { key: 'added', label: 'Just Added' },
+  { key: 'added', label: 'Added' },
   { key: 'owner', label: 'Owner' },
   { key: 'community', label: 'Community' },
   { key: 'promoted', label: 'Promoted' },

--- a/components/discover/sections/FeaturedCitiesSection.tsx
+++ b/components/discover/sections/FeaturedCitiesSection.tsx
@@ -56,7 +56,7 @@ export default function FeaturedCitiesSection() {
 
       {!loading && !error && items.length > 0 ? (
         <div className="overflow-hidden">
-          <div className="-mx-4 flex snap-x snap-mandatory gap-3 overflow-x-auto px-4 pb-1 sm:mx-0 sm:grid sm:snap-none sm:grid-cols-2 sm:overflow-visible sm:px-0 lg:grid-cols-3">
+          <div className="mx-0 flex snap-x snap-mandatory gap-3 overflow-x-auto px-4 pb-1 sm:grid sm:snap-none sm:grid-cols-2 sm:overflow-visible sm:px-0 lg:grid-cols-3">
             {items.map((city) => {
               const totalVerification = city.verificationBreakdown.owner + city.verificationBreakdown.community + city.verificationBreakdown.directory + city.verificationBreakdown.unverified;
               return (

--- a/components/discover/sections/StoriesSection.tsx
+++ b/components/discover/sections/StoriesSection.tsx
@@ -182,8 +182,8 @@ export default function StoriesSection() {
     <>
       <SectionShell title="Stories" description="Snapshot narratives and monthly highlights from the map ecosystem.">
         <div className="mb-4 flex gap-2 overflow-x-auto" role="tablist" aria-label="Stories tabs" onKeyDown={onTabKeyDown}>
-          <TabButton active={activeTab === 'auto'} onClick={() => setActiveTab('auto')} id="stories-tab-auto" controls="stories-panel-auto">Auto Stories</TabButton>
-          <TabButton active={activeTab === 'monthly'} onClick={() => setActiveTab('monthly')} id="stories-tab-monthly" controls="stories-panel-monthly">Monthly Report</TabButton>
+          <TabButton active={activeTab === 'auto'} onClick={() => setActiveTab('auto')} id="stories-tab-auto" controls="stories-panel-auto">Auto</TabButton>
+          <TabButton active={activeTab === 'monthly'} onClick={() => setActiveTab('monthly')} id="stories-tab-monthly" controls="stories-panel-monthly">Monthly</TabButton>
         </div>
 
         {activeTab === 'auto' ? (

--- a/components/discover/sections/shared.tsx
+++ b/components/discover/sections/shared.tsx
@@ -17,7 +17,7 @@ export type SectionState<T> = {
 
 export function SectionShell({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
   return (
-    <section className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
+    <section className="min-w-0 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm sm:p-6">
       <div className="mb-4 space-y-1">
         <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
         {description ? <p className="text-sm text-gray-600">{description}</p> : null}


### PR DESCRIPTION
### Motivation
- Resolve the mobile horizontal overflow observed at `innerWidth=380` on `/discover` while keeping the existing section order and behavior intact. 
- Correct tab label copy to match the v0.1 spec exactly without changing API parameters or section logic. 
- Keep changes minimal and localized to the UI presentation layer (no new features or sponsor/ads content). 

### Description
- Neutralized the negative horizontal margin on the Featured Cities carousel by changing `-mx-4` → `mx-0` in `components/discover/sections/FeaturedCitiesSection.tsx` to prevent the carousel from causing page-wide overflow at very small widths. 
- Added `min-w-0` to the shared section wrapper in `components/discover/sections/shared.tsx` so section children cannot force their grid container wider than the viewport on mobile. 
- Updated Activity tab label from `Just Added` to the exact spec `Added` in `components/discover/sections/ActivityFeedSection.tsx`. 
- Updated Stories tab labels from `Auto Stories` / `Monthly Report` to the exact spec `Auto` / `Monthly` in `components/discover/sections/StoriesSection.tsx`, with no change to API calls or tab keys. 

### Testing
- Verified with a runtime Playwright probe that at `innerWidth=380` the page no longer overflows: `docScrollWidth === 380` and at `innerWidth=480` `docScrollWidth === 480`, with screenshots saved as artifacts for `discover-380.png` and `discover-480.png`. 
- Confirmed UI tab labels via automated runtime probe are `Activity: ["Added", "Owner", "Community", "Promoted"]` and `Stories: ["Auto", "Monthly"]`. 
- Ran `npm run lint` which completed successfully with only unrelated lint warnings and no new errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fa9277a8083289685dd5f4b94d509)