### PR TITLE
Add opt-in Discover fixture audit mode and asset-link consistency

### DIFF
--- a/components/discover/DiscoverPage.tsx
+++ b/components/discover/DiscoverPage.tsx
@@ -9,12 +9,17 @@ import TrendingCountriesSection from './sections/TrendingCountriesSection';
 import VerificationHubSection from './sections/VerificationHubSection';
 
 export default function DiscoverPage() {
+  const isFixtureMode = process.env.NEXT_PUBLIC_DISCOVER_FIXTURE === '1';
+
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8 sm:px-6 sm:py-10">
       <section className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
         <p className="text-xs font-semibold uppercase tracking-wide text-sky-600">Discover</p>
         <h1 className="mt-2 text-3xl font-semibold text-gray-900 sm:text-4xl">See what&apos;s happening in crypto acceptance worldwide.</h1>
         <p className="mt-2 max-w-2xl text-sm text-gray-600 sm:text-base">Track recent additions, trends, stories, and verification context in one place.</p>
+        {isFixtureMode ? (
+          <p className="mt-3 inline-flex rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">Fixture data</p>
+        ) : null}
         <div className="mt-5 flex flex-wrap gap-3">
           <Link href="/map" className="rounded-full bg-gray-900 px-4 py-2 text-sm font-semibold text-white">Open Map</Link>
           <Link href="/stats" className="rounded-full border border-gray-200 px-4 py-2 text-sm font-semibold text-gray-700">View Stats</Link>

--- a/components/discover/sections/AssetExplorerSection.tsx
+++ b/components/discover/sections/AssetExplorerSection.tsx
@@ -180,7 +180,7 @@ export default function AssetExplorerSection() {
             <ul className="mt-2 space-y-2 text-sm">
               {panel.recent5.slice(0, 5).map((item) => (
                 <li key={item.placeId}>
-                  <MapLink href={`/map?place=${encodeURIComponent(item.placeId)}`} className="block rounded px-1 py-1 hover:bg-gray-50">
+                  <MapLink href={`/map?place=${encodeURIComponent(item.placeId)}${activeAsset ? `&asset=${encodeURIComponent(activeAsset)}` : ''}`} className="block rounded px-1 py-1 hover:bg-gray-50">
                     <p className="truncate font-medium text-gray-900">{item.name}</p>
                     <p className="truncate text-xs text-gray-600">{item.city}, {item.country}</p>
                   </MapLink>

--- a/docs/discover-audit-mode.md
+++ b/docs/discover-audit-mode.md
@@ -1,0 +1,57 @@
+# Discover audit mode (fixture data)
+
+This project supports a deterministic fixture mode for `/discover` and `/api/discover/*` so audits can run without a database.
+
+## Enable fixture mode
+
+Fixture mode is **opt-in** and **off by default**.
+
+Set this environment variable before starting Next.js:
+
+```bash
+NEXT_PUBLIC_DISCOVER_FIXTURE=1
+```
+
+Examples:
+
+```bash
+NEXT_PUBLIC_DISCOVER_FIXTURE=1 npm run dev
+```
+
+```bash
+NEXT_PUBLIC_DISCOVER_FIXTURE=1 npm run build && NEXT_PUBLIC_DISCOVER_FIXTURE=1 npm start
+```
+
+When enabled:
+- API endpoints under `/api/discover/*` return deterministic fixture payloads.
+- `/discover` shows a subtle `Fixture data` badge.
+
+## Endpoints covered
+
+- `/api/discover/activity`
+- `/api/discover/trending-countries`
+- `/api/discover/stories/auto`
+- `/api/discover/stories/monthly`
+- `/api/discover/featured-cities`
+- `/api/discover/assets`
+- `/api/discover/assets/[asset]`
+
+All fixture responses keep the standard envelope:
+
+```json
+{ "ok": true, "limited": false, "data": "...", "lastUpdatedISO": "..." }
+```
+
+## Quick responsive verification (380 / 480 / 768 / 1024+)
+
+1. Run with fixture mode enabled.
+2. Open `/discover` in browser devtools responsive mode.
+3. Verify these widths:
+   - `380px`
+   - `480px`
+   - `768px`
+   - `1024px` (or larger)
+4. Check that:
+   - content renders in all Discover sections using fixture data,
+   - section order/layout is unchanged,
+   - Asset Explorer "Recent Items" links include both `place` and `asset` query params when an asset is selected.

--- a/lib/discover/server.ts
+++ b/lib/discover/server.ts
@@ -22,6 +22,8 @@ import type {
 
 const CACHE_CONTROL = "public, s-maxage=180, stale-while-revalidate=60";
 const NO_STORE = "no-store";
+const FIXTURE_LAST_UPDATED_ISO = "2026-01-15T12:00:00.000Z";
+const isDiscoverFixtureMode = process.env.NEXT_PUBLIC_DISCOVER_FIXTURE === "1";
 
 const countryNames = new Intl.DisplayNames(["en"], { type: "region" });
 
@@ -40,13 +42,113 @@ const jsonResponse = <T>(body: DiscoverEnvelope<T>, status = 200) =>
     },
   });
 
-const makeEnvelope = <T>(data: T, options?: { limited?: boolean; reason?: string; ok?: boolean }): DiscoverEnvelope<T> => ({
+const makeEnvelope = <T>(
+  data: T,
+  options?: { limited?: boolean; reason?: string; ok?: boolean; lastUpdatedISO?: string },
+): DiscoverEnvelope<T> => ({
   ok: options?.ok ?? true,
   limited: options?.limited ?? false,
   reason: options?.reason,
   data,
-  lastUpdatedISO: new Date().toISOString(),
+  lastUpdatedISO: options?.lastUpdatedISO ?? new Date().toISOString(),
 });
+
+const fixtureActivity: DiscoverActivityItem[] = [
+  { placeId: "fixture-nyc-001", name: "Satoshi Coffee", city: "New York", country: "US", verificationLevel: "owner", assets: ["BTC", "USDC"], timeLabelISO: "2026-01-15T11:40:00.000Z", eventType: "promote" },
+  { placeId: "fixture-ber-002", name: "Block Brot", city: "Berlin", country: "DE", verificationLevel: "community", assets: ["BTC", "ETH", "USDT"], timeLabelISO: "2026-01-15T09:20:00.000Z", eventType: "approve" },
+  { placeId: "fixture-tok-003", name: "Lightning Ramen", city: "Tokyo", country: "JP", verificationLevel: "directory", assets: ["BTC", "JPYT"], timeLabelISO: "2026-01-14T17:05:00.000Z", eventType: "promote" },
+  { placeId: "fixture-bkk-004", name: "Chain Chai", city: "Bangkok", country: "TH", verificationLevel: "unverified", assets: ["USDT", "USDC"], timeLabelISO: "2026-01-14T13:10:00.000Z", eventType: "approve" },
+  { placeId: "fixture-mex-005", name: "Nodo Tacos", city: "Mexico City", country: "MX", verificationLevel: "owner", assets: ["BTC", "MXNe"], timeLabelISO: "2026-01-14T10:45:00.000Z", eventType: "promote" },
+  { placeId: "fixture-lon-006", name: "Bit Bazaar", city: "London", country: "GB", verificationLevel: "community", assets: ["BTC", "ETH", "USDC"], timeLabelISO: "2026-01-13T19:35:00.000Z", eventType: "approve" },
+  { placeId: "fixture-nbo-007", name: "Crypto Kiosk", city: "Nairobi", country: "KE", verificationLevel: "directory", assets: ["BTC", "USDT"], timeLabelISO: "2026-01-13T08:30:00.000Z", eventType: "promote" },
+  { placeId: "fixture-bcn-008", name: "Tapas on Chain", city: "Barcelona", country: "ES", verificationLevel: "unverified", assets: ["BTC", "EURC"], timeLabelISO: "2026-01-12T16:00:00.000Z", eventType: "approve" },
+];
+
+const fixtureTrendingCountries: DiscoverTrendingCountry[] = [
+  { countryCode: "US", countryName: "United States", delta30d: 41 },
+  { countryCode: "DE", countryName: "Germany", delta30d: 29 },
+  { countryCode: "JP", countryName: "Japan", delta30d: 22 },
+  { countryCode: "MX", countryName: "Mexico", delta30d: 19 },
+  { countryCode: "TH", countryName: "Thailand", delta30d: 16 },
+];
+
+const fixtureFeaturedCities: DiscoverFeaturedCity[] = [
+  { countryCode: "US", city: "New York", totalPlaces: 58, topCategory: "Cafe", topAssets: ["BTC", "USDC", "ETH"], verificationBreakdown: { owner: 18, community: 15, directory: 12, unverified: 13 } },
+  { countryCode: "DE", city: "Berlin", totalPlaces: 46, topCategory: "Restaurant", topAssets: ["BTC", "USDT", "ETH"], verificationBreakdown: { owner: 13, community: 12, directory: 9, unverified: 12 } },
+  { countryCode: "JP", city: "Tokyo", totalPlaces: 44, topCategory: "Retail", topAssets: ["BTC", "JPYT", "USDC"], verificationBreakdown: { owner: 11, community: 10, directory: 12, unverified: 11 } },
+  { countryCode: "MX", city: "Mexico City", totalPlaces: 39, topCategory: "Market", topAssets: ["BTC", "USDT", "MXNe"], verificationBreakdown: { owner: 10, community: 9, directory: 8, unverified: 12 } },
+  { countryCode: "TH", city: "Bangkok", totalPlaces: 34, topCategory: "Food", topAssets: ["USDT", "BTC", "USDC"], verificationBreakdown: { owner: 8, community: 9, directory: 6, unverified: 11 } },
+  { countryCode: "GB", city: "London", totalPlaces: 31, topCategory: "Pub", topAssets: ["BTC", "ETH", "USDC"], verificationBreakdown: { owner: 9, community: 7, directory: 6, unverified: 9 } },
+];
+
+const fixtureAssets: DiscoverAssetListItem[] = [
+  { asset: "BTC", countTotal: 221, delta30d: 28 },
+  { asset: "USDT", countTotal: 176, delta30d: 23 },
+  { asset: "USDC", countTotal: 153, delta30d: 20 },
+  { asset: "ETH", countTotal: 126, delta30d: 14 },
+  { asset: "SOL", countTotal: 88, delta30d: 10 },
+  { asset: "LTC", countTotal: 64, delta30d: 8 },
+  { asset: "XMR", countTotal: 53, delta30d: 6 },
+  { asset: "TRX", countTotal: 49, delta30d: 5 },
+  { asset: "DAI", countTotal: 45, delta30d: 4 },
+  { asset: "EURC", countTotal: 31, delta30d: 3 },
+];
+
+const fixtureStoriesAuto: DiscoverStoryCard[] = [
+  {
+    id: "fixture-country-us",
+    title: "United States leads discover momentum this month",
+    summary: "Fixture telemetry shows a +41 net visibility trend over the last 30 days.",
+    badges: ["Country", "Growth"],
+    dateISO: "2026-01-15",
+    cta: { kind: "map", href: "/map?country=US" },
+    metricsPreview: [{ label: "30d delta", value: "41" }, { label: "Rank", value: "#1" }],
+  },
+  {
+    id: "fixture-city-berlin",
+    title: "Berlin stands out in fixture featured cities",
+    summary: "46 map-ready places with restaurants as the top category.",
+    badges: ["City", "Featured"],
+    dateISO: "2026-01-15",
+    cta: { kind: "map", href: "/map?country=DE&city=Berlin" },
+    metricsPreview: [{ label: "Total places", value: "46" }, { label: "Top category", value: "Restaurant" }],
+  },
+  {
+    id: "fixture-asset-btc",
+    title: "BTC remains the widest acceptance asset",
+    summary: "221 tracked accepts in the current fixture baseline.",
+    badges: ["Asset", "Coverage"],
+    dateISO: "2026-01-15",
+    cta: { kind: "map", href: "/map?asset=BTC" },
+    metricsPreview: [{ label: "Total accepts", value: "221" }, { label: "30d delta", value: "28" }],
+  },
+  {
+    id: "fixture-city-tokyo",
+    title: "Tokyo adoption is broadening beyond cafes",
+    summary: "Retail leads in a 44-place fixture cluster with balanced verification mix.",
+    badges: ["City", "Diversity"],
+    dateISO: "2026-01-14",
+    cta: { kind: "map", href: "/map?country=JP&city=Tokyo" },
+    metricsPreview: [{ label: "Total places", value: "44" }, { label: "Owner verified", value: "11" }],
+  },
+];
+
+const fixtureAssetPanels: Record<string, DiscoverAssetPanel> = {
+  BTC: {
+    asset: "BTC",
+    countriesTop5: [{ countryCode: "US", total: 52 }, { countryCode: "DE", total: 41 }, { countryCode: "JP", total: 35 }, { countryCode: "MX", total: 29 }, { countryCode: "GB", total: 24 }],
+    categoriesTop5: [{ category: "Cafe", total: 39 }, { category: "Restaurant", total: 33 }, { category: "Retail", total: 28 }, { category: "Market", total: 21 }, { category: "Hotel", total: 17 }],
+    recent5: fixtureActivity.slice(0, 5),
+  },
+  USDT: {
+    asset: "USDT",
+    countriesTop5: [{ countryCode: "TH", total: 44 }, { countryCode: "MX", total: 32 }, { countryCode: "DE", total: 29 }, { countryCode: "US", total: 27 }, { countryCode: "KE", total: 20 }],
+    categoriesTop5: [{ category: "Market", total: 26 }, { category: "Food", total: 23 }, { category: "Services", total: 20 }, { category: "Retail", total: 19 }, { category: "Cafe", total: 14 }],
+    recent5: fixtureActivity.filter((item) => item.assets.includes("USDT")).slice(0, 5),
+  },
+};
+
+const makeFixtureEnvelope = <T>(data: T): DiscoverEnvelope<T> => makeEnvelope(data, { limited: false, ok: true, lastUpdatedISO: FIXTURE_LAST_UPDATED_ISO });
 
 const normalizeVerification = (raw: string | null): DiscoverVerificationLevel => {
   const value = (raw ?? "").trim().toLowerCase();
@@ -628,6 +730,18 @@ export const discoverHandlers = {
       return jsonResponse(makeEnvelope([], { ok: false, limited: true, reason: "invalid tab" }), 400);
     }
 
+    if (isDiscoverFixtureMode) {
+      const filtered = fixtureActivity
+        .filter((item) => {
+          if (tab === "owner") return item.verificationLevel === "owner";
+          if (tab === "community") return item.verificationLevel === "community";
+          if (tab === "promoted") return item.eventType === "promote";
+          return true;
+        })
+        .slice(0, limit);
+      return jsonResponse(makeFixtureEnvelope(filtered));
+    }
+
     if (!hasDatabaseUrl()) {
       return jsonResponse(makeEnvelope([], { ok: false, limited: true, reason: "db unavailable" }), 503);
     }
@@ -646,6 +760,9 @@ export const discoverHandlers = {
     if (window !== "30d") {
       return jsonResponse(makeEnvelope([], { ok: false, limited: true, reason: "unsupported window" }), 400);
     }
+    if (isDiscoverFixtureMode) {
+      return jsonResponse(makeFixtureEnvelope(fixtureTrendingCountries));
+    }
     if (!hasDatabaseUrl()) {
       return jsonResponse(makeEnvelope([], { ok: false, limited: true, reason: "db unavailable" }), 503);
     }
@@ -660,6 +777,9 @@ export const discoverHandlers = {
 
   async featuredCities() {
     const route = "api_discover_featured_cities";
+    if (isDiscoverFixtureMode) {
+      return jsonResponse(makeFixtureEnvelope(fixtureFeaturedCities));
+    }
     if (!hasDatabaseUrl()) {
       return jsonResponse(makeEnvelope([], { ok: false, limited: true, reason: "db unavailable" }), 503);
     }
@@ -673,6 +793,9 @@ export const discoverHandlers = {
 
   async assets() {
     const route = "api_discover_assets";
+    if (isDiscoverFixtureMode) {
+      return jsonResponse(makeFixtureEnvelope(fixtureAssets));
+    }
     if (!hasDatabaseUrl()) {
       return jsonResponse(makeEnvelope([], { ok: false, limited: true, reason: "db unavailable" }), 503);
     }
@@ -686,6 +809,16 @@ export const discoverHandlers = {
 
   async assetPanel(asset: string) {
     const route = "api_discover_asset_panel";
+    if (isDiscoverFixtureMode) {
+      const normalizedAsset = asset.trim().toUpperCase();
+      const fixturePanel = fixtureAssetPanels[normalizedAsset] ?? {
+        asset,
+        countriesTop5: fixtureFeaturedCities.slice(0, 5).map((item) => ({ countryCode: item.countryCode, total: Math.max(5, Math.floor(item.totalPlaces / 2)) })),
+        categoriesTop5: ["Cafe", "Restaurant", "Retail", "Market", "Services"].map((category, index) => ({ category, total: 18 - index * 2 })),
+        recent5: fixtureActivity.slice(0, 5),
+      };
+      return jsonResponse(makeFixtureEnvelope({ ...fixturePanel, asset: normalizedAsset || asset }));
+    }
     if (!hasDatabaseUrl()) {
       return jsonResponse(makeEnvelope({ asset, countriesTop5: [], categoriesTop5: [], recent5: [] }, { ok: false, limited: true, reason: "db unavailable" }), 503);
     }
@@ -699,6 +832,9 @@ export const discoverHandlers = {
 
   async storiesAuto() {
     const route = "api_discover_stories_auto";
+    if (isDiscoverFixtureMode) {
+      return jsonResponse(makeFixtureEnvelope(fixtureStoriesAuto));
+    }
     if (!hasDatabaseUrl()) {
       return jsonResponse(makeEnvelope([], { ok: false, limited: true, reason: "db unavailable" }), 503);
     }
@@ -711,6 +847,34 @@ export const discoverHandlers = {
   },
 
   async storiesMonthly() {
+    if (isDiscoverFixtureMode) {
+      return jsonResponse(makeFixtureEnvelope({
+        hasContent: true,
+        items: [
+          {
+            id: "2026-01-fixture",
+            month: "2026-01",
+            title: "Fixture mode monthly digest",
+            highlights: [
+              "US and DE led 30-day fixture growth.",
+              "BTC and USDT stayed dominant across featured cities.",
+              "Owner + community verification accounted for over half of featured city coverage.",
+            ],
+            dateISO: "2026-01-01",
+          },
+          {
+            id: "2025-12-fixture",
+            month: "2025-12",
+            title: "Fixture baseline snapshot",
+            highlights: [
+              "Initial fixture baseline seeded 6 cities and 10 assets.",
+              "Promote and approve events were balanced for audit replay.",
+            ],
+            dateISO: "2025-12-01",
+          },
+        ],
+      }));
+    }
     try {
       return jsonResponse(await queryMonthlyStories());
     } catch {
@@ -718,4 +882,3 @@ export const discoverHandlers = {
     }
   },
 };
-


### PR DESCRIPTION
### Motivation

- Provide deterministic, DB-free data for /discover and its APIs to support audits and visual verification without changing page layout or adding routes.
- Keep fixture mode opt-in and disabled by default in production so normal DB-backed behavior is preserved.
- Fix a minor link consistency issue so Asset Explorer "Recent" links include the selected `asset` query param when available.

### Description

- Added an opt-in fixture flag `NEXT_PUBLIC_DISCOVER_FIXTURE=1` and gated fixture responses in `lib/discover/server.ts`, returning deterministic payloads when enabled and preserving the original response envelope (`ok`, `limited`, `reason?`, `data`, `lastUpdatedISO`).
- Implemented small realistic fixture payloads for all `/api/discover/*` endpoints: `activity`, `trending-countries`, `featured-cities`, `assets`, `assets/[asset]` (top5/countries/categories and recent5), `stories/auto`, and `stories/monthly` while keeping existing types and headers.
- Added a subtle dev-only badge (`Fixture data`) to the top of `/discover` that appears only when fixture mode is enabled via the env flag, without altering layout, order, or styling of sections.
- Updated Asset Explorer `Recent Items` links to append `&asset=<asset>` when an asset is selected while preserving the place-only link compatibility.
- Added `docs/discover-audit-mode.md` documenting how to enable fixture mode, covered endpoints, and quick responsive checks for auditing.

### Testing

- Ran `npm run lint` which completed successfully (repo warnings unrelated to this change were reported). ✅
- Built the app with fixture mode enabled via `NEXT_PUBLIC_DISCOVER_FIXTURE=1 npm run build` which completed successfully. ✅
- Started the app with `NEXT_PUBLIC_DISCOVER_FIXTURE=1 npm start` and exercised all fixture endpoints with `curl`, verifying responses returned `ok: true` and `limited: false` for the fixture payloads. ✅
- Captured a Playwright screenshot of `/discover` with fixture mode enabled to validate UI rendering and the presence of the `Fixture data` badge. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fc6af35e88328a45660074ab422e8)