### PR TITLE
submit: fix crash on multi-image add (stop dataUrl draft storage; use IndexedDB)

### DIFF
--- a/components/submit/SubmitConfirm.tsx
+++ b/components/submit/SubmitConfirm.tsx
@@ -8,7 +8,7 @@ import type { SubmissionKind } from "@/lib/submissions";
 import { submitMultipartSubmission } from "@/lib/submissions/client";
 
 import { buildSubmissionPayload } from "./payload";
-import { clearDraftBundle, hydrateFiles, loadDraftBundle } from "./draftStorage";
+import { buildPreviewUrl, clearDraftBundle, hydrateFiles, loadDraftBundle } from "./draftStorage";
 import type { DraftBundle, SubmissionDraftFiles } from "./types";
 import { validateDraft } from "./validation";
 
@@ -65,6 +65,8 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
   const [submissionError, setSubmissionError] = useState<string | null>(null);
   const [submissionErrorCode, setSubmissionErrorCode] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [storageError, setStorageError] = useState<string | null>(null);
+  const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
 
   useEffect(() => {
     const loaded = loadDraftBundle(kind);
@@ -79,6 +81,43 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
     if (!bundle?.files) return emptyFileState;
     return bundle.files;
   }, [bundle]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const nextUrls: Record<string, string> = {};
+
+    const hydratePreviews = async () => {
+      const allFiles = [...fileCounts.gallery, ...fileCounts.proof, ...fileCounts.evidence];
+      for (const file of allFiles) {
+        try {
+          nextUrls[file.id] = await buildPreviewUrl(file);
+        } catch {
+          // no-op
+        }
+      }
+
+      if (!cancelled) {
+        setPreviewUrls((prev) => {
+          Object.values(prev).forEach((url) => URL.revokeObjectURL(url));
+          return nextUrls;
+        });
+      } else {
+        Object.values(nextUrls).forEach((url) => URL.revokeObjectURL(url));
+      }
+    };
+
+    void hydratePreviews();
+    return () => {
+      cancelled = true;
+    };
+  }, [fileCounts]);
+
+  useEffect(
+    () => () => {
+      Object.values(previewUrls).forEach((url) => URL.revokeObjectURL(url));
+    },
+    [previewUrls],
+  );
 
   const submissionPayload = useMemo(() => {
     if (!bundle) return null;
@@ -150,7 +189,7 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
 
       const result = await submitMultipartSubmission(payload, hydratedFiles);
       if (result.ok && result.data?.submissionId) {
-        clearDraftBundle(kind);
+        await clearDraftBundle(kind, bundle.files);
         if (typeof window !== "undefined") {
           window.sessionStorage.setItem("submit-response", JSON.stringify(result.data));
         }
@@ -167,8 +206,10 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
         setSubmissionError("Submission failed.");
       }
     } catch (error) {
-      setSubmissionErrorCode("NETWORK_ERROR");
-      setSubmissionError((error as Error)?.message ?? "Submission failed.");
+      setSubmissionErrorCode("STORAGE_OR_NETWORK_ERROR");
+      const message = (error as Error)?.message ?? "Submission failed.";
+      setSubmissionError(message);
+      setStorageError(message);
     } finally {
       setIsSubmitting(false);
     }
@@ -214,6 +255,10 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
             <p className="font-semibold">{submissionErrorCode}</p>
             <p>{submissionError}</p>
           </div>
+        ) : null}
+
+        {storageError ? (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-red-800">{storageError}</div>
         ) : null}
 
         <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-4">
