### PR TITLE
Make published snapshot builder schema-aware and add verification guardrails

### DIFF
--- a/docs/audits/2026-03-01-pr-xx-snapshot-refresh.md
+++ b/docs/audits/2026-03-01-pr-xx-snapshot-refresh.md
@@ -1,0 +1,64 @@
+# PR-xx audit: published snapshot refresh + guardrails
+
+## A) Map public visibility rule in normal DB mode
+
+`/api/places` DB-mode currently builds its map-eligible WHERE by appending `getMapDisplayableWhereClauses("p")` and optional user filters (`category/country/city/bbox/search/verification/payment`).
+
+Base map-displayable clause:
+
+```sql
+p.lat IS NOT NULL
+AND p.lng IS NOT NULL
+```
+
+Source:
+- `getMapDisplayableWhereClauses` returns only `lat/lng IS NOT NULL` in `lib/stats/mapPopulation.ts`.
+- `/api/places` appends those clauses directly in DB mode.
+
+## B) Snapshot builder contract + filters
+
+`scripts/build_published_places_snapshot.ts` now:
+- probes `public.places` columns (`status`, `is_demo`) first,
+- applies hard map-displayable checks: `lat/lng` not null and finite,
+- excludes demos when supported: `COALESCE(p.is_demo,false)=false`,
+- applies published-only status when supported: `COALESCE(p.status,'published')='published'`,
+- preserves the existing summary-plus output shape and writes `meta.last_updated` ISO timestamp.
+
+## C) Guardrail
+
+Added `scripts/verify_published_places_snapshot.ts` and npm script `snapshot:verify`.
+
+The check fails non-zero if snapshot contains:
+- `antarctica-*` ids,
+- any legacy test ids from `data/places.json`:
+  - `cpm:tokyo:owner-cafe-1`
+  - `cpm:newyork:community-diner-1`
+  - `cpm:paris:directory-bistro-1`
+  - `cpm:sydney:unverified-bookstore-1`
+  - `cpm:toronto:owner-bakery-1`
+- or `country='AQ'`.
+
+## D) Environment limitation for this Codex run
+
+This container does not provide `DATABASE_URL`, and outbound call to `https://cryptopaymap.com` returned a `403 CONNECT tunnel failed` during verification.
+
+Because of that, this run could not query Neon to regenerate `data/fallback/published_places_snapshot.json` with real rows.
+
+Once `DATABASE_URL` is provided, run:
+
+```bash
+npm run snapshot:build
+npm run snapshot:verify
+```
+
+Then capture fallback evidence with:
+
+```bash
+PORT=3005 DATA_SOURCE=auto DATABASE_URL=postgresql://invalid:invalid@127.0.0.1:1/invalid npm run dev
+curl -i "http://127.0.0.1:3005/api/places?limit=20"
+```
+
+Expected headers in DB-down mode:
+- `x-cpm-limited: 1`
+- `x-cpm-data-source: json`
+- `x-cpm-last-updated: <snapshot meta.last_updated>`

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "audit:submit": "tsx scripts/audit/run-submit-audit.ts",
     "db:schema:check": "tsx scripts/validate_db_schema.ts",
     "validate:map-stats-parity": "node --import tsx scripts/validate_map_stats_parity.ts",
-    "db:migrate:stats-timeseries": "tsx scripts/db_apply_sql.ts migrations/20260227_stats_timeseries.sql"
+    "db:migrate:stats-timeseries": "tsx scripts/db_apply_sql.ts migrations/20260227_stats_timeseries.sql",
+    "snapshot:build": "tsx scripts/build_published_places_snapshot.ts",
+    "snapshot:verify": "tsx scripts/verify_published_places_snapshot.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.862.0",

