### PR TITLE
PR-02b: Make /accepts/[asset] usable — cards, totals, sorting, country filter

### DIFF
--- a/app/accepts/[asset]/page.tsx
+++ b/app/accepts/[asset]/page.tsx
@@ -9,6 +9,7 @@ import { buildPageMetadata } from "@/lib/seo/metadata";
 
 type AcceptsAssetPageProps = {
   params: { asset: string };
+  searchParams?: { country?: string };
 };
 
 const MAX_RESULTS = 50;
@@ -31,7 +32,21 @@ export async function generateMetadata({ params }: AcceptsAssetPageProps): Promi
   });
 }
 
-export default async function AcceptsAssetPage({ params }: AcceptsAssetPageProps) {
+const verificationMeta = {
+  owner: { label: "Owner", className: "bg-emerald-100 text-emerald-800" },
+  community: { label: "Community", className: "bg-sky-100 text-sky-800" },
+  directory: { label: "Community", className: "bg-sky-100 text-sky-800" },
+  unverified: { label: "Unverified", className: "bg-gray-100 text-gray-700" },
+} as const;
+
+const verificationRank: Record<keyof typeof verificationMeta, number> = {
+  owner: 0,
+  community: 1,
+  directory: 1,
+  unverified: 2,
+};
+
+export default async function AcceptsAssetPage({ params, searchParams }: AcceptsAssetPageProps) {
   const asset = normalizeAcceptsAsset(params.asset);
   if (!asset) notFound();
 
@@ -53,6 +68,22 @@ export default async function AcceptsAssetPage({ params }: AcceptsAssetPageProps
   });
 
   const assetLabel = getAcceptsAssetLabel(asset);
+  const countries = Array.from(new Set(result.places.map((place) => place.country).filter(Boolean))).sort((a, b) => a.localeCompare(b));
+  const countryFilter = (searchParams?.country ?? "").trim().toUpperCase();
+
+  const sortedPlaces = [...result.places].sort((a, b) => {
+    const byVerification = verificationRank[a.verification] - verificationRank[b.verification];
+    if (byVerification !== 0) return byVerification;
+
+    const byName = a.name.localeCompare(b.name);
+    if (byName !== 0) return byName;
+
+    return a.id.localeCompare(b.id);
+  });
+
+  const visiblePlaces = countryFilter
+    ? sortedPlaces.filter((place) => place.country.toUpperCase() === countryFilter)
+    : sortedPlaces;
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
@@ -68,17 +99,48 @@ export default async function AcceptsAssetPage({ params }: AcceptsAssetPageProps
       </div>
 
       <section className="mt-8 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
-        <h2 className="text-lg font-semibold text-gray-900">Showing first {MAX_RESULTS} places</h2>
-        {result.places.length === 0 ? (
+        <h2 className="text-lg font-semibold text-gray-900">Total: {result.total} places · Showing first {MAX_RESULTS}</h2>
+        <form className="mt-4">
+          <label htmlFor="country" className="text-sm font-medium text-gray-700">Country</label>
+          <div className="mt-1 flex items-center gap-2">
+            <select
+              id="country"
+              name="country"
+              defaultValue={countryFilter}
+              className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-800"
+            >
+              <option value="">All countries</option>
+              {countries.map((country) => (
+                <option key={country} value={country.toUpperCase()}>{country.toUpperCase()}</option>
+              ))}
+            </select>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Apply
+            </button>
+          </div>
+        </form>
+
+        {visiblePlaces.length === 0 ? (
           <p className="mt-3 text-sm text-gray-600">No places found for this asset yet.</p>
         ) : (
-          <ul className="mt-4 space-y-2">
-            {result.places.map((place) => (
-              <li key={place.id}>
-                <Link href={`/place/${encodeURIComponent(place.id)}`} className="text-sky-700 hover:underline">
+          <ul className="mt-4 space-y-3">
+            {visiblePlaces.map((place) => (
+              <li key={place.id} className="rounded-lg border border-gray-200 p-4">
+                <Link href={`/place/${encodeURIComponent(place.id)}`} className="text-base font-semibold text-sky-700 hover:underline">
                   {place.name}
                 </Link>
-                <span className="ml-2 text-sm text-gray-500">{[place.city, place.country].filter(Boolean).join(", ")}</span>
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
+                  <span>{place.category || "Unknown category"}</span>
+                  <span aria-hidden="true">/</span>
+                  <span>{[place.city, place.country].filter(Boolean).join(", ") || "Location unknown"}</span>
+                  <span aria-hidden="true">/</span>
+                  <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${verificationMeta[place.verification].className}`}>
+                    {verificationMeta[place.verification].label}
+                  </span>
+                </div>
               </li>
             ))}
           </ul>

--- a/app/accepts/[asset]/page.tsx
+++ b/app/accepts/[asset]/page.tsx
@@ -35,7 +35,7 @@ export async function generateMetadata({ params }: AcceptsAssetPageProps): Promi
 const verificationMeta = {
   owner: { label: "Owner", className: "bg-emerald-100 text-emerald-800" },
   community: { label: "Community", className: "bg-sky-100 text-sky-800" },
-  directory: { label: "Community", className: "bg-sky-100 text-sky-800" },
+  directory: { label: "Directory", className: "bg-sky-100 text-sky-800" },
   unverified: { label: "Unverified", className: "bg-gray-100 text-gray-700" },
 } as const;
 
@@ -82,7 +82,7 @@ export default async function AcceptsAssetPage({ params, searchParams }: Accepts
   });
 
   const visiblePlaces = countryFilter
-    ? sortedPlaces.filter((place) => place.country.toUpperCase() === countryFilter)
+    ? sortedPlaces.filter((place) => (place.country ?? "").toUpperCase() === countryFilter)
     : sortedPlaces;
 
   return (

--- a/lib/places/listPlacesForMap.ts
+++ b/lib/places/listPlacesForMap.ts
@@ -46,6 +46,7 @@ export type ListPlacesForMapOptions = {
 
 export type ListPlacesForMapResult = {
   places: PlaceSummaryPlus[];
+  total: number;
   source: "db" | "json";
   limited: boolean;
   lastUpdatedISO?: string;
@@ -86,7 +87,7 @@ const loadPlacesFromSnapshot = async (): Promise<PublishedSnapshot> => {
   throw new Error("FALLBACK_SNAPSHOT_UNAVAILABLE");
 };
 
-const loadPlacesFromDb = async (filters: ListFilters): Promise<PlaceSummaryPlus[] | null> => {
+const loadPlacesFromDb = async (filters: ListFilters): Promise<{ places: PlaceSummaryPlus[]; total: number } | null> => {
   if (!hasDatabaseUrl()) return null;
   const route = "api_places";
   const fallbackById = new Map(fallbackPlaces.map((place) => [place.id, place]));
@@ -169,7 +170,7 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<PlaceSummaryPlus[
 
   if (filters.verification.length) {
     if (!verificationField) {
-      if (!filters.verification.every((v) => v === "unverified")) return [];
+      if (!filters.verification.every((v) => v === "unverified")) return { places: [], total: 0 };
     } else {
       params.push(filters.verification);
       where.push(`COALESCE(${verificationField}, 'unverified') = ANY($${params.length}::text[])`);
@@ -177,13 +178,13 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<PlaceSummaryPlus[
   }
 
   if (filters.asset) {
-    if (!hasPayments) return [];
+    if (!hasPayments) return { places: [], total: 0 };
     params.push(filters.asset);
     where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND UPPER(COALESCE(pa.asset, '')) = $${params.length})`);
   }
 
   if (filters.payment.length) {
-    if (!hasPayments) return [];
+    if (!hasPayments) return { places: [], total: 0 };
     params.push(filters.payment);
     where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND (LOWER(pa.asset) = ANY($${params.length}::text[]) OR LOWER(pa.chain) = ANY($${params.length}::text[])))`);
   }
@@ -198,15 +199,25 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<PlaceSummaryPlus[
   const amenitiesSelect = hasCol("amenities") ? "p.amenities" : "NULL::text[] AS amenities";
   const paymentNoteSelect = hasCol("payment_note") ? "p.payment_note" : "NULL::text AS payment_note";
 
+  const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
   const query = `SELECT p.id, p.name, p.category, p.city, p.country, p.lat, p.lng, ${addressSelect}, ${aboutSelect}, ${amenitiesSelect}, ${paymentNoteSelect}${verificationSelect}
     FROM places p${joinVerification}
-    ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+    ${whereClause}
     ${orderBy}
     LIMIT $${params.length + 1}
     OFFSET $${params.length + 2}`;
-  params.push(filters.limit, filters.offset);
 
-  const { rows } = await dbQuery<{ id: string; name: string; category: string | null; city: string | null; country: string | null; lat: number; lng: number; address: string | null; about: string | null; amenities: string[] | string | null; payment_note: string | null; verification: string | null }>(query, params, { route });
+  const countQuery = `SELECT COUNT(DISTINCT p.id)::int AS total
+    FROM places p${joinVerification}
+    ${whereClause}`;
+
+  const [countResult, placesResult] = await Promise.all([
+    dbQuery<{ total: number }>(countQuery, params, { route }),
+    dbQuery<{ id: string; name: string; category: string | null; city: string | null; country: string | null; lat: number; lng: number; address: string | null; about: string | null; amenities: string[] | string | null; payment_note: string | null; verification: string | null }>(query, [...params, filters.limit, filters.offset], { route }),
+  ]);
+  const total = Number(countResult.rows[0]?.total ?? 0);
+  const rows = placesResult.rows;
 
   const placeIds = rows.map((row) => row.id);
   const paymentsByPlace = new Map<string, PaymentAccept[]>();
@@ -258,7 +269,7 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<PlaceSummaryPlus[
     }
   }
 
-  return rows
+  const places = rows
     .map((row) => {
       const fallback = fallbackById.get(row.id);
       const accepted = hasPayments
@@ -292,6 +303,11 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<PlaceSummaryPlus[
       return sanitizeOptionalStrings(summary);
     })
     .filter((place) => !isLegacyOrDemoId(place.id));
+
+  return {
+    places,
+    total,
+  };
 };
 
 export async function listPlacesForMap(options: ListPlacesForMapOptions): Promise<ListPlacesForMapResult> {
@@ -299,7 +315,7 @@ export async function listPlacesForMap(options: ListPlacesForMapOptions): Promis
     try {
       const dbPlaces = await loadPlacesFromDb(options.filters);
       if (dbPlaces) {
-        return { places: dbPlaces, source: "db", limited: false };
+        return { places: dbPlaces.places, total: dbPlaces.total, source: "db", limited: false };
       }
     } catch (error) {
       if (options.dataSource === "db") {
@@ -352,6 +368,7 @@ export async function listPlacesForMap(options: ListPlacesForMapOptions): Promis
 
   return {
     places,
+    total: filtered.length,
     source: "json",
     limited: true,
     lastUpdatedISO: normalizeText(snapshot.meta?.last_updated) ?? undefined,

--- a/lib/places/listPlacesForMap.ts
+++ b/lib/places/listPlacesForMap.ts
@@ -114,25 +114,25 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<{ places: PlaceSu
   const hasCol = (name: string) => placeColumns.some((r) => r.column_name === name);
 
   const where: string[] = [...getMapDisplayableWhereClauses("p")];
-  const params: unknown[] = [];
+  const paramsWhere: unknown[] = [];
 
   if (filters.category) {
-    params.push(filters.category);
-    where.push(`p.category = $${params.length}`);
+    paramsWhere.push(filters.category);
+    where.push(`p.category = $${paramsWhere.length}`);
   }
   if (filters.country) {
-    params.push(filters.country);
-    where.push(`p.country = $${params.length}`);
+    paramsWhere.push(filters.country);
+    where.push(`p.country = $${paramsWhere.length}`);
   }
   if (filters.city) {
-    params.push(filters.city);
-    where.push(`p.city = $${params.length}`);
+    paramsWhere.push(filters.city);
+    where.push(`p.city = $${paramsWhere.length}`);
   }
   if (hasCol("status")) where.push("COALESCE(p.status, 'published') = 'published'");
   if (hasCol("is_demo")) where.push("COALESCE(p.is_demo, false) = false");
 
-  params.push(Array.from(LEGACY_TEST_IDS));
-  where.push(`NOT (p.id = ANY($${params.length}::text[]))`);
+  paramsWhere.push(Array.from(LEGACY_TEST_IDS));
+  where.push(`NOT (p.id = ANY($${paramsWhere.length}::text[]))`);
 
   const hasVerifications = Boolean(tableChecks[0]?.verifications);
   const hasPayments = Boolean(tableChecks[0]?.payments);
@@ -151,12 +151,12 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<{ places: PlaceSu
     const useGeom = hasCol("geom");
     const clauses: string[] = [];
     for (const bbox of filters.bbox) {
-      const start = params.length + 1;
+      const start = paramsWhere.length + 1;
       if (useGeom) {
-        params.push(bbox.minLng, bbox.minLat, bbox.maxLng, bbox.maxLat);
+        paramsWhere.push(bbox.minLng, bbox.minLat, bbox.maxLng, bbox.maxLat);
         clauses.push(`ST_Intersects(p.geom::geometry, ST_MakeEnvelope($${start}, $${start + 1}, $${start + 2}, $${start + 3}, 4326))`);
       } else {
-        params.push(bbox.minLng, bbox.maxLng, bbox.minLat, bbox.maxLat);
+        paramsWhere.push(bbox.minLng, bbox.maxLng, bbox.minLat, bbox.maxLat);
         clauses.push(`(p.lng BETWEEN $${start} AND $${start + 1} AND p.lat BETWEEN $${start + 2} AND $${start + 3})`);
       }
     }
@@ -164,29 +164,29 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<{ places: PlaceSu
   }
 
   if (filters.search) {
-    params.push(`%${filters.search}%`);
-    where.push(`(p.name ILIKE $${params.length} OR COALESCE(p.address, '') ILIKE $${params.length})`);
+    paramsWhere.push(`%${filters.search}%`);
+    where.push(`(p.name ILIKE $${paramsWhere.length} OR COALESCE(p.address, '') ILIKE $${paramsWhere.length})`);
   }
 
   if (filters.verification.length) {
     if (!verificationField) {
       if (!filters.verification.every((v) => v === "unverified")) return { places: [], total: 0 };
     } else {
-      params.push(filters.verification);
-      where.push(`COALESCE(${verificationField}, 'unverified') = ANY($${params.length}::text[])`);
+      paramsWhere.push(filters.verification);
+      where.push(`COALESCE(${verificationField}, 'unverified') = ANY($${paramsWhere.length}::text[])`);
     }
   }
 
   if (filters.asset) {
     if (!hasPayments) return { places: [], total: 0 };
-    params.push(filters.asset);
-    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND UPPER(COALESCE(pa.asset, '')) = $${params.length})`);
+    paramsWhere.push(filters.asset);
+    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND UPPER(COALESCE(pa.asset, '')) = $${paramsWhere.length})`);
   }
 
   if (filters.payment.length) {
     if (!hasPayments) return { places: [], total: 0 };
-    params.push(filters.payment);
-    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND (LOWER(pa.asset) = ANY($${params.length}::text[]) OR LOWER(pa.chain) = ANY($${params.length}::text[])))`);
+    paramsWhere.push(filters.payment);
+    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND (LOWER(pa.asset) = ANY($${paramsWhere.length}::text[]) OR LOWER(pa.chain) = ANY($${paramsWhere.length}::text[])))`);
   }
 
   const verificationSelect = verificationField
@@ -205,16 +205,18 @@ const loadPlacesFromDb = async (filters: ListFilters): Promise<{ places: PlaceSu
     FROM places p${joinVerification}
     ${whereClause}
     ${orderBy}
-    LIMIT $${params.length + 1}
-    OFFSET $${params.length + 2}`;
+    LIMIT $${paramsWhere.length + 1}
+    OFFSET $${paramsWhere.length + 2}`;
 
   const countQuery = `SELECT COUNT(DISTINCT p.id)::int AS total
     FROM places p${joinVerification}
     ${whereClause}`;
 
+  const paramsQuery = [...paramsWhere, filters.limit, filters.offset];
+
   const [countResult, placesResult] = await Promise.all([
-    dbQuery<{ total: number }>(countQuery, params, { route }),
-    dbQuery<{ id: string; name: string; category: string | null; city: string | null; country: string | null; lat: number; lng: number; address: string | null; about: string | null; amenities: string[] | string | null; payment_note: string | null; verification: string | null }>(query, [...params, filters.limit, filters.offset], { route }),
+    dbQuery<{ total: number }>(countQuery, paramsWhere, { route }),
+    dbQuery<{ id: string; name: string; category: string | null; city: string | null; country: string | null; lat: number; lng: number; address: string | null; about: string | null; amenities: string[] | string | null; payment_note: string | null; verification: string | null }>(query, paramsQuery, { route }),
   ]);
   const total = Number(countResult.rows[0]?.total ?? 0);
   const rows = placesResult.rows;


### PR DESCRIPTION
### Motivation
- Improve the follow-up `/accepts/[asset]` UX from a link list to a practical page that helps users pick a store by surfacing more metadata, count information, and a sensible sort order.
- Expose a reliable `total` so the UI can show `Total: N places · Showing first 50` instead of a misleading message.

### Description
- Updated the page rendering in `app/accepts/[asset]/page.tsx` to show each place as a two-line card with the name (link) on line one and `category / city,country / verification` on line two, and preserved the top and bottom map CTAs (`Open Map` / `View all on map`).
- Added verification badge meta and stable ordering on the page via `verificationRank` with the required priority `owner → community (directory treated as community) → unverified`, then `name` ascending and `id` as tiebreaker.
- Implemented a small local country filter (dropdown) scoped to the fetched first 50 entries in `app/accepts/[asset]/page.tsx` (client-side form submit filters the visible list by `country`).
- Extended `lib/places/listPlacesForMap.ts` return types to include `total`, added a counting query for DB results (`COUNT(DISTINCT p.id)` reusing the same WHERE clause) and returned `total` for the JSON snapshot fallback (`filtered.length`) so the page can display the true total while still limiting displayed items to the first 50.

### Testing
- Ran `npm run lint` which completed successfully (non-blocking Next.js warnings remain unrelated to this change). ✅
- Ran `npm run build` which completed successfully and generated the production build with the updated `/accepts/[asset]` page. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8e4c0eaa88328b15b17f3f1d63d4b)