### PR TITLE
Add workflow to refresh published_places_snapshot.json

### DIFF
--- a/.github/workflows/refresh-published-places-snapshot.yml
+++ b/.github/workflows/refresh-published-places-snapshot.yml
@@ -1,0 +1,55 @@
+name: Refresh published places snapshot
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  refresh-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate DATABASE_URL secret presence
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "DATABASE_URL secret is not configured." >&2
+            exit 1
+          fi
+
+      - name: Build snapshot from Neon
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: npm run snapshot:build
+
+      - name: Verify snapshot integrity
+        run: npm run snapshot:verify
+
+      - name: Commit refreshed snapshot
+        run: |
+          if git diff --quiet -- data/fallback/published_places_snapshot.json; then
+            echo "No snapshot changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/fallback/published_places_snapshot.json
+          git commit -m "chore(snapshot): refresh published_places_snapshot.json"
+          git push origin "HEAD:${GITHUB_REF_NAME}"


### PR DESCRIPTION
### Motivation

- Automate regenerating and committing the published places fallback snapshot from the Neon database to keep `data/fallback/published_places_snapshot.json` up to date. 
- Ensure the snapshot build validates integrity and that a `DATABASE_URL` secret is present before attempting to build.

### Description

- Add a new GitHub Actions workflow `/.github/workflows/refresh-published-places-snapshot.yml` that is manually triggerable via `workflow_dispatch` and grants `contents: write` permission. 
- Workflow steps include `actions/checkout@v4`, `actions/setup-node@v4` with Node 20, and `npm ci` to prepare the environment. 
- The workflow validates the `DATABASE_URL` secret, runs `npm run snapshot:build` and `npm run snapshot:verify`, and commits and pushes changes to `data/fallback/published_places_snapshot.json` using the GitHub Actions bot identity if the file changed. 

### Testing

- No automated tests were executed as part of this pull request; the workflow is added and will run `npm ci`, `npm run snapshot:build`, and `npm run snapshot:verify` when manually dispatched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a429bc45b48328b0fc15adc4958eda)