### PR TITLE
PR-01: Home hero map-first UX with total places and static preview

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import Image from 'next/image';
 import { buildPageMetadata } from '@/lib/seo/metadata';
+import { HomeTotalPlaces } from '@/components/home/HomeTotalPlaces';
 
 const SUPPORTED_PAYMENTS = [
   {
@@ -72,23 +74,40 @@ export default function HomePage() {
           <p>Check trusted listing signals before visiting and compare options by area.</p>
           <p>Help keep the map fresh by submitting new places and updates.</p>
         </div>
-        <div className="mt-7 flex flex-wrap gap-3">
-          <Link href="/map" className="rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white">
+
+        <HomeTotalPlaces />
+
+        <div className="mt-6">
+          <Link
+            href="/map"
+            className="inline-flex w-full items-center justify-center rounded-full bg-gray-900 px-5 py-3 text-sm font-semibold text-white sm:w-auto"
+          >
             Open Map
           </Link>
-          <Link
-            href="/discover"
-            className="rounded-full border border-gray-200 px-5 py-2.5 text-sm font-semibold text-gray-700"
-          >
-            Discover
-          </Link>
-          <Link
-            href="/submit"
-            className="rounded-full border border-gray-200 px-5 py-2.5 text-sm font-semibold text-gray-700"
-          >
-            Submit
-          </Link>
+          <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 text-sm font-medium text-gray-600">
+            <Link href="/discover" className="hover:text-gray-900 hover:underline">
+              Explore listings → Discover
+            </Link>
+            <Link href="/submit" className="hover:text-gray-900 hover:underline">
+              Add a place → Submit
+            </Link>
+          </div>
         </div>
+
+        <Link
+          href="/map"
+          className="group mt-6 block overflow-hidden rounded-2xl border border-gray-200 bg-gray-50 p-2 transition hover:border-gray-300"
+          aria-label="Open map preview and go to the map"
+        >
+          <Image
+            src="/map-preview.svg"
+            alt="Preview of crypto-friendly places around the world"
+            width={1400}
+            height={720}
+            className="h-auto w-full rounded-xl border border-gray-100 object-cover"
+            priority
+          />
+        </Link>
       </section>
 
       <section className="w-full rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-10" aria-label="Home SEO content">

--- a/components/home/HomeTotalPlaces.tsx
+++ b/components/home/HomeTotalPlaces.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type StatsResponse = {
+  total_places?: number;
+};
+
+const formatter = new Intl.NumberFormat('en-US');
+
+export function HomeTotalPlaces() {
+  const [totalPlaces, setTotalPlaces] = useState<number | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadStats = async () => {
+      try {
+        const response = await fetch('/api/stats', {
+          method: 'GET',
+          signal: controller.signal,
+          cache: 'no-store',
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const data = (await response.json()) as StatsResponse;
+        if (typeof data.total_places === 'number') {
+          setTotalPlaces(data.total_places);
+        }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          return;
+        }
+        console.warn('Failed to load total places.');
+      }
+    };
+
+    void loadStats();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return <p className="mt-6 text-sm font-medium text-gray-700 sm:text-base">{totalPlaces === null ? '—' : formatter.format(totalPlaces)} crypto-friendly places worldwide</p>;
+}

--- a/public/map-preview.svg
+++ b/public/map-preview.svg
@@ -1,0 +1,21 @@
+<svg width="1400" height="720" viewBox="0 0 1400 720" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Map preview with highlighted crypto-friendly places">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1400" y2="720" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#EFF6FF"/>
+      <stop offset="1" stop-color="#F8FAFC"/>
+    </linearGradient>
+  </defs>
+  <rect width="1400" height="720" rx="24" fill="url(#bg)"/>
+  <path d="M142 246C300 126 475 125 596 184C717 243 805 292 948 255C1060 226 1192 240 1258 291" stroke="#CBD5E1" stroke-width="32" stroke-linecap="round"/>
+  <path d="M194 487C310 392 478 365 591 403C735 451 838 522 986 496C1089 478 1187 507 1248 545" stroke="#D1D5DB" stroke-width="28" stroke-linecap="round"/>
+  <g fill="#0F172A" opacity="0.9">
+    <circle cx="310" cy="221" r="13"/><circle cx="403" cy="196" r="10"/><circle cx="500" cy="233" r="11"/>
+    <circle cx="655" cy="268" r="14"/><circle cx="773" cy="312" r="12"/><circle cx="908" cy="272" r="11"/>
+    <circle cx="1041" cy="250" r="13"/><circle cx="1164" cy="278" r="10"/><circle cx="970" cy="500" r="12"/>
+    <circle cx="840" cy="522" r="10"/><circle cx="694" cy="471" r="12"/><circle cx="552" cy="430" r="11"/>
+    <circle cx="434" cy="409" r="10"/><circle cx="324" cy="447" r="12"/><circle cx="1146" cy="534" r="11"/>
+  </g>
+  <rect x="36" y="36" width="250" height="62" rx="31" fill="#111827"/>
+  <text x="161" y="75" text-anchor="middle" fill="white" font-size="28" font-family="Arial, sans-serif" font-weight="700">Open Map</text>
+  <text x="700" y="656" text-anchor="middle" fill="#475569" font-size="28" font-family="Arial, sans-serif">Map preview (click to explore)</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Make the home hero clearly prioritize entering the map so users can reach `/map` in one click. 
- Surface listing trust by showing `total_places` in the hero to increase credibility and click-through. 
- Provide a lightweight visual cue (static map preview) that links to `/map` without loading any client map library on the top page.

### Description
- Reworked the home hero so `Open Map` is the single primary CTA and `Discover`/`Submit` are secondary inline links below it in the hero. 
- Added a client-only component `HomeTotalPlaces` that fetches `/api/stats` and displays `total_places` formatted for humans with a safe `—` fallback when unavailable. 
- Added a static preview asset `public/map-preview.svg` and integrated it into the hero as a clickable block that navigates to `/map` (the hero does not import or start Leaflet or other map clients). 
- Kept the rest of the home content (Supported payments, Browse by region, How verification works, FAQ, Support this project) unchanged in structure and order.

### Testing
- Ran `npm run lint`, which completed successfully (repository has unrelated pre-existing ESLint warnings). 
- Ran `npm run build`, which completed successfully (build warnings/deopt notices are pre-existing and unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8292d0cd08328a8358b87bcb9101b)