### PR TITLE
docs: add post-PR298 discover fixture final audit re-run

### DIFF
--- a/docs/discover-v0.1-final-audit-fixture-2.md
+++ b/docs/discover-v0.1-final-audit-fixture-2.md
@@ -1,0 +1,90 @@
+# Discover v0.1 Final Audit (Fixture Mode) — Post-PR298 Re-run
+
+Date: 2026-02-26  
+Route: `/discover`  
+Mode: `NEXT_PUBLIC_DISCOVER_FIXTURE=1`
+
+## Scope of this re-run
+
+This re-run validates the two previously-blocking mobile requirements from the prior fixture final audit:
+
+1. Featured Cities has detectable mobile carousel controls at 380px.
+2. Verification Hub is a real mobile accordion at 380px (expand/collapse with `aria-expanded`).
+
+It also re-checks horizontal overflow at 380px and 480px.
+
+---
+
+## Results (PASS/FAIL)
+
+| Item | Result | Evidence |
+|---|---|---|
+| Featured Cities mobile carousel controls detectable at **380px** | **PASS** | In the `Featured Crypto Cities` section, both `Previous city` and `Next city` buttons were detected and visible at 380px (`prevDetected=true`, `nextDetected=true`, `prevVisible=true`, `nextVisible=true`). |
+| Verification Hub behaves as a mobile accordion at **380px** | **PASS** | In the `Verification Hub` section, 4 accordion triggers with `aria-expanded` were detected (`triggerCount=4`). On interaction, first trigger changed `aria-expanded` from `false` → `true` → `false`, confirming expand/collapse behavior. |
+| No horizontal scroll at **380px** | **PASS** | Measured `innerWidth=380` and `scrollWidth=380` (equal). |
+| No horizontal scroll at **480px** | **PASS** | Measured `innerWidth=480` and `scrollWidth=480` (equal). |
+
+---
+
+## Raw measurement snapshot
+
+```json
+{
+  "380": {
+    "scroll": {
+      "innerWidth": 380,
+      "scrollWidth": 380
+    },
+    "featuredCitiesMobileControls": {
+      "prevDetected": true,
+      "nextDetected": true,
+      "prevVisible": true,
+      "nextVisible": true
+    },
+    "verificationHubMobileAccordion": {
+      "triggerCount": 4,
+      "before": "false",
+      "afterOpen": "true",
+      "afterClose": "false"
+    }
+  },
+  "480": {
+    "scroll": {
+      "innerWidth": 480,
+      "scrollWidth": 480
+    },
+    "featuredCitiesMobileControls": {
+      "prevDetected": true,
+      "nextDetected": true,
+      "prevVisible": true,
+      "nextVisible": true
+    },
+    "verificationHubMobileAccordion": {
+      "triggerCount": 4,
+      "before": "false",
+      "afterOpen": "true",
+      "afterClose": "false"
+    }
+  }
+}
+```
+
+---
+
+## Screenshots
+
+### 380px
+
+![Discover fixture audit at 380px](browser:/tmp/codex_browser_invocations/faea393159ec5f8a/artifacts/artifacts/discover-final-audit-fixture2-380.png)
+
+### 480px
+
+![Discover fixture audit at 480px](browser:/tmp/codex_browser_invocations/faea393159ec5f8a/artifacts/artifacts/discover-final-audit-fixture2-480.png)
+
+---
+
+## Final verdict
+
+**READY TO ANNOUNCE? — Yes**
+
+Both prior blockers are now validated as fixed in fixture mode, and horizontal overflow checks pass at both requested mobile widths.


### PR DESCRIPTION
### Motivation
- Re-run the deterministic fixture-mode final audit for `/discover` after PR-298 to confirm two previously-blocking mobile regressions are fixed. 
- Validate that Featured Cities exposes mobile carousel controls and that Verification Hub behaves as a mobile accordion at narrow widths, and re-check horizontal overflow at 380px/480px.

### Description
- Add `docs/discover-v0.1-final-audit-fixture-2.md` which contains the re-run scope, PASS/FAIL matrix, raw measurement JSON, screenshot links, and a final verdict. 
- The report records element-detection evidence for `Featured Crypto Cities` carousel controls (`Previous city` / `Next city`) and `Verification Hub` accordion `aria-expanded` transitions. 
- The report also includes measured overflow checks (`innerWidth == scrollWidth`) for both 380px and 480px and embedded screenshots for both viewports. 

### Testing
- Launched the app in fixture mode with `NEXT_PUBLIC_DISCOVER_FIXTURE=1` and confirmed the site served at `http://localhost:3000` successfully. 
- Ran automated Playwright checks against `/discover` at `380px` and `480px` to detect carousel buttons, verify `aria-expanded` toggling on verification triggers, measure `innerWidth` vs `scrollWidth`, and capture screenshots; all asserted checks passed for the two previously-blocking items. 
- Captured artifacts `discover-final-audit-fixture2-380.png` and `discover-final-audit-fixture2-480.png` and recorded raw measurement JSON in the report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fddd3c69c832889e7e7c1efcd4af8)