### PR TITLE
CPM: remove Antarctica demo notice localStorage persistence

### DIFF
--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -38,7 +38,6 @@ const DEFAULT_COORDINATES: [number, number] = [20, 0];
 const DEFAULT_ZOOM = 2;
 const MAX_CLIENT_LIMIT = 12000;
 const BBOX_PRECISION = 6;
-const ANTARCTICA_DEMO_NOTICE_STORAGE_KEY = "cpm_hide_antarctica_demo_notice";
 
 const PIN_SVGS: Record<PinType, string> = {
   owner: `<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g><path d="M16 2 C10 2,6 6.5,6 12 C6 20,16 30,16 30 C16 30,26 20,26 12 C26 6.5,22 2,16 2Z" fill="#F59E0B" stroke="white" stroke-width="2"/><circle cx="16" cy="12" r="4" fill="white"/></g></svg>`,
@@ -200,16 +199,8 @@ export default function MapClient() {
     setMounted(true);
   }, []);
 
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const hidden = window.localStorage.getItem(ANTARCTICA_DEMO_NOTICE_STORAGE_KEY) === "1";
-    setShowAntarcticaDemoNotice(!hidden);
-  }, []);
-
   const dismissAntarcticaDemoNotice = useCallback(() => {
     setShowAntarcticaDemoNotice(false);
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(ANTARCTICA_DEMO_NOTICE_STORAGE_KEY, "1");
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
### Motivation
- The Antarctica demo notice on `/map` was being permanently hidden via a `localStorage` key `cpm_hide_antarctica_demo_notice`, and the intent is to always show the demo notice on reload/ revisit. 
- Remove the persisted hide behavior so closing the notice only hides it for the current view session. 
- Keep existing copy, layout, and links unchanged while changing only behavior.

### Description
- Deleted the `cpm_hide_antarctica_demo_notice` constant and removed the `useEffect` that read from `localStorage` to hydrate the notice visibility. 
- Removed the `localStorage.setItem(...)` write from the dismiss handler so `dismissAntarcticaDemoNotice` now only calls `setShowAntarcticaDemoNotice(false)` (in-memory). 
- Left the initial state as `showAntarcticaDemoNotice = true` so the notice is shown on page load and unchanged render markup/links remain intact.

### Testing
- Ran `rg -n "cpm_hide_antarctica_demo_notice|localStorage" components/map/MapClient.tsx` and confirmed there are no matches related to the removed persistence. 
- Started the app with `npm run dev` and confirmed the `/map` page served successfully. 
- Executed an automated Playwright check which validated that the notice is initially visible (`true`), hides after clicking the close button on the page (`true`), and is visible again after reload and in a new tab (`visibleAfterReload: true`, `visibleInNewTab: true`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6434ed6f48328b9901674c133a10f)