### PR TITLE
ops: add backfill + gap check + staleness signals for stats_timeseries

### DIFF
--- a/docs/stats-v4.1.md
+++ b/docs/stats-v4.1.md
@@ -365,3 +365,28 @@ Primary Key:
 * 非対応条件は明示
 
 ---
+
+---
+
+## 🛠 Stats timeseries 運用（PR-10）
+
+- Backfill は安全デフォルトで実行する（全期間デフォルト禁止）。
+  - `1h`: 既定48時間
+  - `1d`: 既定7日
+  - `1w`: 既定8週
+- 推奨コマンド:
+  - `pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1d --days=90`
+  - `pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1w --weeks=52`
+  - `pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1h --hours=48`
+- 欠損検知コマンド:
+  - `pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1h --hours=48 --dim-type=all --dim-key=all --fail-if-gaps-above=0`
+  - `pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1d --days=90 --dim-type=all --dim-key=all --fail-if-gaps-above=0`
+  - `pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1w --weeks=52 --dim-type=all --dim-key=all --fail-if-gaps-above=0`
+- stale 判定しきい値:
+  - `1h`: period/generated の遅延が3時間超
+  - `1d`: period/generated の遅延が48時間超
+  - `1w`: period/generated の遅延が14日超
+- 保持方針（削除実装は別PR）:
+  - `1h`: 最大60日
+  - `1d`: 最大2年
+  - `1w`: 最大5年

--- a/lib/stats/retention.ts
+++ b/lib/stats/retention.ts
@@ -1,0 +1,7 @@
+import { Grain } from "@/lib/stats/generateTimeseries";
+
+export const STATS_TIMESERIES_RETENTION_BUCKETS: Record<Grain, number> = {
+  "1h": 24 * 60,
+  "1d": 365 * 2,
+  "1w": 52 * 5,
+};

