### PR TITLE
Hotfix: Fetch fallback snapshot from GitHub raw and add short in-memory cache

### DIFF
--- a/lib/places/listPlacesForMap.ts
+++ b/lib/places/listPlacesForMap.ts
@@ -1,6 +1,3 @@
-import { promises as fs } from "node:fs";
-import path from "node:path";
-
 import { normalizeAccepted, type PaymentAccept } from "@/lib/accepted";
 import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
 import { type ParsedBbox } from "@/lib/geo/bbox";
@@ -19,12 +16,21 @@ import {
 } from "./mapDto/toSummaryPlus";
 import type { DbContact, PlaceSummaryPlus } from "./mapDto/types";
 
-const FALLBACK_SNAPSHOT_FILE = path.join(process.cwd(), "data", "fallback", "published_places_snapshot.json");
+const FALLBACK_SNAPSHOT_URL =
+  "https://raw.githubusercontent.com/badjoke-lab/cryptopaymap-v2/main/data/fallback/published_places_snapshot.json";
+const FALLBACK_SNAPSHOT_CACHE_TTL_MS = 45_000;
 
 type PublishedSnapshot = {
   meta?: { last_updated?: string };
   places: Place[];
 };
+
+type SnapshotCacheEntry = {
+  expiresAt: number;
+  snapshot: PublishedSnapshot;
+};
+
+let snapshotCache: SnapshotCacheEntry | null = null;
 
 type ListFilters = {
   category: string | null;
@@ -77,10 +83,26 @@ const sanitizeOptionalStrings = <T>(input: T): T => {
 };
 
 const loadPlacesFromSnapshot = async (): Promise<PublishedSnapshot> => {
-  const raw = await fs.readFile(FALLBACK_SNAPSHOT_FILE, "utf8");
-  const parsed = JSON.parse(raw);
+  if (snapshotCache && snapshotCache.expiresAt > Date.now()) {
+    return snapshotCache.snapshot;
+  }
+
+  const response = await fetch(FALLBACK_SNAPSHOT_URL, {
+    headers: { Accept: "application/json" },
+    next: { revalidate: 45 },
+  });
+  if (!response.ok) {
+    throw new Error("FALLBACK_SNAPSHOT_UNAVAILABLE");
+  }
+
+  const parsed = await response.json();
   if (parsed && typeof parsed === "object" && Array.isArray((parsed as PublishedSnapshot).places)) {
-    return parsed as PublishedSnapshot;
+    const snapshot = parsed as PublishedSnapshot;
+    snapshotCache = {
+      snapshot,
+      expiresAt: Date.now() + FALLBACK_SNAPSHOT_CACHE_TTL_MS,
+    };
+    return snapshot;
   }
   throw new Error("FALLBACK_SNAPSHOT_UNAVAILABLE");
 };


### PR DESCRIPTION
### Motivation
- Avoid Vercel’s "Deploying outputs…" internal error caused by bundling/reading the large local snapshot file while preserving the JSON fallback path for map data.
- Keep the limited/fallback contract intact so the API still signals unavailable explicitly instead of silently returning an empty list.

### Description
- Replace local `fs` snapshot read with `fetch` from `https://raw.githubusercontent.com/badjoke-lab/cryptopaymap-v2/main/data/fallback/published_places_snapshot.json` in `lib/places/listPlacesForMap.ts` and remove the previous filesystem dependency.
- Add a short in-memory snapshot cache with a TTL of `45_000` ms to reduce requests to raw.githubusercontent.com and return the cached snapshot while valid.
- Preserve error behavior by throwing `FALLBACK_SNAPSHOT_UNAVAILABLE` when the fetch or parse fails so the route continues to return an explicit unavailable response.
- Send `Accept: "application/json"` and include `next: { revalidate: 45 }` on the fetch to align with runtime caching intent.

### Testing
- Ran `npm run build` and the Next.js production build completed successfully, including compilation, type checking, and static page generation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a568ba20048328a90a3b503e09b7c9)