### PR TITLE
Add Submit page info box with review & per-flow constraints

### DIFF
--- a/app/(site)/submit/page.tsx
+++ b/app/(site)/submit/page.tsx
@@ -39,6 +39,69 @@ export default function SubmitPage() {
           <h1 className="text-3xl font-bold text-gray-900">Choose what you want to submit</h1>
           <p className="text-gray-600">Select the flow that matches your request.</p>
         </div>
+        <section className="rounded-xl border border-blue-100 bg-blue-50/70 p-5 sm:p-6 text-gray-800 shadow-sm">
+          <div className="space-y-4 text-sm sm:text-base leading-relaxed">
+            <h2 className="text-xl font-semibold text-gray-900">Submit</h2>
+
+            <p>
+              Submitting a listing to CryptoPayMap is <strong>free</strong>.<br />
+              All submissions are reviewed. Listings appear on the Map <strong>only after
+              approval</strong> (no automatic publishing).
+            </p>
+
+            <hr className="border-blue-100" />
+
+            <section className="space-y-2">
+              <h3 className="text-lg font-semibold text-gray-900">Owner Verification</h3>
+              <p>Official submission by the business owner or authorized representative.</p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>About: up to 600 characters</li>
+                <li>Gallery images: up to 8 images (max 2MB each)</li>
+                <li>Proof: required (image or URL, selectable type)</li>
+                <li>Payment note: up to 150 characters</li>
+                <li>Amenities notes: up to 150 characters</li>
+              </ul>
+            </section>
+
+            <hr className="border-blue-100" />
+
+            <section className="space-y-2">
+              <h3 className="text-lg font-semibold text-gray-900">Community Suggestion</h3>
+              <p>Submission by a community member.</p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>About: up to 300 characters</li>
+                <li>Gallery images: up to 4 images (max 2MB each)</li>
+                <li>Proof URLs: minimum 2 required</li>
+                <li>Payment note: up to 150 characters</li>
+                <li>Amenities notes: up to 150 characters</li>
+              </ul>
+            </section>
+
+            <hr className="border-blue-100" />
+
+            <section className="space-y-2">
+              <h3 className="text-lg font-semibold text-gray-900">Report a Listing</h3>
+              <p>Request correction for incorrect, closed, or misleading listings.</p>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>Evidence URLs: one per line</li>
+                <li>Evidence images: up to 4 images (max 2MB each)</li>
+              </ul>
+            </section>
+
+            <hr className="border-blue-100" />
+
+            <section className="space-y-2">
+              <h3 className="text-lg font-semibold text-gray-900">General</h3>
+              <ul className="list-disc pl-6 space-y-1">
+                <li>Accepted image formats: JPEG / PNG / WebP</li>
+                <li>Maximum file size: 2MB per image</li>
+                <li>
+                  False, insufficient, or inappropriate submissions will not be approved
+                </li>
+              </ul>
+            </section>
+          </div>
+        </section>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <SubmitCard
             title="Owner verification"


### PR DESCRIPTION
### Motivation
- Ensure the Submit index clearly communicates that submissions are free and that listings are shown on the Map only after review and approval.
- Surface concise input constraints for Owner, Community, and Report flows so users see requirements before choosing a form.
- Provide the information in a prominent, readable block that appears above the Owner / Community / Report cards and works on both mobile and desktop.

### Description
- Added a new info box section to `app/(site)/submit/page.tsx` placed above the three submit cards and populated with the exact provided English copy (unchanged). 
- Implemented styling with Tailwind classes for a bordered, rounded, lightly shaded info box and responsive typography/spacing (`rounded-xl`, `border`, `bg-blue-50/70`, `p-5 sm:p-6`, `text-sm sm:text-base`).
- Structured the content with headings, separators, and bullet lists to match a markdown-like appearance while preserving the existing SubmitCard components and navigation.

### Testing
- Ran `npm run lint`, which completed successfully (existing unrelated warnings remain in other files). 
- Launched the dev server with `npm run dev` and captured automated screenshots via a Playwright script for desktop (1280px) and mobile (375px) to validate layout and responsiveness, with artifacts generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a39c743ccc8328a917d1f3a469d6fd)