--- a/lib/stats/staleness.ts
+++ b/lib/stats/staleness.ts
@@ -1,0 +1,165 @@
+import { dbQuery } from "@/lib/db";
+
+export type StatsGrain = "1h" | "1d" | "1w";
+
+export type StalenessStatus = "fresh" | "stale";
+
+export type StalenessThreshold = {
+  maxPeriodLagHours: number;
+  maxGeneratedAgeHours: number;
+};
+
+export type StatsStaleness = {
+  grain: StatsGrain;
+  dimType: string;
+  dimKey: string;
+  status: StalenessStatus;
+  reason: "missing" | "period_lag" | "generated_at_lag" | "fresh";
+  now: string;
+  lastPeriodStart: string | null;
+  lastGeneratedAt: string | null;
+  ageHours: number | null;
+  generatedAgeHours: number | null;
+  threshold: StalenessThreshold;
+};
+
+export const STALENESS_THRESHOLDS: Record<StatsGrain, StalenessThreshold> = {
+  "1h": {
+    maxPeriodLagHours: 3,
+    maxGeneratedAgeHours: 3,
+  },
+  "1d": {
+    maxPeriodLagHours: 48,
+    maxGeneratedAgeHours: 48,
+  },
+  "1w": {
+    maxPeriodLagHours: 24 * 14,
+    maxGeneratedAgeHours: 24 * 14,
+  },
+};
+
+const toHours = (valueMs: number) => Number((valueMs / (1000 * 60 * 60)).toFixed(2));
+
+const staleMissing = (grain: StatsGrain, dimType: string, dimKey: string, now: Date): StatsStaleness => ({
+  grain,
+  dimType,
+  dimKey,
+  status: "stale",
+  reason: "missing",
+  now: now.toISOString(),
+  lastPeriodStart: null,
+  lastGeneratedAt: null,
+  ageHours: null,
+  generatedAgeHours: null,
+  threshold: STALENESS_THRESHOLDS[grain],
+});
+
+export const evaluateStatsStaleness = (params: {
+  grain: StatsGrain;
+  dimType: string;
+  dimKey: string;
+  now?: Date;
+  lastPeriodStart: string | null;
+  lastGeneratedAt: string | null;
+}): StatsStaleness => {
+  const now = params.now ?? new Date();
+  const threshold = STALENESS_THRESHOLDS[params.grain];
+
+  if (!params.lastPeriodStart) {
+    return staleMissing(params.grain, params.dimType, params.dimKey, now);
+  }
+
+  const lastPeriodStartDate = new Date(params.lastPeriodStart);
+  if (Number.isNaN(lastPeriodStartDate.getTime())) {
+    return staleMissing(params.grain, params.dimType, params.dimKey, now);
+  }
+
+  const ageHours = toHours(now.getTime() - lastPeriodStartDate.getTime());
+  const generatedAgeHours = (() => {
+    if (!params.lastGeneratedAt) return null;
+    const generatedDate = new Date(params.lastGeneratedAt);
+    if (Number.isNaN(generatedDate.getTime())) return null;
+    return toHours(now.getTime() - generatedDate.getTime());
+  })();
+
+  if (ageHours > threshold.maxPeriodLagHours) {
+    return {
+      grain: params.grain,
+      dimType: params.dimType,
+      dimKey: params.dimKey,
+      status: "stale",
+      reason: "period_lag",
+      now: now.toISOString(),
+      lastPeriodStart: lastPeriodStartDate.toISOString(),
+      lastGeneratedAt: params.lastGeneratedAt,
+      ageHours,
+      generatedAgeHours,
+      threshold,
+    };
+  }
+
+  if (generatedAgeHours !== null && generatedAgeHours > threshold.maxGeneratedAgeHours) {
+    return {
+      grain: params.grain,
+      dimType: params.dimType,
+      dimKey: params.dimKey,
+      status: "stale",
+      reason: "generated_at_lag",
+      now: now.toISOString(),
+      lastPeriodStart: lastPeriodStartDate.toISOString(),
+      lastGeneratedAt: params.lastGeneratedAt,
+      ageHours,
+      generatedAgeHours,
+      threshold,
+    };
+  }
+
+  return {
+    grain: params.grain,
+    dimType: params.dimType,
+    dimKey: params.dimKey,
+    status: "fresh",
+    reason: "fresh",
+    now: now.toISOString(),
+    lastPeriodStart: lastPeriodStartDate.toISOString(),
+    lastGeneratedAt: params.lastGeneratedAt,
+    ageHours,
+    generatedAgeHours,
+    threshold,
+  };
+};
+
+export const getStatsStaleness = async (params: {
+  grain: StatsGrain;
+  dimType?: string;
+  dimKey?: string;
+  route?: string;
+  now?: Date;
+}) => {
+  const dimType = params.dimType ?? "all";
+  const dimKey = params.dimKey ?? "all";
+  const route = params.route ?? "stats_staleness";
+
+  const { rows } = await dbQuery<{ period_start: string; generated_at: string | null }>(
+    `SELECT period_start, generated_at
+     FROM public.stats_timeseries
+     WHERE grain = $1
+       AND dim_type = $2
+       AND dim_key = $3
+     ORDER BY period_start DESC
+     LIMIT 1`,
+    [params.grain, dimType, dimKey],
+    { route },
+  );
+
+  const latest = rows[0];
+
+  return evaluateStatsStaleness({
+    grain: params.grain,
+    dimType,
+    dimKey,
+    now: params.now,
+    lastPeriodStart: latest?.period_start ?? null,
+    lastGeneratedAt: latest?.generated_at ?? null,
+  });
+};

