### PR TITLE
Discover: Add mobile carousel controls and verification accordion

### DIFF
--- a/components/discover/sections/FeaturedCitiesSection.tsx
+++ b/components/discover/sections/FeaturedCitiesSection.tsx
@@ -12,6 +12,7 @@ export default function FeaturedCitiesSection() {
   const [limitedReason, setLimitedReason] = useState<string | undefined>();
   const [retrying, setRetrying] = useState(false);
   const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const carouselRef = useRef<HTMLDivElement | null>(null);
 
   const load = useCallback(async (force = false) => {
     setLoading(true);
@@ -48,6 +49,20 @@ export default function FeaturedCitiesSection() {
 
   const barWidth = (value: number, total: number) => `${Math.max((value / Math.max(total, 1)) * 100, 8)}%`;
 
+  const scrollCities = (direction: 'prev' | 'next') => {
+    const carousel = carouselRef.current;
+    if (!carousel) return;
+    const firstCard = carousel.firstElementChild as HTMLElement | null;
+    const cardWidth = firstCard?.offsetWidth ?? carousel.clientWidth * 0.85;
+    const gap = 12;
+    const delta = cardWidth + gap;
+
+    carousel.scrollBy({
+      left: direction === 'next' ? delta : -delta,
+      behavior: 'smooth',
+    });
+  };
+
   return (
     <SectionShell title="Featured Crypto Cities" description="Top city clusters by active crypto-friendly places.">
       {loading ? <SimpleSkeletonRows rows={3} rowClassName="h-[152px]" /> : null}
@@ -56,14 +71,38 @@ export default function FeaturedCitiesSection() {
 
       {!loading && !error && items.length > 0 ? (
         <div className="overflow-hidden">
-          <div className="mx-0 flex snap-x snap-mandatory gap-3 overflow-x-auto px-4 pb-1 sm:grid sm:snap-none sm:grid-cols-2 sm:overflow-visible sm:px-0 lg:grid-cols-3">
+          <div className="mb-2 flex items-center justify-end gap-2 px-4 md:hidden">
+            <button
+              type="button"
+              aria-label="Previous city"
+              data-testid="cities-prev"
+              className="rounded border border-gray-200 px-2 py-1 text-sm font-semibold text-gray-700"
+              onClick={() => scrollCities('prev')}
+            >
+              Prev
+            </button>
+            <button
+              type="button"
+              aria-label="Next city"
+              data-testid="cities-next"
+              className="rounded border border-gray-200 px-2 py-1 text-sm font-semibold text-gray-700"
+              onClick={() => scrollCities('next')}
+            >
+              Next
+            </button>
+          </div>
+          <div
+            ref={carouselRef}
+            data-testid="cities-carousel"
+            className="mx-0 flex snap-x snap-mandatory gap-3 overflow-x-auto px-4 pb-1 md:grid md:snap-none md:grid-cols-2 md:overflow-visible md:px-0 lg:grid-cols-3"
+          >
             {items.map((city) => {
               const totalVerification = city.verificationBreakdown.owner + city.verificationBreakdown.community + city.verificationBreakdown.directory + city.verificationBreakdown.unverified;
               return (
                 <MapLink
                   key={`${city.countryCode}-${city.city}`}
                   href={`/map?country=${encodeURIComponent(city.countryCode)}&city=${encodeURIComponent(city.city)}`}
-                  className="min-w-[83.333%] snap-start rounded-lg border border-gray-200 p-4 transition hover:bg-gray-50 sm:min-w-0"
+                  className="min-w-[83.333%] snap-start rounded-lg border border-gray-200 p-4 transition hover:bg-gray-50 md:min-w-0"
                 >
                   <p className="truncate font-semibold text-gray-900">{city.city}, {city.countryCode}</p>
                   <p className="text-sm text-gray-600">{city.totalPlaces} places</p>

--- a/components/discover/sections/VerificationHubSection.tsx
+++ b/components/discover/sections/VerificationHubSection.tsx
@@ -32,10 +32,11 @@ const verificationItems = [
 
 export default function VerificationHubSection() {
   const [expandedDesktop, setExpandedDesktop] = useState<string | null>(null);
+  const [expandedMobile, setExpandedMobile] = useState<string | null>(null);
 
   return (
     <SectionShell title="Verification Hub" description="How verification labels are used across map listings.">
-      <div className="hidden gap-3 sm:grid sm:grid-cols-2 lg:grid-cols-4">
+      <div className="hidden gap-3 md:grid md:grid-cols-2 lg:grid-cols-4">
         {verificationItems.map((item) => (
           <article key={item.key} className="rounded-lg border border-gray-200 p-4">
             <h3 className="font-semibold text-gray-900">{item.title}</h3>
@@ -52,13 +53,25 @@ export default function VerificationHubSection() {
         ))}
       </div>
 
-      <div className="space-y-2 sm:hidden">
+      <div className="space-y-2 md:hidden" data-testid="verification-accordion">
         {verificationItems.map((item) => (
-          <details key={item.key} className="rounded-lg border border-gray-200 bg-white p-3">
-            <summary className="cursor-pointer list-none py-1 text-base font-semibold text-gray-900">{item.title}</summary>
-            <p className="mt-2 text-sm text-gray-600">{item.summary}</p>
-            <p className="mt-2 text-xs text-gray-600">{item.details}</p>
-          </details>
+          <article key={item.key} className="rounded-lg border border-gray-200 bg-white p-3">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-3 py-1 text-left text-base font-semibold text-gray-900"
+              onClick={() => setExpandedMobile((prev) => (prev === item.key ? null : item.key))}
+              aria-expanded={expandedMobile === item.key}
+              aria-controls={`verification-content-${item.key}`}
+              data-testid={`verification-trigger-${item.key}`}
+            >
+              <span>{item.title}</span>
+              <span className="text-xs font-semibold text-gray-600">{expandedMobile === item.key ? 'Hide' : 'More'}</span>
+            </button>
+            <div id={`verification-content-${item.key}`} className="mt-2" hidden={expandedMobile !== item.key}>
+              <p className="text-sm text-gray-600">{item.summary}</p>
+              <p className="mt-2 text-xs text-gray-600">{item.details}</p>
+            </div>
+          </article>
         ))}
       </div>
     </SectionShell>


### PR DESCRIPTION
### Motivation
- Address two blocking audit failures in the Discover page: make Featured Cities carousel controls detectable on mobile and make Verification Hub behave as a real accordion on mobile while preserving desktop/tablet behavior. 
- Maintain existing layout/styling and avoid adding sponsor/ads wording or changing section order.

### Description
- Featured Cities: added a `carouselRef`, explicit mobile-only Prev/Next buttons with exact aria-labels `"Previous city"` and `"Next city"`, and stable test IDs `data-testid="cities-carousel"`, `data-testid="cities-prev"`, and `data-testid="cities-next"`; buttons scroll the carousel by ~1 card width with smooth behavior. 
- Verification Hub: replaced the mobile `<details>` pattern with a button-driven accordion (Owner/Community/Directory/Unverified) that uses `aria-expanded` and `aria-controls`, keeps content in the DOM, and adds `data-testid="verification-accordion"` plus `data-testid="verification-trigger-<key>"` for each trigger. 
- CSS breakpoints adjusted to ensure desktop/tablet cards remain unchanged (`md+` for grid/cards) and mobile behavior applies up through 767px, while `overflow-hidden` and card sizing are preserved to avoid horizontal page overflow at narrow widths.

### Testing
- Ran `npm run lint` and it completed successfully (project warnings unrelated to these changes were reported). 
- Launched the dev server and executed a headless Playwright script to capture mobile interactions and layout at 380px; screenshots were produced at: `browser:/tmp/codex_browser_invocations/986ffd94ee87a912/artifacts/artifacts/discover-380-collapsed.png` and `browser:/tmp/codex_browser_invocations/986ffd94ee87a912/artifacts/artifacts/discover-380-expanded.png`. 
- Automated viewport overflow checks at 380px and 480px reported no horizontal overflow (`scrollWidth === clientWidth`) and the mobile controls/accordion interaction behaved as expected. All automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fda809960832881486f1eeea2830e)