### PR TITLE
Add Cache-Control headers to /api/places responses for edge caching

### DIFF
--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -16,6 +16,8 @@ const MAX_LIMIT = 5000;
 const ALL_MODE_LIMIT = 1200;
 const CACHE_TTL_MS = 20_000;
 const DB_ERROR_LOG_WINDOW_MS = 60_000;
+const CACHE_CONTROL = "public, max-age=0, s-maxage=30, stale-while-revalidate=300";
+const NO_STORE = "no-store";
 
 type CacheEntry = {
   expiresAt: number;
@@ -81,13 +83,16 @@ export async function GET(request: NextRequest) {
     const stubName = parseSearchTerm(searchParams.get("q")) ?? "[DRY RUN]";
     return NextResponse.json(
       [{ id: dryRunId, name: stubName, lat: 0, lng: 0, verification: "unverified", category: "dry-run", city: "", country: "", accepted: [], address_full: null, about_short: null, paymentNote: null, amenities: null, phone: null, website: null, twitter: null, instagram: null, facebook: null, coverImage: null }],
-      { headers: buildDataSourceHeaders("json", true) },
+      { headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("json", true) } },
     );
   }
 
   const bboxResult = parseBbox(searchParams.get("bbox"));
   if (bboxResult.error) {
-    return NextResponse.json({ ok: false, error: "INVALID_BBOX", message: bboxResult.error }, { status: 400, headers: defaultHeaders });
+    return NextResponse.json(
+      { ok: false, error: "INVALID_BBOX", message: bboxResult.error },
+      { status: 400, headers: { "Cache-Control": NO_STORE, ...defaultHeaders } },
+    );
   }
 
   const requestedLimit = parsePositiveInt(searchParams.get("limit"));
@@ -97,7 +102,12 @@ export async function GET(request: NextRequest) {
   if (mode === "all") {
     const country = searchParams.get("country");
     const city = searchParams.get("city");
-    if (!country && !city) return NextResponse.json({ ok: false, error: "MODE_ALL_REQUIRES_SCOPE" }, { status: 400 });
+    if (!country && !city) {
+      return NextResponse.json(
+        { ok: false, error: "MODE_ALL_REQUIRES_SCOPE" },
+        { status: 400, headers: { "Cache-Control": NO_STORE, ...defaultHeaders } },
+      );
+    }
     limit = Math.min(requestedLimit ?? ALL_MODE_LIMIT, ALL_MODE_LIMIT);
     offset = 0;
   }
@@ -116,6 +126,7 @@ export async function GET(request: NextRequest) {
   if (cached && cached.expiresAt > Date.now()) {
     return NextResponse.json(cached.data, {
       headers: {
+        "Cache-Control": CACHE_CONTROL,
         ...buildDataSourceHeaders(cached.source, cached.limited),
         ...(cached.lastUpdatedISO ? { "x-cpm-last-updated": cached.lastUpdatedISO } : {}),
       },
@@ -157,6 +168,7 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(result.places, {
       headers: {
+        "Cache-Control": CACHE_CONTROL,
         ...buildDataSourceHeaders(result.source, result.limited),
         ...(result.lastUpdatedISO ? { "x-cpm-last-updated": result.lastUpdatedISO } : {}),
       },
@@ -164,11 +176,20 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     logDbFailure("database query failed", error);
     if (!shouldAllowJson || dataSource === "db") {
-      return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503, headers: buildDataSourceHeaders("db", true) });
+      return NextResponse.json(
+        { ok: false, error: "DB_UNAVAILABLE" },
+        { status: 503, headers: { "Cache-Control": NO_STORE, ...buildDataSourceHeaders("db", true) } },
+      );
     }
     if (error instanceof DbUnavailableError) {
-      return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503, headers: buildDataSourceHeaders("db", true) });
+      return NextResponse.json(
+        { ok: false, error: "DB_UNAVAILABLE" },
+        { status: 503, headers: { "Cache-Control": NO_STORE, ...buildDataSourceHeaders("db", true) } },
+      );
     }
-    return NextResponse.json({ ok: false, error: "FALLBACK_SNAPSHOT_UNAVAILABLE" }, { status: 503, headers: buildDataSourceHeaders("json", true) });
+    return NextResponse.json(
+      { ok: false, error: "FALLBACK_SNAPSHOT_UNAVAILABLE" },
+      { status: 503, headers: { "Cache-Control": NO_STORE, ...buildDataSourceHeaders("json", true) } },
+    );
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce initial p95 latency spikes by allowing identical `/api/places` responses to be cached at the edge for a short time.
- Standardize cache semantics across all return paths so successful responses are CDN-cacheable and error responses are not.

### Description
- Added `const CACHE_CONTROL = "public, max-age=0, s-maxage=30, stale-while-revalidate=300"` and `const NO_STORE = "no-store"` to `app/api/places/route.ts`.
- Applied `Cache-Control: CACHE_CONTROL` to success responses: `dryRun`, in-memory cache-hit, and DB success responses while keeping `buildDataSourceHeaders(...)` and `x-cpm-last-updated` intact.
- Applied `Cache-Control: NO_STORE` to error responses: `INVALID_BBOX` (400), `MODE_ALL_REQUIRES_SCOPE` (400) which previously lacked headers, and all 503 responses (`DB_UNAVAILABLE`, `FALLBACK_SNAPSHOT_UNAVAILABLE`).
- Only `app/api/places/route.ts` was modified.

### Testing
- Ran `npm run lint` which completed successfully (existing unrelated lint warnings remain).
- Started the dev server and ran `curl -sSI "http://localhost:3000/api/places?limit=2000&bbox=139.730,35.650,139.800,35.705"` and verified the response includes the header `cache-control: public, max-age=0, s-maxage=30, stale-while-revalidate=300`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf6b9a8f483288371b576b5a265cf)