### PR TITLE
Unify place detail link to /place/[id] and add audit evidence

### DIFF
--- a/docs/pr-03a-url-audit.md
+++ b/docs/pr-03a-url-audit.md
@@ -1,0 +1,49 @@
+# PR-03a URL統一（/places→/place）監査メモ
+
+## 1) PR-03a差分確認
+- Commit: `e72b958` (`fix: unify internal place detail link to /place/[id] (#338)`)
+- 変更ファイル: `components/internal/SubmissionDetail.tsx`
+- 変更内容: toast内の詳細リンクを `href={`/places/${toast.placeId}`}` から `href={`/place/${toast.placeId}`}` に1行のみ修正。
+- 変更理由: 正規詳細ページが `/place/[id]` のため、誤ルート `/places/${id}` 生成を是正。
+
+## 2) 残骸スキャン
+実行コマンド:
+
+```bash
+rg -n '"/places/|/places/\$\{|href=.*\/places\/|router\.(push|replace)\(.*\/places\/' app components -S
+```
+
+出力:
+
+```text
+components/map/MapClient.tsx:810:    safeFetch<Place>(`/api/places/${selectedPlaceId}`, {
+```
+
+- ヒットは API エンドポイント `/api/places/...` のみで、ページ遷移リンク `/places/...` の生成は検出なし。
+
+## 3) 正規ルート確認（/place/[id]）
+実行コマンド:
+
+```bash
+find app -type f -maxdepth 5 | rg -n 'app/.*/place|place/\[|/place/' -S
+```
+
+出力:
+
+```text
+29:app/place/[id]/page.tsx
+46:app/api/places/route.ts
+47:app/api/places/[id]/route.ts
+48:app/api/places/by-id/route.ts
+```
+
+- ページルートとしては `app/place/[id]/page.tsx` のみ。
+- その他は `/api/places/*` の API ルート。
+
+## 4) 最低限テスト
+- `npm run lint`: 成功（既存 Warning のみ）
+- `npm run build`: 成功（既存 Warning のみ）
+
+## 結論
+- PR-03a は **OK（最小差分で整合）**。
+- `/places/${id}` のリンク生成残骸は今回スキャン範囲（`app`, `components`）では検出なし。


### PR DESCRIPTION
### Motivation
- Ensure internal links point to the canonical place detail route `/place/[id]` by fixing a toast-generated link that used the incorrect `/places/${id}` path.

### Description
- Update `components/internal/SubmissionDetail.tsx` (around lines 343–349) to replace `href={`/places/${toast.placeId}`}` with `href={`/place/${toast.placeId}`}` as the sole runtime change.
- Add `docs/pr-03a-url-audit.md` containing command outputs and evidence that no other `/places/...` page-link generation was found in the `app`/`components` scan and that `app/place/[id]/page.tsx` is the only place detail page.
- No other codepaths or UI behavior were modified beyond the single-link fix and the audit document.

### Testing
- Ran a targeted ripgrep scan `rg -n '"/places/|/places/\$\{|href=.*\/places\/|router\.(push|replace)\(.*\/places\/' app components -S`, which returned only an API fetch (`components/map/MapClient.tsx:810: safeFetch('/api/places/...')`) and no `/places/...` page-link generation.
- Confirmed route discovery with `find app -type f -maxdepth 5 | rg -n 'app/.*/place|place/\[|/place/' -S` showing `app/place/[id]/page.tsx` as the detail page.
- Executed `npm run lint` and `npm run build`, both completed successfully with only existing warnings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90c28d30883289453b6598f507378)