--- a/scripts/backfill_stats_timeseries.ts
+++ b/scripts/backfill_stats_timeseries.ts
@@ -1,0 +1,227 @@
+import { Grain, runStatsTimeseriesGeneration } from "@/lib/stats/generateTimeseries";
+
+type CliOptions = {
+  grain: Grain;
+  since?: string;
+  until?: string;
+  days?: number;
+  weeks?: number;
+  hours?: number;
+  topN: number;
+};
+
+const DEFAULTS: Record<Grain, { lookback: number }> = {
+  "1h": { lookback: 48 },
+  "1d": { lookback: 7 },
+  "1w": { lookback: 8 },
+};
+
+const printHelp = () => {
+  console.log(`Usage:\n  pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1d [--days=90] [--top-n=30]\n  pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1w [--weeks=52] [--top-n=30]\n  pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1h [--hours=48] [--top-n=30]\n  pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1d --since=2026-01-01 --until=2026-02-01`);
+};
+
+const parseIntValue = (name: string, value: string) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive number.`);
+  }
+  return Math.floor(parsed);
+};
+
+const parseUtcDate = (raw: string) => {
+  const parsed = new Date(`${raw}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date: ${raw}. Expected YYYY-MM-DD.`);
+  }
+  return parsed;
+};
+
+const startOfUtcHour = (date: Date) => {
+  const value = new Date(date);
+  value.setUTCMinutes(0, 0, 0);
+  return value;
+};
+
+const startOfUtcDay = (date: Date) => {
+  const value = new Date(date);
+  value.setUTCHours(0, 0, 0, 0);
+  return value;
+};
+
+const startOfUtcWeek = (date: Date) => {
+  const value = startOfUtcDay(date);
+  const day = value.getUTCDay();
+  const offset = (day + 6) % 7;
+  value.setUTCDate(value.getUTCDate() - offset);
+  return value;
+};
+
+const addBucket = (date: Date, grain: Grain, count = 1) => {
+  const value = new Date(date);
+  if (grain === "1h") {
+    value.setUTCHours(value.getUTCHours() + count);
+  } else if (grain === "1d") {
+    value.setUTCDate(value.getUTCDate() + count);
+  } else {
+    value.setUTCDate(value.getUTCDate() + count * 7);
+  }
+  return value;
+};
+
+const bucketStart = (date: Date, grain: Grain) => {
+  if (grain === "1h") return startOfUtcHour(date);
+  if (grain === "1d") return startOfUtcDay(date);
+  return startOfUtcWeek(date);
+};
+
+const parseArgs = (): CliOptions => {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const options: Partial<CliOptions> = {
+    topN: 30,
+  };
+
+  for (const arg of args) {
+    const [rawKey, rawValue] = arg.split("=");
+    const key = rawKey?.trim();
+    const value = rawValue?.trim();
+    if (!key?.startsWith("--") || !value) continue;
+
+    if (key === "--grain" && ["1h", "1d", "1w"].includes(value)) {
+      options.grain = value as Grain;
+    } else if (key === "--since") {
+      options.since = value;
+    } else if (key === "--until") {
+      options.until = value;
+    } else if (key === "--days") {
+      options.days = parseIntValue("--days", value);
+    } else if (key === "--weeks") {
+      options.weeks = parseIntValue("--weeks", value);
+    } else if (key === "--hours") {
+      options.hours = parseIntValue("--hours", value);
+    } else if (key === "--top-n") {
+      options.topN = parseIntValue("--top-n", value);
+    }
+  }
+
+  if (!options.grain) {
+    throw new Error("--grain is required (1h | 1d | 1w)");
+  }
+
+  return options as CliOptions;
+};
+
+const resolveRange = (options: CliOptions) => {
+  const now = new Date();
+  const grain = options.grain;
+  const endExclusive = (() => {
+    if (options.until) {
+      return addBucket(bucketStart(parseUtcDate(options.until), grain), grain, 1);
+    }
+    return addBucket(bucketStart(now, grain), grain, 1);
+  })();
+
+  let start = options.since ? bucketStart(parseUtcDate(options.since), grain) : null;
+
+  if (!start) {
+    if (grain === "1h") {
+      const lookback = options.hours ?? DEFAULTS[grain].lookback;
+      start = addBucket(endExclusive, grain, -lookback);
+    } else if (grain === "1d") {
+      const lookback = options.days ?? DEFAULTS[grain].lookback;
+      start = addBucket(endExclusive, grain, -lookback);
+    } else {
+      const lookback = options.weeks ?? DEFAULTS[grain].lookback;
+      start = addBucket(endExclusive, grain, -lookback);
+    }
+  }
+
+  if (start >= endExclusive) {
+    throw new Error("Invalid range: start must be earlier than end.");
+  }
+
+  return { start, endExclusive };
+};
+
+const runBucket = async (grain: Grain, bucketStartAt: Date, topN: number) => {
+  if (grain === "1h") {
+    return runStatsTimeseriesGeneration({
+      grain,
+      hourStart: bucketStartAt.toISOString(),
+      topN,
+      route: "scripts_backfill_stats_timeseries",
+    });
+  }
+
+  if (grain === "1d") {
+    return runStatsTimeseriesGeneration({
+      grain,
+      date: bucketStartAt.toISOString().slice(0, 10),
+      topN,
+      route: "scripts_backfill_stats_timeseries",
+    });
+  }
+
+  return runStatsTimeseriesGeneration({
+    grain,
+    weekStart: bucketStartAt.toISOString().slice(0, 10),
+    topN,
+    route: "scripts_backfill_stats_timeseries",
+  });
+};
+
+const main = async () => {
+  const options = parseArgs();
+  const { start, endExclusive } = resolveRange(options);
+
+  const buckets: Date[] = [];
+  for (let cursor = new Date(start); cursor < endExclusive; cursor = addBucket(cursor, options.grain, 1)) {
+    buckets.push(new Date(cursor));
+  }
+
+  console.log("[backfill_stats_timeseries] start", {
+    grain: options.grain,
+    start: start.toISOString(),
+    endExclusive: endExclusive.toISOString(),
+    buckets: buckets.length,
+    safeDefault: !options.since && !options.until,
+  });
+
+  let totalFacts = 0;
+  let totalUpserted = 0;
+
+  for (let index = 0; index < buckets.length; index += 1) {
+    const bucket = buckets[index];
+    const progress = `${index + 1}/${buckets.length}`;
+
+    const result = await runBucket(options.grain, bucket, options.topN);
+    totalFacts += result.facts;
+    totalUpserted += result.upserted;
+
+    console.log("[backfill_stats_timeseries] bucket", {
+      progress,
+      bucket_start: bucket.toISOString(),
+      window_start: result.windowStart,
+      window_end: result.windowEnd,
+      facts: result.facts,
+      upserted: result.upserted,
+    });
+  }
+
+  console.log("[backfill_stats_timeseries] done", {
+    grain: options.grain,
+    buckets: buckets.length,
+    facts: totalFacts,
+    upserted: totalUpserted,
+  });
+};
+
+main().catch((error) => {
+  console.error("[backfill_stats_timeseries] failed", error);
+  process.exitCode = 1;
+});

--- a/scripts/check_stats_timeseries_gaps.ts
+++ b/scripts/check_stats_timeseries_gaps.ts
@@ -1,0 +1,226 @@
+import { dbQuery, hasDatabaseUrl } from "@/lib/db";
+import { Grain } from "@/lib/stats/generateTimeseries";
+
+type CliOptions = {
+  grain: Grain;
+  since?: string;
+  until?: string;
+  days?: number;
+  weeks?: number;
+  hours?: number;
+  dimType: string;
+  dimKey: string;
+  maxList: number;
+  failIfGapsAbove?: number;
+};
+
+const printHelp = () => {
+  console.log(`Usage:\n  pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1d --days=90\n  pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1w --weeks=52\n  pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1h --hours=48 --dim-type=all --dim-key=all\n  pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1d --since=2026-01-01 --until=2026-03-01 --fail-if-gaps-above=0`);
+};
+
+const parseIntValue = (name: string, raw: string) => {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number.`);
+  }
+  return Math.floor(parsed);
+};
+
+const parseUtcDate = (raw: string) => {
+  const parsed = new Date(`${raw}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date: ${raw}. Expected YYYY-MM-DD.`);
+  }
+  return parsed;
+};
+
+const startOfUtcHour = (date: Date) => {
+  const value = new Date(date);
+  value.setUTCMinutes(0, 0, 0);
+  return value;
+};
+
+const startOfUtcDay = (date: Date) => {
+  const value = new Date(date);
+  value.setUTCHours(0, 0, 0, 0);
+  return value;
+};
+
+const startOfUtcWeek = (date: Date) => {
+  const value = startOfUtcDay(date);
+  const day = value.getUTCDay();
+  const offset = (day + 6) % 7;
+  value.setUTCDate(value.getUTCDate() - offset);
+  return value;
+};
+
+const addBucket = (date: Date, grain: Grain, count = 1) => {
+  const value = new Date(date);
+  if (grain === "1h") value.setUTCHours(value.getUTCHours() + count);
+  else if (grain === "1d") value.setUTCDate(value.getUTCDate() + count);
+  else value.setUTCDate(value.getUTCDate() + count * 7);
+  return value;
+};
+
+const bucketStart = (date: Date, grain: Grain) => {
+  if (grain === "1h") return startOfUtcHour(date);
+  if (grain === "1d") return startOfUtcDay(date);
+  return startOfUtcWeek(date);
+};
+
+const parseArgs = (): CliOptions => {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const options: Partial<CliOptions> = {
+    dimType: "all",
+    dimKey: "all",
+    maxList: 10,
+  };
+
+  for (const arg of args) {
+    const [rawKey, rawValue] = arg.split("=");
+    const key = rawKey?.trim();
+    const value = rawValue?.trim();
+    if (!key?.startsWith("--") || value === undefined) continue;
+
+    if (key === "--grain" && ["1h", "1d", "1w"].includes(value)) {
+      options.grain = value as Grain;
+    } else if (key === "--since") {
+      options.since = value;
+    } else if (key === "--until") {
+      options.until = value;
+    } else if (key === "--days") {
+      options.days = parseIntValue("--days", value);
+    } else if (key === "--weeks") {
+      options.weeks = parseIntValue("--weeks", value);
+    } else if (key === "--hours") {
+      options.hours = parseIntValue("--hours", value);
+    } else if (key === "--dim-type") {
+      options.dimType = value || "all";
+    } else if (key === "--dim-key") {
+      options.dimKey = value || "all";
+    } else if (key === "--max-list") {
+      options.maxList = parseIntValue("--max-list", value);
+    } else if (key === "--fail-if-gaps-above") {
+      options.failIfGapsAbove = parseIntValue("--fail-if-gaps-above", value);
+    }
+  }
+
+  if (!options.grain) {
+    throw new Error("--grain is required (1h | 1d | 1w)");
+  }
+
+  return options as CliOptions;
+};
+
+const resolveRange = (options: CliOptions) => {
+  const now = new Date();
+  const endExclusive = options.until
+    ? addBucket(bucketStart(parseUtcDate(options.until), options.grain), options.grain, 1)
+    : addBucket(bucketStart(now, options.grain), options.grain, 1);
+
+  const since = options.since ? bucketStart(parseUtcDate(options.since), options.grain) : null;
+
+  const lookback = (() => {
+    if (options.grain === "1h") return options.hours ?? 48;
+    if (options.grain === "1d") return options.days ?? 90;
+    return options.weeks ?? 52;
+  })();
+
+  const start = since ?? addBucket(endExclusive, options.grain, -lookback);
+  if (start >= endExclusive) {
+    throw new Error("Invalid range: start must be earlier than end.");
+  }
+
+  return { start, endExclusive };
+};
+
+const compressRanges = (gaps: string[], grain: Grain) => {
+  if (gaps.length === 0) return [] as Array<{ start: string; end: string; length: number }>;
+
+  const ranges: Array<{ start: string; end: string; length: number }> = [];
+  let rangeStart = new Date(gaps[0]);
+  let previous = new Date(gaps[0]);
+  let count = 1;
+
+  for (let index = 1; index < gaps.length; index += 1) {
+    const current = new Date(gaps[index]);
+    const expectedNext = addBucket(previous, grain, 1);
+    if (expectedNext.getTime() === current.getTime()) {
+      previous = current;
+      count += 1;
+      continue;
+    }
+
+    ranges.push({ start: rangeStart.toISOString(), end: previous.toISOString(), length: count });
+    rangeStart = current;
+    previous = current;
+    count = 1;
+  }
+
+  ranges.push({ start: rangeStart.toISOString(), end: previous.toISOString(), length: count });
+  return ranges;
+};
+
+const main = async () => {
+  const options = parseArgs();
+
+  if (!hasDatabaseUrl()) {
+    throw new Error("DATABASE_URL is required.");
+  }
+
+  const { start, endExclusive } = resolveRange(options);
+
+  const { rows } = await dbQuery<{ period_start: string }>(
+    `SELECT period_start
+     FROM public.stats_timeseries
+     WHERE grain = $1
+       AND dim_type = $2
+       AND dim_key = $3
+       AND period_start >= $4
+       AND period_start < $5
+     ORDER BY period_start ASC`,
+    [options.grain, options.dimType, options.dimKey, start.toISOString(), endExclusive.toISOString()],
+    { route: "scripts_check_stats_timeseries_gaps" },
+  );
+
+  const existing = new Set(rows.map((row) => new Date(row.period_start).toISOString()));
+
+  const expected: string[] = [];
+  for (let cursor = new Date(start); cursor < endExclusive; cursor = addBucket(cursor, options.grain, 1)) {
+    expected.push(cursor.toISOString());
+  }
+
+  const gaps = expected.filter((bucket) => !existing.has(bucket));
+  const ranges = compressRanges(gaps, options.grain);
+
+  console.log("[check_stats_timeseries_gaps] result", {
+    grain: options.grain,
+    dim_type: options.dimType,
+    dim_key: options.dimKey,
+    since: start.toISOString(),
+    until_exclusive: endExclusive.toISOString(),
+    expected_count: expected.length,
+    actual_count: rows.length,
+    gaps_count: gaps.length,
+    gap_samples: gaps.slice(0, options.maxList),
+    gap_ranges: ranges.slice(0, options.maxList),
+  });
+
+  if (options.failIfGapsAbove !== undefined && gaps.length > options.failIfGapsAbove) {
+    console.error("[check_stats_timeseries_gaps] threshold exceeded", {
+      fail_if_gaps_above: options.failIfGapsAbove,
+      gaps_count: gaps.length,
+    });
+    process.exitCode = 2;
+  }
+};
+
+main().catch((error) => {
+  console.error("[check_stats_timeseries_gaps] failed", error);
+  process.exitCode = 1;
+});

