### PR TITLE
db: add stats_timeseries table for stats v4.1 cube

### DIFF
--- a/lib/types/stats.ts
+++ b/lib/types/stats.ts
@@ -3,3 +3,5 @@ export type VerificationKey = "total" | "owner" | "community" | "directory" | "u
 export type VerificationTotals = Record<VerificationKey, number>;
 
 export type StatsPopulationScope = "map_displayable_places";
+
+export type StatsTimeseriesGrain = "1h" | "1d" | "1w";

--- a/migrations/20260227_stats_timeseries.sql
+++ b/migrations/20260227_stats_timeseries.sql
@@ -1,0 +1,21 @@
+-- Stats v4.1: pre-aggregated timeseries cube storage (PR-01: table only)
+
+CREATE TABLE IF NOT EXISTS public.stats_timeseries (
+  period_start TIMESTAMPTZ NOT NULL,
+  period_end TIMESTAMPTZ NOT NULL,
+  grain TEXT NOT NULL CHECK (grain IN ('1h', '1d', '1w')),
+  dim_type TEXT NOT NULL,
+  dim_key TEXT NOT NULL,
+  total_count INTEGER NOT NULL,
+  verified_count INTEGER NOT NULL,
+  accepting_any_count INTEGER NOT NULL,
+  breakdown_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (period_start, grain, dim_type, dim_key)
+);
+
+CREATE INDEX IF NOT EXISTS stats_timeseries_dim_period_idx
+  ON public.stats_timeseries (grain, dim_type, dim_key, period_start DESC);
+
+CREATE INDEX IF NOT EXISTS stats_timeseries_period_idx
+  ON public.stats_timeseries (period_start DESC);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:map-smoke:headed": "playwright test tests/map-smoke.spec.ts --headed",
     "audit:submit": "tsx scripts/audit/run-submit-audit.ts",
     "db:schema:check": "tsx scripts/validate_db_schema.ts",
-    "validate:map-stats-parity": "node --import tsx scripts/validate_map_stats_parity.ts"
+    "validate:map-stats-parity": "node --import tsx scripts/validate_map_stats_parity.ts",
+    "db:migrate:stats-timeseries": "tsx scripts/db_apply_sql.ts migrations/20260227_stats_timeseries.sql"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.862.0",


### PR DESCRIPTION
### Motivation
- Add the persistent storage for Stats v4.1 pre-aggregated timeseries as defined in `docs/stats-v4.1.md` so future jobs/reads have a non-destructive place to store cubes. 
- Keep changes limited to schema + minimal typings and tooling so existing UI/API/jobs remain unaffected (table-only "box" PR).

### Description
- Added migration `migrations/20260227_stats_timeseries.sql` which creates `public.stats_timeseries` with columns `period_start TIMESTAMPTZ NOT NULL`, `period_end TIMESTAMPTZ NOT NULL`, `grain TEXT NOT NULL CHECK (grain IN ('1h','1d','1w'))`, `dim_type TEXT NOT NULL`, `dim_key TEXT NOT NULL`, `total_count INTEGER NOT NULL`, `verified_count INTEGER NOT NULL`, `accepting_any_count INTEGER NOT NULL`, `breakdown_json JSONB NOT NULL DEFAULT '{}'::jsonb`, and `generated_at TIMESTAMPTZ NOT NULL DEFAULT now()`. 
- Primary key is `(period_start, grain, dim_type, dim_key)` and indexes added are `(grain, dim_type, dim_key, period_start DESC)` and `(period_start DESC)` to support range and dim lookups. 
- Added a small type helper `export type StatsTimeseriesGrain = "1h" | "1d" | "1w"` in `lib/types/stats.ts` and an npm script `db:migrate:stats-timeseries` which runs the migration via `tsx scripts/db_apply_sql.ts migrations/20260227_stats_timeseries.sql`. 
- This PR does not implement generation jobs or change any `/api/stats` or `/api/stats/trends` logic and intentionally does not wire the new table into runtime code.

### Testing
- `npm run build` completed successfully and the app compiled without type-breaking errors. 
- `pnpm exec tsc --noEmit` failed due to environment package manager (corepack/pnpm) fetch errors and could not be completed in this environment. 
- `npx tsc --noEmit` failed with existing unrelated test file syntax errors in `tests/audit/*` and the failures are not caused by these changes. 
- `npm run db:migrate:stats-timeseries` and `npm run db:check` were not applied because `DATABASE_URL` was not set in the environment, so runtime DB verification / `SELECT 1` table-existence check could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13b10d0a48328b5dcb23701ba9257)