### PR TITLE
docs: add Discover v0.1 fixture-mode final audit report

### DIFF
--- a/docs/discover-v0.1-final-audit-fixture.md
+++ b/docs/discover-v0.1-final-audit-fixture.md
@@ -1,0 +1,80 @@
+# Discover v0.1 Final Audit (Fixture Mode)
+
+Date: 2026-02-26  
+Route: `/discover`  
+Mode: `NEXT_PUBLIC_DISCOVER_FIXTURE=1`
+
+## Executive verdict
+
+**READY TO ANNOUNCE? — No**
+
+The fixture mode audit is deterministic and most requirements pass (including horizontal overflow checks, fixture badge, core tab/link behavior, and no sponsor/ad wording), but two required behavior checks fail in the current implementation:
+
+1. **Featured cities mobile carousel** controls/behavior are not present in fixture runtime (no carousel next/prev controls detected on 380px).
+2. **Verification hub mobile accordion** behavior is not present (cards remain static; only “More” links are interactive).
+
+---
+
+## Evidence summary
+
+- Fixture badge visible: **PASS**
+- Horizontal overflow checks (380/480 with measured values): **PASS**
+- Breakpoint captures (380/480/768/1024): **PASS**
+- Sponsor/ads wording absent: **PASS**
+- Section behavior checks: **mixed** (see checklist)
+
+---
+
+## Checklist (PASS/FAIL)
+
+| Requirement | Result | Evidence |
+|---|---|---|
+| Fixture mode active and badge shown | **PASS** | `Fixture data` badge detected at `/discover`. |
+| No horizontal scroll at 380px | **PASS** | `innerWidth=380`, `scrollWidth=380`; screenshot captured. |
+| No horizontal scroll at 480px | **PASS** | `innerWidth=480`, `scrollWidth=480`; screenshot captured. |
+| Breakpoint screenshot: 380px | **PASS** | See artifact list. |
+| Breakpoint screenshot: 480px | **PASS** | See artifact list. |
+| Breakpoint screenshot: 768px | **PASS** | See artifact list. |
+| Breakpoint screenshot: 1024px+ | **PASS** | See artifact list. |
+| Activity tabs switch (Added/Owner/Community/Promoted) and each has data | **PASS** | Counts observed: Added 8, Owner 2, Community 2, Promoted 4. |
+| Activity retry works | **PASS** | Forced one network failure for `tab=promoted`, Retry button shown and recovery produced 4 cards. |
+| Trending countries shows Top 5 | **PASS** | 5 rows found. |
+| Trending rows link to `/map?country=` | **PASS** | Sample hrefs: `/map?country=US`, `/map?country=DE`, `/map?country=JP`, `/map?country=MX`, `/map?country=TH`. |
+| Stories Auto/Monthly tabs work | **PASS** | Both tabs selectable; content present. |
+| Story card opens modal | **PASS** | `Open story details` opens dialog. |
+| Story modal closes by ESC | **PASS** | ESC closes dialog. |
+| Story modal closes by X | **PASS** | `Close story modal` button closes dialog. |
+| Story modal closes by backdrop | **PASS** | Backdrop click closes dialog. |
+| Story CTA navigates | **PASS** | Auto CTA navigates to `/map?...`; Monthly CTA navigates to `/stats`. |
+| Featured cities has 6 cards | **PASS** | 6 links found with `country+city`. |
+| Featured city links include country + city | **PASS** | Sample: `/map?country=US&city=New%20York`. |
+| Featured cities **mobile carousel works** | **FAIL** | At 380px no carousel controls were found (no Next/Previous buttons), so required carousel interaction could not be validated as implemented. |
+| Asset explorer pills switch and panel loads | **PASS** | Asset panel visible/loaded; links populated in Countries/Categories/Recent. |
+| Asset links include asset + place params | **PASS** | Samples: `/map?country=US&asset=BTC`, `/map?category=Cafe&asset=BTC`, `/map?place=fixture-nyc-001&asset=BTC`. |
+| Verification hub has 4 items | **PASS** | 4 cards rendered. |
+| Verification hub **mobile accordion works** | **FAIL** | No accordion expand/collapse controls detected on 380px; section appears static with “More” links only. |
+| No sponsor/ads wording on `/discover` | **PASS** | Runtime body-text scan found no sponsor/ads terms. |
+
+---
+
+## Screenshot / artifact paths
+
+- 380px full page: `browser:/tmp/codex_browser_invocations/497edad4fcb23938/artifacts/artifacts/discover-380.png`
+- 480px full page: `browser:/tmp/codex_browser_invocations/497edad4fcb23938/artifacts/artifacts/discover-480.png`
+- 768px full page: `browser:/tmp/codex_browser_invocations/497edad4fcb23938/artifacts/artifacts/discover-768.png`
+- 1024px full page: `browser:/tmp/codex_browser_invocations/497edad4fcb23938/artifacts/artifacts/discover-1024.png`
+- Desktop behavior evidence: `browser:/tmp/codex_browser_invocations/0fac6149f12d2a09/artifacts/artifacts/discover-behavior-desktop.png`
+- Mobile evidence (380px): `browser:/tmp/codex_browser_invocations/1bdc8985bff8e84b/artifacts/artifacts/discover-mobile-interactions.png`
+- Activity retry failure-state capture: `browser:/tmp/codex_browser_invocations/d4cab091a1c3a2fc/artifacts/artifacts/discover-activity-retry.png`
+
+---
+
+## Final decision
+
+**READY TO ANNOUNCE? — No**
+
+Blocking reasons:
+- Required “Featured cities mobile carousel works” criterion is not met in observed fixture runtime.
+- Required “Verification hub mobile accordion works” criterion is not met in observed fixture runtime.
+
+If those two mobile interaction requirements are implemented/verified, this audit can be re-run quickly with the same fixture setup and likely flipped to **Yes**.


