### PR TITLE
CPM: minimize /api/places response to map DTO only

### DIFF
--- a/app/api/places/route.ts
+++ b/app/api/places/route.ts
@@ -10,6 +10,8 @@ import {
 } from "@/lib/dataSource";
 import { normalizeAcceptsAsset } from "@/lib/acceptsAsset";
 import { listPlacesForMap } from "@/lib/places/listPlacesForMap";
+import { toPlaceMapItem } from "@/lib/places/mapDto/toSummaryPlus";
+import type { PlaceMapItem } from "@/lib/places/mapDto/types";
 
 const DEFAULT_LIMIT = 1200;
 const MAX_LIMIT = 5000;
@@ -21,7 +23,7 @@ const NO_STORE = "no-store";
 
 type CacheEntry = {
   expiresAt: number;
-  data: unknown[];
+  data: PlaceMapItem[];
   source: "db" | "json";
   limited: boolean;
   lastUpdatedISO?: string;
@@ -82,7 +84,7 @@ export async function GET(request: NextRequest) {
     const dryRunId = searchParams.get("placeId") ?? "cpm:dryrun-placeholder";
     const stubName = parseSearchTerm(searchParams.get("q")) ?? "[DRY RUN]";
     return NextResponse.json(
-      [{ id: dryRunId, name: stubName, lat: 0, lng: 0, verification: "unverified", category: "dry-run", city: "", country: "", accepted: [], address_full: null, about_short: null, paymentNote: null, amenities: null, phone: null, website: null, twitter: null, instagram: null, facebook: null, coverImage: null }],
+      [{ id: dryRunId, name: stubName, lat: 0, lng: 0, verification: "unverified", category: "dry-run", city: "", country: "", accepted: [] } satisfies PlaceMapItem],
       { headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("json", true) } },
     );
   }
@@ -158,15 +160,17 @@ export async function GET(request: NextRequest) {
       { message: "DB_TIMEOUT" },
     );
 
+    const body = result.places.map(toPlaceMapItem);
+
     placesCache.set(cacheKey, {
-      data: result.places,
+      data: body,
       expiresAt: Date.now() + CACHE_TTL_MS,
       source: result.source,
       limited: result.limited,
       lastUpdatedISO: result.lastUpdatedISO,
     });
 
-    return NextResponse.json(result.places, {
+    return NextResponse.json(body, {
       headers: {
         "Cache-Control": CACHE_CONTROL,
         ...buildDataSourceHeaders(result.source, result.limited),

--- a/lib/places/mapDto/toSummaryPlus.ts
+++ b/lib/places/mapDto/toSummaryPlus.ts
@@ -1,6 +1,6 @@
 import type { Place } from "@/types/places";
 
-import { type DbContact, type PlaceSummaryPlus, type Verification } from "./types";
+import { type DbContact, type PlaceMapItem, type PlaceSummaryPlus, type Verification } from "./types";
 
 const VERIFICATION_LEVELS = new Set(["owner", "community", "directory", "unverified", "report", "verified", "pending"]);
 
@@ -79,6 +79,20 @@ export const pickCoverImage = (place: {
   return candidates.find((value): value is string => Boolean(value)) ?? null;
 };
 
+
+export function toPlaceMapItem(place: PlaceSummaryPlus): PlaceMapItem {
+  return {
+    id: place.id,
+    name: place.name,
+    lat: place.lat,
+    lng: place.lng,
+    verification: place.verification,
+    category: place.category,
+    city: place.city,
+    country: place.country,
+    accepted: place.accepted,
+  };
+}
 export function toSummaryPlus(
   place: Place,
   accepted: string[],

--- a/lib/places/mapDto/types.ts
+++ b/lib/places/mapDto/types.ts
@@ -12,6 +12,8 @@ export type PlaceSummary = {
   accepted: string[];
 };
 
+export type PlaceMapItem = PlaceSummary;
+
 export type PlaceSummaryPlus = PlaceSummary & {
   address_full: string | null;
   about_short: string | null;


### PR DESCRIPTION
### Motivation
- Reduce payload size for `/api/places` by returning only the fields required for map listing (`id, name, lat, lng, category, verification, accepted, country, city`).
- Keep detailed place information available from `/api/places/[id]` and preserve existing headers and error responses.

### Description
- Added `PlaceMapItem` type alias to represent the minimal map list DTO (`lib/places/mapDto/types.ts`).
- Added `toPlaceMapItem(place)` mapper to project `PlaceSummaryPlus` -> `PlaceMapItem` (`lib/places/mapDto/toSummaryPlus.ts`).
- Updated `app/api/places/route.ts` to return the minimal DTO for dry-run responses, DB/JSON success responses, and cache-hit responses, and to store `PlaceMapItem[]` in the cache instead of full summaries. 
- Preserved existing behavior for error responses (`400/503`) and existing headers (`Cache-Control`, data-source headers, `x-cpm-last-updated`).

### Testing
- Ran `npm run lint` which completed successfully (only pre-existing warnings were reported). 
- Ran `npm run build` which completed successfully (only pre-existing warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf76490188328aec367983ea6bfaf)