### PR TITLE
Fix toast place link path to singular `/place/:id`

### DIFF
--- a/components/internal/SubmissionDetail.tsx
+++ b/components/internal/SubmissionDetail.tsx
@@ -343,7 +343,7 @@ export default function SubmissionDetailCard({ submissionId }: { submissionId: s
               <p>{toast.text}</p>
               {toast.placeId && (
                 <p className="mt-1">
-                  Place: <Link className="font-semibold text-emerald-700" href={`/places/${toast.placeId}`}>
+                  Place: <Link className="font-semibold text-emerald-700" href={`/place/${toast.placeId}`}>
                     {toast.placeId}
                   </Link>
                 </p>


### PR DESCRIPTION
### Motivation
- Correct the place link shown in the submission toast so it navigates to the actual place detail route instead of the incorrect plural path.

### Description
- Change the toast `Link` href from `/places/${toast.placeId}` to `/place/${toast.placeId}` in `components/internal/SubmissionDetail.tsx`.

### Testing
- Ran `yarn test` and `yarn lint` against the changed files and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a905fcd220832880a33789a8fab91e)