### PR TITLE
CPM: /api/places/[id] に Cache-Control を追加して詳細APIの再利用を有効化

### DIFF
--- a/app/api/places/[id]/route.ts
+++ b/app/api/places/[id]/route.ts
@@ -3,6 +3,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { DbUnavailableError } from "@/lib/db";
 import { getPlaceDetail } from "@/lib/places/detail";
 
+const CACHE_CONTROL = "public, max-age=0, s-maxage=30, stale-while-revalidate=300";
+const NO_STORE = "no-store";
+
 const decodePlaceId = (rawId: string) => {
   try {
     return { ok: true, id: decodeURIComponent(rawId) };
@@ -14,7 +17,10 @@ const decodePlaceId = (rawId: string) => {
 export async function GET(_request: NextRequest, { params }: { params: { id: string } }) {
   const decoded = decodePlaceId(params.id);
   if (!decoded.ok) {
-    return NextResponse.json({ error: "Invalid place id" }, { status: 400 });
+    return NextResponse.json(
+      { error: "Invalid place id" },
+      { status: 400, headers: { "Cache-Control": NO_STORE } },
+    );
   }
 
   if (decoded.id.startsWith("cpm:dryrun-")) {
@@ -28,14 +34,20 @@ export async function GET(_request: NextRequest, { params }: { params: { id: str
   try {
     const result = await getPlaceDetail(decoded.id);
     if (result.place) {
-      return NextResponse.json(result.place);
+      return NextResponse.json(result.place, { headers: { "Cache-Control": CACHE_CONTROL } });
     }
   } catch (error) {
     if (error instanceof DbUnavailableError) {
-      return NextResponse.json({ ok: false, error: "DB_UNAVAILABLE" }, { status: 503 });
+      return NextResponse.json(
+        { ok: false, error: "DB_UNAVAILABLE" },
+        { status: 503, headers: { "Cache-Control": NO_STORE } },
+      );
     }
     throw error;
   }
 
-  return NextResponse.json({ error: "not_found" }, { status: 404 });
+  return NextResponse.json(
+    { error: "not_found" },
+    { status: 404, headers: { "Cache-Control": NO_STORE } },
+  );
 }


### PR DESCRIPTION
### Motivation
- 本番で `/api/places/[id]` の詳細APIが毎回 `x-vercel-cache=MISS`/age=0 で約2.4s の遅延を生んでいるため、200レスポンスにキャッシュ方針を付与して再利用を促進するための変更です。 
- 変更は `app/api/places/[id]/route.ts` のみを対象とし、一覧API `/api/places` や UI、既存のレスポンス形状は変更しません。 

### Description
- ファイル先頭に `const CACHE_CONTROL = "public, max-age=0, s-maxage=30, stale-while-revalidate=300"` と `const NO_STORE = "no-store"` を追加しました。 
- `getPlaceDetail` の成功 200（`result.place` を返す箇所）に対して `Cache-Control: CACHE_CONTROL` ヘッダーを付与しました。 
- 400（不正ID）、404（not_found）、503（DB_UNAVAILABLE）の返却点には `Cache-Control: NO_STORE` を付与しました。 
- 変更は `app/api/places/[id]/route.ts` のみで、レスポンスボディの形状は不変です。 

### Testing
- `npm run build` を実行して型チェックとビルドを通過しました（成功）。 
- 開発サーバを起動してヘッダーを確認し、`curl -I '.../api/places/%25'` で 400 が `cache-control: no-store` を返すことを確認しました（成功）。 
- `curl -I '.../api/places/cpm%3Adoes-not-exist'` で 404 が `cache-control: no-store` を返すことを確認しました（成功）。 
- ローカルのデータ状況により `result.place` を返す実際の 200 レスポンスは再現できませんでしたが、該当 200 返却点には実装上 `Cache-Control: CACHE_CONTROL` を付与済みです。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac0ed78be48328bcd353f11b488e9c)