--- a/scripts/generate_stats_timeseries.ts
+++ b/scripts/generate_stats_timeseries.ts
@@ -9,12 +9,13 @@ type CliOptions = {
   grain: Grain;
   date?: string;
   weekStart?: string;
+  hourStart?: string;
   sinceHours: number;
   topN: number;
 };
 
 const printHelp = () => {
-  console.log(`Usage:\n  pnpm tsx scripts/generate_stats_timeseries.ts --grain=1h [--since-hours=48] [--top-n=30]\n  pnpm tsx scripts/generate_stats_timeseries.ts --grain=1d [--date=YYYY-MM-DD] [--top-n=30]\n  pnpm tsx scripts/generate_stats_timeseries.ts --grain=1w [--week-start=YYYY-MM-DD] [--top-n=30]`);
+  console.log(`Usage:\n  pnpm tsx scripts/generate_stats_timeseries.ts --grain=1h [--since-hours=48] [--hour-start=2026-03-01T10:00:00Z] [--top-n=30]\n  pnpm tsx scripts/generate_stats_timeseries.ts --grain=1d [--date=YYYY-MM-DD] [--top-n=30]\n  pnpm tsx scripts/generate_stats_timeseries.ts --grain=1w [--week-start=YYYY-MM-DD] [--top-n=30]`);
 };
 
 const parseArgs = (): CliOptions => {
@@ -42,6 +43,8 @@ const parseArgs = (): CliOptions => {
       options.date = value;
     } else if (key === "--week-start" && value) {
       options.weekStart = value;
+    } else if (key === "--hour-start" && value) {
+      options.hourStart = value;
     } else if (key === "--since-hours" && value) {
       const parsed = Number(value);
       if (!Number.isFinite(parsed) || parsed <= 0) {


### PR DESCRIPTION
### Motivation

- Stabilize `stats_timeseries` operation by providing safe, bounded backfill tooling so operators can recover missing buckets without running unbounded heavy recomputation. 
- Provide an automated gap-detection tool that can be used in CI/monitoring to detect missing time buckets for specific grains and dims. 
- Surface generation delays (staleness) as concrete, auditable signals in cron logs and the `/api/stats/trends` response so UI/ops can show or alert on delayed updates. 
- Keep the precomputed-cube architecture and existing API/UX behavior intact while adding small, well-scoped operational helpers and documentation.

### Description

- Added a backfill CLI `scripts/backfill_stats_timeseries.ts` that accepts `--grain=1h|1d|1w`, window specifiers (`--since=YYYY-MM-DD`, `--until=YYYY-MM-DD` or relative `--hours/--days/--weeks`), emits per-bucket progress logs, and reuses `runStatsTimeseriesGeneration` (no co-located copy of aggregation logic). The safe defaults are bounded (1h:48, 1d:7, 1w:8). Example: `pnpm tsx scripts/backfill_stats_timeseries.ts --grain=1d --days=90`.
- Added a gap-check CLI `scripts/check_stats_timeseries_gaps.ts` that lists missing `period_start` buckets for a given `--grain`, `--dim-type`/`--dim-key` and period, prints `gaps_count`, sample gaps and compressed continuous-gap ranges, and supports `--fail-if-gaps-above=N` to produce a non-zero exit code for CI/monitoring use. Example: `pnpm tsx scripts/check_stats_timeseries_gaps.ts --grain=1h --hours=48 --dim-type=all --dim-key=all --fail-if-gaps-above=0`.
- Introduced reusable staleness logic in `lib/stats/staleness.ts` with thresholds (1h:3h, 1d:48h, 1w:14d) and functions `evaluateStatsStaleness` and `getStatsStaleness`, and integrated staleness checks into daily cron logs (emits `[stats][stale] ...` lines) and into `/api/stats/trends` under `meta.staleness` so the UI can display an informative message when data is stale.
- Added `hourStart` support to the generator (`lib/stats/generateTimeseries.ts` + `scripts/generate_stats_timeseries.ts`) to allow precise 1h bucket regeneration from backfill tooling, and added a retention guidance constant `lib/stats/retention.ts` with suggested bucket counts (1h:60d, 1d:2y, 1w:5y) with deletion left to a future PR.
- Documented operational guidance and command examples in `docs/stats-v4.1.md` (PR-10 section) and kept all new code small, logged, and conservative by default.

### Testing

- Ran `npm run lint` which completed successfully and reported only existing lint warnings. 
- Verified CLI help and basic invocation parsing with `npx tsx scripts/backfill_stats_timeseries.ts --help`, `npx tsx scripts/check_stats_timeseries_gaps.ts --help`, and `npx tsx scripts/generate_stats_timeseries.ts --help`, all of which printed usage successfully. 
- Unit/logic check: executed a local evaluation of staleness via `npx tsx -e "import { evaluateStatsStaleness } from './lib/stats/staleness'; ..."` which returned the expected stale/fresh outputs. 
- Exercise of DB-backed flows (`npx tsx scripts/backfill_stats_timeseries.ts --grain=1d --days=1` and `npx tsx scripts/check_stats_timeseries_gaps.ts --grain=1d --days=7 --fail-if-gaps-above=0`) failed in this environment with `DATABASE_URL is required.`, so DB upsert/query behavior was not validated here (these will succeed when run with a configured database). 
- Full test run `npm run test:stats` and type-check `npx tsc --noEmit` failed due to unrelated repository test/type issues and module resolution in this execution environment (these failures are not caused by the changes to stats tooling).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17910d4f48328be8ffd82abe9a7bf)