--- a/scripts/verify_published_places_snapshot.ts
+++ b/scripts/verify_published_places_snapshot.ts
@@ -1,0 +1,68 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+type SnapshotPlace = {
+  id?: unknown;
+  country?: unknown;
+};
+
+type Snapshot = {
+  places?: SnapshotPlace[];
+};
+
+const SNAPSHOT_PATH = path.join(process.cwd(), "data", "fallback", "published_places_snapshot.json");
+
+const LEGACY_TEST_IDS = new Set([
+  "cpm:tokyo:owner-cafe-1",
+  "cpm:newyork:community-diner-1",
+  "cpm:paris:directory-bistro-1",
+  "cpm:sydney:unverified-bookstore-1",
+  "cpm:toronto:owner-bakery-1",
+]);
+
+const isAntarcticaDemoId = (id: string) => id.toLowerCase().startsWith("antarctica-");
+
+async function main() {
+  const raw = await readFile(SNAPSHOT_PATH, "utf8");
+  const parsed = JSON.parse(raw) as Snapshot;
+  const places = Array.isArray(parsed.places) ? parsed.places : [];
+
+  const flaggedIds: string[] = [];
+  let antarcticaCountryCount = 0;
+
+  for (const place of places) {
+    const id = typeof place.id === "string" ? place.id : "";
+    const country = typeof place.country === "string" ? place.country.trim().toUpperCase() : "";
+
+    if (id && (LEGACY_TEST_IDS.has(id) || isAntarcticaDemoId(id))) {
+      flaggedIds.push(id);
+    }
+
+    if (country === "AQ") {
+      antarcticaCountryCount += 1;
+    }
+  }
+
+  if (flaggedIds.length > 0 || antarcticaCountryCount > 0) {
+    console.error("[verify_published_places_snapshot] FAILED", {
+      snapshot: SNAPSHOT_PATH,
+      total_places: places.length,
+      flagged_ids: flaggedIds,
+      aq_count: antarcticaCountryCount,
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("[verify_published_places_snapshot] PASS", {
+    snapshot: SNAPSHOT_PATH,
+    total_places: places.length,
+    flagged_ids: 0,
+    aq_count: antarcticaCountryCount,
+  });
+}
+
+main().catch((error) => {
+  console.error("[verify_published_places_snapshot] FAILED", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- Ensure the Map fallback (Plan B) contains real, approved/published Neon rows (not the 5-test fixture) and clearly exposes `meta.last_updated` when DB is down.
- Prevent regressions where demo/legacy test listings reappear in the committed fallback snapshot by adding an automated guard.

### Description
- Update `scripts/build_published_places_snapshot.ts` to probe `public.places` for optional `status` and `is_demo` columns and apply a schema-safe WHERE that requires finite `lat`/`lng`, excludes demos when supported, and enforces `published` status when supported while preserving the existing `summary-plus` shape and `meta.last_updated` ISO timestamp.
- Add `scripts/verify_published_places_snapshot.ts` which fails non-zero if the snapshot contains any `antarctica-*` demo IDs, any of the 5 legacy test IDs, or any rows with `country = 'AQ'`.
- Add npm shortcuts `snapshot:build` and `snapshot:verify`, and a short audit note at `docs/audits/2026-03-01-pr-xx-snapshot-refresh.md` documenting the contract and the runbook for regenerating the snapshot.

### Testing
- `npm run snapshot:build` was executed and correctly failed in this environment because `DATABASE_URL` is not set (environment limitation). 
- `npm run snapshot:verify` was executed and correctly failed because the currently committed snapshot still contains the legacy test IDs which the guard detects (flagged IDs: `cpm:tokyo:owner-cafe-1`, `cpm:newyork:community-diner-1`, `cpm:paris:directory-bistro-1`, `cpm:sydney:unverified-bookstore-1`, `cpm:toronto:owner-bakery-1`).
- Simulated DB-down fallback by starting the app with `DATA_SOURCE=auto` and an invalid DB, and `curl`-checked `/api/places`; the route returned fallback results and headers `x-cpm-limited: 1`, `x-cpm-data-source: json`, and `x-cpm-last-updated` and Playwright screenshots were captured for desktop and mobile.
- Current snapshot evidence in the branch: total places = `5`, example IDs/names include `cpm:tokyo:owner-cafe-1 :: Satoshi Coffee`, `cpm:newyork:community-diner-1 :: Liberty Diner`, `cpm:paris:directory-bistro-1 :: Bistro du Coin`, and `country='AQ'` count = `0` (guardrail detected the remaining legacy test records).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3c63ae914832885fe0a43019f4425)