@@ -320,7 +365,13 @@ export default function SubmitConfirm({ kind }: { kind: SubmissionKind }) {
                   {entries.map((file, index) => (
                     <li key={`${field}-${file.name}-${index}`} className="rounded border border-gray-200 bg-white p-2">
                       <div className="aspect-square overflow-hidden rounded bg-gray-100">
-                        <img src={file.dataUrl} alt={file.name} className="h-full w-full object-cover" />
+                        {previewUrls[file.id] ? (
+                          <img src={previewUrls[file.id]} alt={file.name} className="h-full w-full object-cover" />
+                        ) : (
+                          <div className="flex h-full items-center justify-center text-xs text-gray-500">
+                            Preview unavailable
+                          </div>
+                        )}
                       </div>
                       <p className="mt-2 text-xs text-gray-700">#{index + 1} {file.name}</p>
                     </li>

--- a/components/submit/SubmitForm.tsx
+++ b/components/submit/SubmitForm.tsx
@@ -11,7 +11,7 @@ import type { SubmissionKind } from "@/lib/submissions";
 import PaymentAcceptsEditor from "./PaymentAcceptsEditor";
 import LimitedTextarea from "./LimitedTextarea";
 import { FILE_LIMITS, MAX_LENGTHS } from "./constants";
-import { loadDraftBundle, saveDraftBundle, serializeFiles } from "./draftStorage";
+import { buildPreviewUrl, loadDraftBundle, removeStoredFile, saveDraftBundle, storeFile } from "./draftStorage";
 import type { OwnerCommunityDraft, ReportDraft, SubmissionDraft, SubmissionDraftFiles, StoredFile } from "./types";
 import { validateDraft } from "./validation";
 
@@ -82,12 +82,14 @@ type SubmitFormProps = {
 
 const AttachmentList = ({
   files,
+  previewUrls,
   onRemove,
   onReorder,
   onMoveUp,
   onMoveDown,
 }: {
   files: StoredFile[];
+  previewUrls: Record<string, string>;
   onRemove: (index: number) => void;
   onReorder: (from: number, to: number) => void;
   onMoveUp: (index: number) => void;
@@ -118,7 +120,11 @@ const AttachmentList = ({
           }}
         >
           <div className="aspect-square overflow-hidden rounded bg-gray-100">
-            <img src={file.dataUrl} alt={file.name} className="h-full w-full object-cover" />
+            {previewUrls[file.id] ? (
+              <img src={previewUrls[file.id]} alt={file.name} className="h-full w-full object-cover" />
+            ) : (
+              <div className="flex h-full items-center justify-center text-xs text-gray-500">Preview unavailable</div>
+            )}
           </div>
           <div className="mt-2 flex items-center justify-between text-xs text-gray-500">
             <span className="font-semibold" aria-hidden>≡</span>
@@ -173,6 +179,8 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
   const [limitedMode, setLimitedMode] = useState(false);
   const [initialized, setInitialized] = useState(false);
   const [activeDropField, setActiveDropField] = useState<keyof SubmissionDraftFiles | null>(null);
+  const [storageError, setStorageError] = useState<string | null>(null);
+  const [previewUrls, setPreviewUrls] = useState<Record<string, string>>({});
   const proofInputRef = useRef<HTMLInputElement | null>(null);
   const galleryInputRef = useRef<HTMLInputElement | null>(null);
   const evidenceInputRef = useRef<HTMLInputElement | null>(null);
@@ -204,8 +212,45 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
 
   useEffect(() => {
     if (!initialized) return;
-    saveDraftBundle(kind, draft, files);
+    const error = saveDraftBundle(kind, draft, files);
+    setStorageError(error);
   }, [draft, files, initialized, kind]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const nextUrls: Record<string, string> = {};
+
+    const hydratePreviews = async () => {
+      const allFiles = [...files.gallery, ...files.proof, ...files.evidence];
+      for (const file of allFiles) {
+        try {
+          nextUrls[file.id] = await buildPreviewUrl(file);
+        } catch {
+          // no-op
+        }
+      }
+      if (!cancelled) {
+        setPreviewUrls((prev) => {
+          Object.values(prev).forEach((url) => URL.revokeObjectURL(url));
+          return nextUrls;
+        });
+      } else {
+        Object.values(nextUrls).forEach((url) => URL.revokeObjectURL(url));
+      }
+    };
+
+    void hydratePreviews();
+    return () => {
+      cancelled = true;
+    };
+  }, [files]);
+
+  useEffect(
+    () => () => {
+      Object.values(previewUrls).forEach((url) => URL.revokeObjectURL(url));
+    },
+    [previewUrls],
+  );
 
   const citiesForCountry = useMemo(() => {
     if (!meta || draft.kind === "report") return [];
@@ -284,8 +329,15 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
         if (strictSingleField) newErrors[field] = "Unsupported file type";
         continue;
       }
-      const [stored] = await serializeFiles([file]);
-      nextFiles.push(stored);
+      try {
+        const stored = await storeFile(file);
+        nextFiles.push(stored);
+      } catch (error) {
+        const message = (error as Error)?.message || "Failed to store file in browser storage.";
+        messages.push(`storage_error: ${file.name} (${message})`);
+        newErrors[field] = message;
+        setStorageError(message);
+      }
     }
 
     setErrors((prev) => ({ ...prev, ...newErrors }));
@@ -294,10 +346,18 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
   };
 
   const handleFileRemove = (field: keyof SubmissionDraftFiles, index: number) => {
-    setFiles((prev) => ({
-      ...prev,
-      [field]: prev[field].filter((_, i) => i !== index),
-    }));
+    setFiles((prev) => {
+      const removed = prev[field][index];
+      if (removed) {
+        void removeStoredFile(removed).catch(() => {
+          setStorageError("Failed to remove a stored attachment. Please refresh and try again.");
+        });
+      }
+      return {
+        ...prev,
+        [field]: prev[field].filter((_, i) => i !== index),
+      };
+    });
   };
 
   const handleFileReorder = (field: keyof SubmissionDraftFiles, from: number, to: number) => {
@@ -363,7 +423,9 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
     const validationErrors = validateDraft(kind, draft, files);
     setErrors(validationErrors);
     if (Object.keys(validationErrors).length) return;
-    saveDraftBundle(kind, draft, files);
+    const saveError = saveDraftBundle(kind, draft, files);
+    setStorageError(saveError);
+    if (saveError) return;
     router.push(`/submit/${kind}/confirm`);
   };
 
@@ -402,6 +464,9 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
         </div>
 
         {limitedMode ? <LimitedModeNotice className="w-full max-w-sm" /> : null}
+        {storageError ? (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800">{storageError}</div>
+        ) : null}
 
         {kind !== "report" && ownerDraft ? (
           <div className="rounded-lg bg-white p-4 shadow-sm border border-gray-100 space-y-4">
@@ -697,6 +762,7 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
                   ) : null}
                   <AttachmentList
                     files={files.proof}
+                    previewUrls={previewUrls}
                     onRemove={(index) => handleFileRemove("proof", index)}
                     onReorder={(from, to) => handleFileReorder("proof", from, to)}
                     onMoveUp={(index) => handleFileMoveUp("proof", index)}
@@ -934,6 +1000,7 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
               ) : null}
               <AttachmentList
                 files={files.gallery}
+                previewUrls={previewUrls}
                 onRemove={(index) => handleFileRemove("gallery", index)}
                 onReorder={(from, to) => handleFileReorder("gallery", from, to)}
                 onMoveUp={(index) => handleFileMoveUp("gallery", index)}
@@ -980,6 +1047,7 @@ export default function SubmitForm({ kind }: SubmitFormProps) {
               ) : null}
               <AttachmentList
                 files={files.evidence}
+                previewUrls={previewUrls}
                 onRemove={(index) => handleFileRemove("evidence", index)}
                 onReorder={(from, to) => handleFileReorder("evidence", from, to)}
                 onMoveUp={(index) => handleFileMoveUp("evidence", index)}

--- a/components/submit/draftStorage.ts
+++ b/components/submit/draftStorage.ts
@@ -3,39 +3,113 @@ import type { SubmissionKind } from "@/lib/submissions";
 import type { DraftBundle, StoredFile, SubmissionDraft, SubmissionDraftFiles } from "./types";
 
 const DRAFT_PREFIX = "submit-draft";
+const FILE_DB_NAME = "submit-draft-files";
+const FILE_STORE_NAME = "files";
 
 const buildKey = (kind: SubmissionKind) => `${DRAFT_PREFIX}:${kind}`;
+const buildBlobId = () =>
+  typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
-const readFileAsDataUrl = (file: File): Promise<string> =>
+const openFileDb = (): Promise<IDBDatabase> =>
   new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result));
