### PR TITLE
CPM: Home navigation improvements (accepts entry + region→map)

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -24,15 +24,17 @@ const SUPPORTED_PAYMENTS = [
 ] as const;
 
 const REGIONS = [
-  'United States',
-  'France',
-  'Japan',
-  'Germany',
-  'Canada',
-  'UK',
-  'Singapore',
-  'Australia',
+  { name: 'United States', iso2: 'US' },
+  { name: 'France', iso2: 'FR' },
+  { name: 'Japan', iso2: 'JP' },
+  { name: 'Germany', iso2: 'DE' },
+  { name: 'Canada', iso2: 'CA' },
+  { name: 'UK', iso2: 'GB' },
+  { name: 'Singapore', iso2: 'SG' },
+  { name: 'Australia', iso2: 'AU' },
 ] as const;
+
+const BROWSE_ASSETS = ['BTC', 'ETH', 'USDT', 'USDC', 'SOL', 'XRP'] as const;
 
 const FEATURED_CITIES = ['Berlin', 'Tokyo', 'Singapore'] as const;
 
@@ -120,6 +122,7 @@ export default function HomePage() {
       <section className="w-full rounded-2xl border border-gray-200 bg-white p-6 shadow-sm sm:p-10" aria-label="Home SEO content">
         <div>
           <h2 className="text-2xl font-semibold text-gray-900">Supported payments</h2>
+          <p className="mt-2 text-sm text-gray-700">Popular assets and payment rails found across listed places.</p>
           <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {SUPPORTED_PAYMENTS.map((group) => (
               <div key={group.title} className="rounded-xl border border-gray-100 bg-gray-50 p-4">
@@ -136,16 +139,32 @@ export default function HomePage() {
           </div>
         </div>
 
+        <div className="mt-8">
+          <h2 className="text-2xl font-semibold text-gray-900">Browse by asset</h2>
+          <p className="mt-2 text-sm text-gray-700">Jump directly to places that accept a specific crypto asset.</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {BROWSE_ASSETS.map((asset) => (
+              <Link
+                key={asset}
+                href={`/accepts/${asset}`}
+                className="rounded-full border border-gray-200 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                {asset}
+              </Link>
+            ))}
+          </div>
+        </div>
+
         <div className="mt-10">
           <h2 className="text-2xl font-semibold text-gray-900">Browse by region</h2>
           <div className="mt-4 flex flex-wrap gap-2">
             {REGIONS.map((region) => (
               <Link
-                key={region}
-                href="/discover"
+                key={region.iso2}
+                href={`/map?country=${region.iso2}`}
                 className="rounded-full border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
               >
-                {region}
+                {region.name}
               </Link>
             ))}
           </div>

--- a/docs/home-navigation-entrypoints.md
+++ b/docs/home-navigation-entrypoints.md
@@ -1,0 +1,17 @@
+# Home navigation entrypoints
+
+Updated Home primary discovery paths to keep key pages reachable:
+
+- Added a **Browse by asset** section near Supported payments with fixed quick links:
+  - `/accepts/BTC`
+  - `/accepts/ETH`
+  - `/accepts/USDT`
+  - `/accepts/USDC`
+  - `/accepts/SOL`
+  - `/accepts/XRP`
+- Updated **Browse by region** chips to open map country filters instead of discover:
+  - format: `/map?country=<ISO2>`
+  - examples: US, JP, DE
+- Existing Home CTA paths remain unchanged:
+  - `Open Map` → `/map`
+  - `Submit a place` → `/submit`


### PR DESCRIPTION
### Motivation
- Ensure Home always exposes primary discovery paths so users can reach `/accepts` asset pages and `/map` country filters directly. 
- Make the existing “Supported payments” area actionable so it leads to exploration rather than being only informational. 
- Preserve existing CTAs (Open Map / Submit a place) while adding explicit, discoverable shortcuts for common assets and regions.

### Description
- Changed `REGIONS` in `app/(site)/page.tsx` from a string list to `{ name, iso2 }` objects and updated region chips to link to `/map?country=<ISO2>` instead of `/discover`.
- Added a `BROWSE_ASSETS` array and a new “Browse by asset” section that renders links to `/accepts/<ASSET>` (examples: `BTC`, `ETH`, `USDT`, `USDC`, `SOL`, `XRP`) in `app/(site)/page.tsx`.
- Added a small descriptive line under “Supported payments” and kept other Home CTAs unchanged (Open Map → `/map`, Submit a place → `/submit`).
- Added `docs/home-navigation-entrypoints.md` with a short spec/summary of the new Home entrypoint behavior.

### Testing
- Ran `npm run lint`, which completed successfully but reported existing Next.js image/script warnings. 
- Ran `npm run build`, which completed successfully and generated the production build with a few Next.js deopt warnings. 
- Verified endpoints with HTTP checks: `curl -I http://localhost:3000/accepts/BTC` returned `200 OK` and `curl -I 'http://localhost:3000/map?country=JP'` returned `200 OK`, and `curl -I http://localhost:3000/map` and `curl -I http://localhost:3000/submit` also returned `200 OK`.
- Attempted automated Playwright interactions to screenshot and click through the Home page, but the Playwright browser process crashed in this environment (SIGSEGV), so visual interaction artifacts could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99080f66483288ddfb83048695098)