### PR DESCRIPTION
### Motivation
- Provide a deterministic, DB-free final audit for the `/discover` route using fixture mode (`NEXT_PUBLIC_DISCOVER_FIXTURE=1`) so UI/interaction evidence can be captured and reviewed.
- Record PASS/FAIL outcomes, measured overflow values, breakpoint screenshots, and a clear readiness verdict for release review.

### Description
- Add `docs/discover-v0.1-final-audit-fixture.md` containing the full fixture-mode audit, a PASS/FAIL checklist for all required criteria, measured `innerWidth` vs `scrollWidth` values, and artifact paths for screenshots at 380/480/768/1024 breakpoints.
- Document behavior checks for Activity, Trending, Stories, Featured Cities, Asset Explorer, and Verification Hub and call out blocking findings (mobile Featured Cities carousel and mobile Verification Hub accordion not validating in fixture runtime).
- Produce a final verdict: **READY TO ANNOUNCE? — No** with explicit reasons and instructions to re-run once the two mobile interactions are available for verification.

### Testing
- Ran the app in fixture mode with `NEXT_PUBLIC_DISCOVER_FIXTURE=1 npm run dev` and executed headless Playwright scripts to capture breakpoints, measure `innerWidth`/`scrollWidth`, and take full-page screenshots at `380`, `480`, `768`, and `1024` pixels, which produced artifacts referenced in the doc.
- Executed automated interaction checks via Playwright that validated: Activity tabs + retry (forced network failure), Trending top-5 links, Stories modal open/close/CTA navigation, Asset Explorer pills and link params, Featured Cities link counts, and Verification Hub item counts; results are summarized in the report (two mobile interactions failed to validate).
- Forced a network abort for `tab=promoted` to verify the Retry flow and captured an activity retry artifact; all automated scripts produced the screenshots and runtime observations listed in the document.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fcf223eb88328bf74a2addc5a36cb)