-    reader.onerror = () => reject(reader.error);
-    reader.readAsDataURL(file);
+    if (typeof window === "undefined" || typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB is not available in this environment."));
+      return;
+    }
+
+    const request = indexedDB.open(FILE_DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(FILE_STORE_NAME)) {
+        db.createObjectStore(FILE_STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Failed to open IndexedDB."));
   });
 
-export const serializeFiles = async (files: File[]): Promise<StoredFile[]> => {
-  const stored: StoredFile[] = [];
-  for (const file of files) {
-    stored.push({
-      name: file.name,
-      type: file.type,
-      size: file.size,
-      lastModified: file.lastModified,
-      dataUrl: await readFileAsDataUrl(file),
-    });
-  }
-  return stored;
+const putFileBlob = async (id: string, file: File): Promise<void> => {
+  const db = await openFileDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(FILE_STORE_NAME, "readwrite");
+    tx.objectStore(FILE_STORE_NAME).put(file, id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error("Failed to store file in IndexedDB."));
+    tx.onabort = () => reject(tx.error ?? new Error("Failed to store file in IndexedDB."));
+  });
+  db.close();
+};
+
+const getFileBlob = async (id: string): Promise<Blob | null> => {
+  const db = await openFileDb();
+  const file = await new Promise<Blob | null>((resolve, reject) => {
+    const tx = db.transaction(FILE_STORE_NAME, "readonly");
+    const request = tx.objectStore(FILE_STORE_NAME).get(id);
+    request.onsuccess = () => resolve((request.result as Blob | undefined) ?? null);
+    request.onerror = () => reject(request.error ?? new Error("Failed to read file from IndexedDB."));
+  });
+  db.close();
+  return file;
+};
+
+const deleteFileBlob = async (id: string): Promise<void> => {
+  const db = await openFileDb();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(FILE_STORE_NAME, "readwrite");
+    tx.objectStore(FILE_STORE_NAME).delete(id);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error("Failed to remove file from IndexedDB."));
+    tx.onabort = () => reject(tx.error ?? new Error("Failed to remove file from IndexedDB."));
+  });
+  db.close();
+};
+
+const normalizeFiles = (files?: SubmissionDraftFiles): SubmissionDraftFiles => ({
+  gallery: files?.gallery ?? [],
+  proof: files?.proof ?? [],
+  evidence: files?.evidence ?? [],
+});
+
+export const storeFile = async (file: File): Promise<StoredFile> => {
+  const id = buildBlobId();
+  await putFileBlob(id, file);
+  return {
+    id,
+    name: file.name,
+    type: file.type,
+    size: file.size,
+    lastModified: file.lastModified,
+  };
+};
+
+export const buildPreviewUrl = async (file: StoredFile): Promise<string> => {
+  const blob = await getFileBlob(file.id);
+  if (!blob) throw new Error(`Attachment is unavailable: ${file.name}`);
+  return URL.createObjectURL(blob);
 };
 
 export const hydrateFiles = async (stored: StoredFile[]): Promise<File[]> => {
   const files: File[] = [];
   for (const entry of stored) {
-    const response = await fetch(entry.dataUrl);
-    const blob = await response.blob();
+    const blob = await getFileBlob(entry.id);
+    if (!blob) {
+      throw new Error(`Attachment is unavailable: ${entry.name}`);
+    }
     files.push(new File([blob], entry.name, { type: entry.type || blob.type, lastModified: entry.lastModified }));
   }
   return files;
+};
+
+export const removeStoredFile = async (file: StoredFile): Promise<void> => {
+  await deleteFileBlob(file.id);
+};
+
+export const removeStoredFiles = async (files: StoredFile[]): Promise<void> => {
+  for (const file of files) {
+    await deleteFileBlob(file.id);
+  }
 };
 
 export const loadDraftBundle = (kind: SubmissionKind): DraftBundle | null => {
@@ -43,25 +117,44 @@ export const loadDraftBundle = (kind: SubmissionKind): DraftBundle | null => {
   const raw = window.sessionStorage.getItem(buildKey(kind));
   if (!raw) return null;
   try {
-    return JSON.parse(raw) as DraftBundle;
+    const parsed = JSON.parse(raw) as DraftBundle;
+    return {
+      ...parsed,
+      files: normalizeFiles(parsed.files),
+    };
   } catch (error) {
     console.warn("Failed to parse draft bundle", error);
     return null;
   }
 };
 
-export const saveDraftBundle = (kind: SubmissionKind, payload: SubmissionDraft, files: SubmissionDraftFiles) => {
-  if (typeof window === "undefined") return;
+export const saveDraftBundle = (kind: SubmissionKind, payload: SubmissionDraft, files: SubmissionDraftFiles): string | null => {
+  if (typeof window === "undefined") return null;
   const bundle: DraftBundle = {
     kind,
     payload,
-    files,
+    files: normalizeFiles(files),
     updatedAt: new Date().toISOString(),
   };
-  window.sessionStorage.setItem(buildKey(kind), JSON.stringify(bundle));
+  try {
+    window.sessionStorage.setItem(buildKey(kind), JSON.stringify(bundle));
+    return null;
+  } catch (error) {
+    console.error("Failed to save draft bundle", error);
+    return "Failed to save draft state in this browser. Please free storage and try again.";
+  }
 };
 
-export const clearDraftBundle = (kind: SubmissionKind) => {
-  if (typeof window === "undefined") return;
-  window.sessionStorage.removeItem(buildKey(kind));
+export const clearDraftBundle = async (kind: SubmissionKind, files?: SubmissionDraftFiles) => {
+  if (typeof window !== "undefined") {
+    window.sessionStorage.removeItem(buildKey(kind));
+  }
+  const normalized = normalizeFiles(files);
+  const allFiles = [...normalized.gallery, ...normalized.proof, ...normalized.evidence];
+  if (!allFiles.length) return;
+  try {
+    await removeStoredFiles(allFiles);
+  } catch (error) {
+    console.warn("Failed to cleanup draft files", error);
+  }
 };

--- a/components/submit/types.ts
+++ b/components/submit/types.ts
@@ -55,11 +55,11 @@ export type ReportDraft = {
 export type SubmissionDraft = OwnerCommunityDraft | ReportDraft;
 
 export type StoredFile = {
+  id: string;
   name: string;
   type: string;
   size: number;
   lastModified: number;
-  dataUrl: string;
 };
 
 export type SubmissionDraftFiles = {

--- a/tests/submit-validation.test.ts
+++ b/tests/submit-validation.test.ts
@@ -49,11 +49,11 @@ const baseCommunityDraft = (): OwnerCommunityDraft => ({
 const emptyFiles = (): SubmissionDraftFiles => ({ gallery: [], proof: [], evidence: [] });
 
 const sampleProofFile = {
+  id: "proof-1",
   name: "proof.png",
   type: "image/png",
   size: 100,
   lastModified: 1,
-  dataUrl: "data:image/png;base64,AAAA",
 };
 
 test("owner requires payment URL or screenshot", () => {


### PR DESCRIPTION
### Motivation
- Prevent crashes when users add many gallery images at once by removing data-URL serialization into `sessionStorage` which could overflow and crash the app.
- Keep only lightweight file metadata in the draft and store binary blobs in IndexedDB so multi-file add and preview remain reliable.
- Surface actionable UI errors when browser storage fails instead of triggering the global "Something went wrong" boundary.

### Description
- Replaced dataUrl-based draft persistence with an IndexedDB-backed blob store in `components/submit/draftStorage.ts`, exposing `storeFile`, `hydrateFiles`, `buildPreviewUrl`, `removeStoredFile(s)`, `loadDraftBundle`, `saveDraftBundle`, and `clearDraftBundle` (now cleans stored blobs on submit).
- Switched `StoredFile` shape in `components/submit/types.ts` to remove `dataUrl` and add an `id` so drafts store only metadata + blob id.
- Updated `SubmitForm.tsx` to persist selected files to IndexedDB via `storeFile`, handle storage exceptions (set `storageError` and file-level messages), and show previews with `buildPreviewUrl`; reordering/removal preserve metadata order and clean blobs.
- Updated `SubmitConfirm.tsx` to resolve previews from IndexedDB, hydrate files via `hydrateFiles` before final `submitMultipartSubmission`, clear draft + blobs on success, and display storage/network errors (no uncaught exceptions on large uploads).
- Adjusted test fixture in `tests/submit-validation.test.ts` to include the new `id` property for `StoredFile`.

### Testing
- Ran `npm run lint` and the linter completed (existing unrelated image-element warnings remain).
- Ran type-check + unit tests with `tsc --project tsconfig.test.json && node --test .tmp-tests/tests/submit-validation.test.js` and the submit validation tests passed.
- Ran the project test suite `npm run test:stats` where one unrelated test failed due to a preexisting module alias resolution issue in the test harness (`@/lib/db`), not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7842ddab48328b20ff96d225706f6)