### PR TITLE
Add city landing page (/city/[city]) MVP and navigation links

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -34,6 +34,8 @@ const REGIONS = [
   'Australia',
 ] as const;
 
+const FEATURED_CITIES = ['Berlin', 'Tokyo', 'Singapore'] as const;
+
 const VERIFICATION_STEPS = [
   'Unverified – imported from OpenStreetMap (not yet verified)',
   'Community – updated/confirmed by the community',
@@ -144,6 +146,21 @@ export default function HomePage() {
                 className="rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
               >
                 {region}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-10">
+          <h2 className="text-2xl font-semibold text-gray-900">Browse by city</h2>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {FEATURED_CITIES.map((city) => (
+              <Link
+                key={city}
+                href={`/city/${encodeURIComponent(city.toLowerCase())}`}
+                className="rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                {city}
               </Link>
             ))}
           </div>

--- a/app/city/[city]/page.tsx
+++ b/app/city/[city]/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { headers } from 'next/headers';
+
+import { buildPageMetadata } from '@/lib/seo/metadata';
+
+const MAX_RESULTS = 50;
+
+type CityPageProps = {
+  params: { city: string };
+};
+
+type PlaceSummary = {
+  id: string;
+  name: string;
+  category?: string | null;
+  city?: string | null;
+  country?: string | null;
+  verification?: 'owner' | 'community' | 'directory' | 'unverified';
+};
+
+const verificationMeta = {
+  owner: { label: 'Owner', className: 'bg-emerald-100 text-emerald-800' },
+  community: { label: 'Community', className: 'bg-sky-100 text-sky-800' },
+  directory: { label: 'Community', className: 'bg-sky-100 text-sky-800' },
+  unverified: { label: 'Unverified', className: 'bg-gray-100 text-gray-700' },
+} as const;
+
+const verificationRank: Record<keyof typeof verificationMeta, number> = {
+  owner: 0,
+  community: 1,
+  directory: 1,
+  unverified: 2,
+};
+
+const formatCityName = (slug: string) => {
+  const decoded = decodeURIComponent(slug).trim();
+  if (!decoded) return '';
+
+  return decoded
+    .replace(/[-_]+/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+};
+
+const toCitySlug = (city: string) => encodeURIComponent(city.trim().replace(/\s+/g, '-').toLowerCase());
+
+export async function generateMetadata({ params }: CityPageProps): Promise<Metadata> {
+  const cityName = formatCityName(params.city);
+  return buildPageMetadata({
+    title: cityName ? `Places in ${cityName}` : 'Places by city',
+    description: cityName ? `Browse crypto-friendly places in ${cityName}.` : 'Browse crypto-friendly places by city.',
+    path: cityName ? `/city/${encodeURIComponent(params.city)}` : '/city',
+  });
+}
+
+async function fetchPlacesByCity(city: string): Promise<PlaceSummary[]> {
+  const headerStore = headers();
+  const host = headerStore.get('x-forwarded-host') ?? headerStore.get('host') ?? 'localhost:3000';
+  const protocol = headerStore.get('x-forwarded-proto') ?? 'http';
+  const baseUrl = `${protocol}://${host}`;
+
+  const response = await fetch(
+    `${baseUrl}/api/places?city=${encodeURIComponent(city)}&limit=${MAX_RESULTS}`,
+    { cache: 'no-store' },
+  );
+
+  if (!response.ok) return [];
+
+  const data = (await response.json()) as unknown;
+  if (!Array.isArray(data)) return [];
+
+  return data as PlaceSummary[];
+}
+
+export default async function CityPage({ params }: CityPageProps) {
+  const cityName = formatCityName(params.city);
+  const places = cityName ? await fetchPlacesByCity(cityName) : [];
+
+  const sortedPlaces = [...places].sort((a, b) => {
+    const aVerification = a.verification ?? 'unverified';
+    const bVerification = b.verification ?? 'unverified';
+    const byVerification = verificationRank[aVerification] - verificationRank[bVerification];
+    if (byVerification !== 0) return byVerification;
+
+    const byName = a.name.localeCompare(b.name);
+    if (byName !== 0) return byName;
+
+    return a.id.localeCompare(b.id);
+  });
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-8 sm:px-6 sm:py-12">
+      <h1 className="text-3xl font-semibold text-gray-900 sm:text-4xl">Places in {cityName || 'Unknown City'}</h1>
+      <p className="mt-3 text-base text-gray-700">Explore the first crypto-friendly places we found for this city.</p>
+
+      <div className="mt-5">
+        <Link
+          href={`/map?city=${encodeURIComponent(cityName)}`}
+          className="inline-flex items-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700"
+        >
+          Open Map
+        </Link>
+      </div>
+
+      <section className="mt-8 rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">Total: {places.length} places · Showing first {MAX_RESULTS}</h2>
+
+        {sortedPlaces.length === 0 ? (
+          <p className="mt-3 text-sm text-gray-600">No places found for this city yet.</p>
+        ) : (
+          <ul className="mt-4 space-y-3">
+            {sortedPlaces.map((place) => {
+              const verification = place.verification ?? 'unverified';
+              const location = [place.city, place.country].filter(Boolean).join(', ') || 'Location unknown';
+
+              return (
+                <li key={place.id} className="rounded-lg border border-gray-200 p-4">
+                  <Link href={`/place/${encodeURIComponent(place.id)}`} className="text-base font-semibold text-sky-700 hover:underline">
+                    {place.name}
+                  </Link>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-sm text-gray-500">
+                    <span>{place.category || 'Unknown category'}</span>
+                    <span aria-hidden="true">/</span>
+                    <span>{location}</span>
+                    <span aria-hidden="true">/</span>
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${verificationMeta[verification].className}`}>
+                      {verificationMeta[verification].label}
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {cityName ? (
+          <div className="mt-6 border-t border-gray-100 pt-4">
+            <Link
+              href={`/map?city=${encodeURIComponent(cityName)}`}
+              className="inline-flex items-center rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-700"
+            >
+              View all on map
+            </Link>
+          </div>
+        ) : null}
+      </section>
+
+      {cityName ? (
+        <div className="mt-6 text-sm text-gray-600">
+          Looking for another city? Try{' '}
+          <Link href={`/city/${toCitySlug('Tokyo')}`} className="text-sky-700 hover:underline">Tokyo</Link>
+          {' '}or{' '}
+          <Link href={`/city/${toCitySlug('Berlin')}`} className="text-sky-700 hover:underline">Berlin</Link>.
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/app/place/[id]/page.tsx
+++ b/app/place/[id]/page.tsx
@@ -19,6 +19,7 @@ const siteUrl = 'https://www.cryptopaymap.com';
 const relatedLinksLimit = 6;
 
 const normalizeText = (value: string | null | undefined) => value?.trim().toLowerCase() ?? '';
+const toCitySlug = (city: string) => encodeURIComponent(city.trim().replace(/\s+/g, '-').toLowerCase());
 
 export async function generateMetadata({ params }: PlacePageProps): Promise<Metadata> {
   const rawId = params.id;
@@ -114,6 +115,15 @@ export default async function PlaceDetailPage({ params }: PlacePageProps) {
         />
 
         <h1 className="text-3xl font-semibold text-gray-900 sm:text-4xl">{heading}</h1>
+
+        {place.city?.trim() ? (
+          <p className="mt-3 text-sm text-gray-600">
+            More places in{' '}
+            <Link href={`/city/${toCitySlug(place.city)}`} className="font-medium text-sky-700 hover:underline">
+              {place.city}
+            </Link>
+          </p>
+        ) : null}
 
         <dl className="mt-8 grid gap-5">
           {place.category?.trim() ? (


### PR DESCRIPTION
### Motivation
- Provide a minimal landing page for city-specific discovery at `/city/[city]` so users can browse places by city and navigate into the map and place pages. 
- Reuse the existing `/api/places` endpoint and existing UI patterns so this is lightweight and ship-ready as an MVP.

### Description
- Added a new server-rendered route `app/city/[city]/page.tsx` that formats slugs into display names, fetches up to 50 places via `/api/places?city=...&limit=50`, sorts by verification (`owner` → `community`/`directory` → `unverified`) then name, and renders H1, one-line description, `Open Map` CTA (`/map?city=...`), `Total: N places · Showing first 50`, and place cards with name link, category, location and verification badge.
- Wired small navigation additions: a `Browse by city` section on the home page at `app/(site)/page.tsx` linking into `/city/*`, and a `More places in {City}` link on the place detail page at `app/place/[id]/page.tsx` that goes to the city landing page.
- Implemented simple helpers inside the new page: `formatCityName` (decode slug, replace `-/_` with spaces and title-case) and `toCitySlug` for internal linking; retained existing verification badge styling and MAX_RESULTS = 50 for the MVP.

### Testing
- Ran `npm run lint` and the lint step completed (repo warnings unrelated to these changes remain). — passed.
- Ran `npm run build` (Next build + type checks) and the build completed successfully (build warnings/deopt messages are unchanged). — passed.
- Started the app and performed automated HTTP checks using `curl` for `/city/berlin`, `/city/tokyo`, and a non-existent slug `/city/zzzz-no-such-city`, all returned `200` and rendered the expected UI strings (checked via `rg` for `Places in`, `Open Map`, `Total:`, `No places found`, `/map?city=`). — passed.
- Captured a Playwright screenshot of `/city/berlin` to validate rendering (artifact produced). — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8efd046588328bf2a8800a6e4ca9a)