### PR TITLE
docs: add Discover v0.1 final audit report (post-PR294)

### DIFF
--- a/docs/discover-v0.1-final-audit.md
+++ b/docs/discover-v0.1-final-audit.md
@@ -1,0 +1,94 @@
+# Discover v0.1 Final Audit (Post-PR294)
+
+Date: 2026-02-26
+Scope: `/discover` route (`app/(site)/discover/page.tsx`) and section components/APIs.
+Mode: **Report-only audit** (no refactor).
+
+## Executive Verdict
+
+**READY TO ANNOUNCE? — No (Not Ready for definitive announcement).**
+
+Reason: implementation appears aligned with spec in code for structure, labels, and interaction wiring, but this environment cannot fully produce runtime UI evidence at required breakpoints (browser automation crash + Playwright browser download blocked), and data-backed interactions are not fully exercisable because most discover APIs currently return `ok:false` (`db unavailable`) in this environment.
+
+---
+
+## Pass/Fail Checklist
+
+### 1) No horizontal scroll at 380px and 480px (`docScrollWidth === innerWidth`)
+- **Status:** ⚠️ **Blocked / not conclusively verified**
+- Notes:
+  - Could not run a functioning browser capture/DOM-measure session in this container (Playwright Chromium in browser tool crashes with SIGSEGV; local Playwright browser install blocked with 403).
+  - Code review suggests mobile overflow risks were addressed in several sections (`min-w-0`, truncation, wrapped pills, constrained card widths), but this is not equivalent to measured `docScrollWidth` proof.
+
+### 2) Section order
+- **Status:** ✅ **Pass (code-confirmed)**
+- Required order: Hero -> Activity -> Trending -> Stories -> Cities -> Asset Explorer -> Verification Hub
+- Observed in `DiscoverPage` render tree in exactly that sequence.
+
+### 3) Label spec
+- **Activity tabs:** ✅ Added / Owner / Community / Promoted
+- **Stories tabs:** ✅ Auto / Monthly
+
+### 4) Behavior
+- Activity tab fetch by selected tab: ✅ code path uses `/api/discover/activity?tab=${activeTab}&limit=${limit}`.
+- Activity card navigation: ✅ cards link to `/map?place=<placeId>`.
+- Trending row navigation: ✅ rows link to `/map?country=<countryCode>`.
+- Stories modal behavior:
+  - Open on story card click: ✅
+  - Close on ESC: ✅ window keydown handler
+  - Close on X: ✅ close button
+  - Close on backdrop: ✅ outer dialog click handler
+  - CTA navigation: ✅ auto modal CTA to map link; monthly modal CTA to `/stats`
+- Cities card links: ✅ `/map?country=<countryCode>&city=<city>`
+- Asset explorer:
+  - Pills switch selected asset: ✅ state updates and panel reload per selected asset
+  - Panel loads by asset: ✅ `/api/discover/assets/${asset}` fetch
+  - Links include params:
+    - Countries: ✅ `country` + `asset`
+    - Categories: ✅ `category` + `asset`
+    - Recent item: ⚠️ place-only link (`/map?place=...`) does not include explicit `asset` param (may still be acceptable depending on strictness of requirement wording)
+
+### 5) Resilience (loading / empty / error + retry per dynamic section)
+- **Status:** ✅ **Pass (code-confirmed)**
+- Activity, Trending, Stories(auto/monthly), Cities, Asset list/panel each implement loading skeletons, empty states, error component, and retry action.
+- Limited note handling exists (`Limited data available right now.`) and is conditionally rendered from envelope `limited` flags. This is subtle and not misleading.
+
+### 6) No sponsor/ads wording anywhere on `/discover`
+- **Status:** ✅ **Pass**
+- No sponsor/ads/advert wording found in discover page/section code search.
+
+---
+
+## Runtime Evidence Collected
+
+### API behavior in this environment
+Most dynamic discover APIs currently return `ok:false` with `reason:"db unavailable"` (except monthly stories endpoint), which prevents end-to-end data-driven card interaction validation here.
+
+Sample responses observed:
+- `/api/discover/activity?tab=added&limit=6` -> `{ ok:false, limited:true, reason:"db unavailable", data:[] }`
+- `/api/discover/trending-countries?window=30d` -> `{ ok:false, limited:true, reason:"db unavailable", data:[] }`
+- `/api/discover/stories/auto` -> `{ ok:false, limited:true, reason:"db unavailable", data:[] }`
+- `/api/discover/stories/monthly` -> `{ ok:true, ... }`
+- `/api/discover/featured-cities` -> `{ ok:false, limited:true, reason:"db unavailable", data:[] }`
+- `/api/discover/assets` -> `{ ok:false, limited:true, reason:"db unavailable", data:[] }`
+
+### Screenshot / artifact status (380/480/768/1024+)
+- **Status:** ⚠️ **Unavailable in this run**
+- Attempted methods:
+  1. MCP browser Playwright script with forwarded port 3000 -> Chromium launch SIGSEGV.
+  2. Local Playwright screenshot command -> required browser binary missing.
+  3. `npx playwright install chromium` -> blocked by 403 from CDN.
+
+Because of the above, required breakpoint screenshots could not be produced in this specific environment.
+
+---
+
+## Final Recommendation
+
+**Not Ready (for announcement sign-off from this audit run alone).**
+
+To flip this to **Ready** with confidence, run the same audit in an environment where:
+1. Browser automation can run and capture viewport evidence at 380/480/768/1024+.
+2. Discover APIs are backed by available DB data (or deterministic fixture mode) so interactive navigation checks can be witnessed live.
+
+If those two conditions pass, implementation-level checks in this audit strongly suggest the page is close to launch-ready.


### PR DESCRIPTION
### Motivation
- Re-run a focused post-PR294 audit of the `/discover` v0.1 surface to confirm spec alignment and produce a definitive ready/not-ready verdict for announcement.
- Capture a concise pass/fail checklist covering layout at narrow viewports, section order, label correctness, interaction behavior, resilience states, and any sponsor/ads wording.

### Description
- Added `docs/discover-v0.1-final-audit.md` containing the full audit, pass/fail checklist, runtime evidence notes, and a final verdict (`READY TO ANNOUNCE? — No`) with remediation guidance. 
- The report documents code-level verification for section order, labels, link patterns, modal behaviors, and per-section loading/empty/error/retry handling.
- The audit notes a minor behavior observation that recent items in the asset panel link to `/map?place=...` without an explicit `asset` query parameter.
- The document records environment blockers encountered when attempting automated viewport screenshots and end-to-end interaction captures.

### Testing
- Started the local dev server with `npm run dev` and exercised discover endpoints with `curl` to validate API envelopes, which returned `ok:false` with `reason: "db unavailable"` for most endpoints and `ok:true` for the monthly stories endpoint. (API queries succeeded and responses were recorded.)
- Attempted browser automation via Playwright script, which failed due to a Chromium crash (`SIGSEGV`) in the environment and could not produce viewport screenshots or DOM measurements. (Failure documented in the report.)
- Attempted `npx playwright screenshot` and `npx playwright install chromium`, both of which failed because the browser binary was absent and the Playwright browser download was blocked by a `403` from the CDN, preventing automated artifact generation. (Failures recorded.)
- All executed commands and their outcomes are summarized in the audit document for reproducibility and next-step guidance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fc19bc7788328861b166743784c03)