### PR TITLE
PR-XX: Exclude AQ demo pins from Stats & Discover via is_demo flag

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -146,6 +146,26 @@
 
 ---
 
+
+## 7. Demo Pins Policy (AQ)
+
+To ensure all four verification classes are always visible on the map, four temporary Antarctica demo places are maintained:
+
+- `antarctica-community-1`
+- `antarctica-directory-1`
+- `antarctica-owner-1`
+- `antarctica-unverified-1`
+
+Rules:
+
+- These records are marked in DB via `public.places.is_demo = true`.
+- Map display remains enabled for these demo records.
+- Stats / Discover and ranking-style aggregates must always exclude demo records via `COALESCE(is_demo, false) = false`.
+- Do not use country-based hardcoded exclusions (e.g., `country='AQ'`) for this purpose.
+- Once enough non-demo real examples exist for each verification class, these demo pins should be reviewed for removal.
+
+---
+
 ## Appendix A — Place ID Policy v1（legacy sources / keep as-is）
 
 > ここから下は従来の Place ID policy を **原文のまま保持**する。  

--- a/migrations/20260228_demo_pins_is_demo.sql
+++ b/migrations/20260228_demo_pins_is_demo.sql
@@ -1,0 +1,13 @@
+-- PR-XX: flag Antarctica demo pins so they can remain on map while excluded from Stats/Discover aggregates.
+
+ALTER TABLE public.places
+  ADD COLUMN IF NOT EXISTS is_demo boolean NOT NULL DEFAULT false;
+
+UPDATE public.places
+SET is_demo = true
+WHERE id IN (
+  'antarctica-community-1',
+  'antarctica-directory-1',
+  'antarctica-owner-1',
+  'antarctica-unverified-1'
+);


### PR DESCRIPTION
### Motivation

- Keep the four Antarctica demo places visible on the map while preventing them from contaminating Stats and Discover aggregates and rankings.
- Use a durable DB flag on `public.places` rather than country-based filtering so exclusion is explicit and future-proof.

### Description

- Add an idempotent Neon/Postgres migration `migrations/20260228_demo_pins_is_demo.sql` to create `public.places.is_demo boolean NOT NULL DEFAULT false` and mark the four demo IDs (`antarctica-community-1`, `antarctica-directory-1`, `antarctica-owner-1`, `antarctica-unverified-1`) as `is_demo = true`.
- Update Stats snapshot SQL population CTE in `app/api/stats/route.ts` to include `COALESCE(p.is_demo, false) = false` when the column exists so demo rows are always excluded from Stats regardless of URL params.
- Update Discover server queries in `lib/discover/server.ts` (activity, trending countries, featured cities, assets, asset panel and history→places joins) to exclude demo rows using the same `COALESCE(p.is_demo, false) = false` predicate while remaining compatible when the column is absent.
- Leave Map / places APIs unchanged so demo pins remain visible on the map, and add a policy section in `docs/policies.md` describing intent and rules for the AQ demo pins.

### Testing

- Ran `npx eslint app/api/stats/route.ts lib/discover/server.ts` which completed without errors.
- Ran `npm run test:stats` which could not complete due to an existing repository test environment issue (`Cannot find module '@/lib/db'`) unrelated to these changes, causing the run to fail.
- Ran `npx tsc --noEmit` which surfaced pre-existing TypeScript test-file syntax errors in `tests/audit/*.spec.ts` unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f803df608328afbb9b41bf8eae50)