### PR TITLE
Speed up home total places using snapshot fallback

### DIFF
--- a/app/(site)/HomeTotalPlaces.tsx
+++ b/app/(site)/HomeTotalPlaces.tsx
@@ -2,21 +2,55 @@
 
 import { useEffect, useMemo, useState } from 'react';
 
+import fallbackSnapshot from '@/data/fallback/published_places_snapshot.json';
+
 type StatsResponse = {
   total_places?: number;
 };
 
 const formatter = new Intl.NumberFormat('en-US');
 
+const countFromSnapshot = (snapshot: unknown): number => {
+  if (!snapshot) {
+    return 0;
+  }
+
+  if (Array.isArray(snapshot)) {
+    return snapshot.length;
+  }
+
+  if (typeof snapshot !== 'object') {
+    return 0;
+  }
+
+  const record = snapshot as Record<string, unknown>;
+  const places = record.places;
+  if (Array.isArray(places)) {
+    return places.length;
+  }
+
+  const knownArrayKeys = ['items', 'rows', 'data'] as const;
+  for (const key of knownArrayKeys) {
+    const value = record[key];
+    if (Array.isArray(value)) {
+      return value.length;
+    }
+  }
+
+  return 0;
+};
+
+const initialCount = countFromSnapshot(fallbackSnapshot);
+
 export function HomeTotalPlaces() {
-  const [totalPlaces, setTotalPlaces] = useState<number | null>(null);
+  const [totalPlaces, setTotalPlaces] = useState<number>(initialCount);
 
   useEffect(() => {
     const controller = new AbortController();
 
     const loadTotalPlaces = async () => {
       try {
-        const response = await fetch('/api/stats', {
+        const response = await fetch('/api/stats/snapshot', {
           method: 'GET',
           cache: 'no-store',
           signal: controller.signal,
@@ -44,12 +78,7 @@ export function HomeTotalPlaces() {
     };
   }, []);
 
-  const label = useMemo(() => {
-    if (totalPlaces === null) {
-      return '—';
-    }
-    return formatter.format(totalPlaces);
-  }, [totalPlaces]);
+  const label = useMemo(() => formatter.format(totalPlaces), [totalPlaces]);
 
   return <p className="mt-6 text-sm font-medium text-gray-700 sm:text-base">{label} crypto-friendly places worldwide</p>;
 }


### PR DESCRIPTION
### Motivation
- The home page headline count for “crypto-friendly places worldwide” was blank or showing a skeleton until the stats API responded, causing poor perceived performance. 
- Use an on-disk snapshot as an immediate initial value so the number is visible on first paint and the UI doesn’t wait for the API. 
- Keep the existing architecture and non-blocking rendering so other home elements are not delayed.

### Description
- Import `data/fallback/published_places_snapshot.json` and derive an `initialCount` from it to seed the component state on first render. 
- Add `countFromSnapshot(snapshot)` to robustly count places across common snapshot shapes (`places` array, root array, or keys like `items`, `rows`, `data`) and default to `0` if shape is unexpected. 
- Change the background refresh to `GET /api/stats/snapshot` and only update state when a numeric `total_places` is returned, leaving the fallback value intact on errors. 
- Preserve the original display text and only optimize how `N` is populated immediately.

### Testing
- Ran `npm run lint`, which completed successfully (only non-blocking warnings were reported). 
- Ran `npm run build` (`next build`), which compiled and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a98c4f9b6083288ff8b411cc1dbb55)