### PR TITLE
CPM: add unfiltered fast-path for /api/stats and /api/stats/snapshot

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -10,6 +10,7 @@ import {
   getDataSourceSetting,
   withDbTimeout,
 } from "@/lib/dataSource";
+import { loadUnfilteredStatsSnapshotFastPath } from "@/lib/stats/snapshotFastPath";
 import { getMapDisplayableWhereClauses, isMapDisplayablePlace } from "@/lib/stats/mapPopulation";
 import { normalizeAcceptanceChainKey } from "@/lib/stats/acceptance";
 
@@ -25,6 +26,11 @@ type StatsFilters = {
   verification: string;
   promoted: string;
   source: string;
+};
+
+type StatsRouteOptions = {
+  route: string;
+  allowUnfilteredFastPath?: boolean;
 };
 
 // Response shape for GET /api/stats.
@@ -122,6 +128,9 @@ const EMPTY_FILTERS: StatsFilters = {
 };
 
 const normalizeFilterValue = (value: string | null) => (value ?? "").trim();
+
+const isUnfilteredRequest = (filters: StatsFilters) =>
+  FILTER_KEYS.every((key) => filters[key].length === 0);
 
 const parseFilters = (request: Request): StatsFilters => {
   const url = new URL(request.url);
@@ -829,15 +838,50 @@ const loadStatsFromDb = async (route: string, filters: StatsFilters): Promise<St
   return fetchDbSnapshotV4(route, filters);
 };
 
-export async function GET(request: Request) {
+const withOkMeta = (statsResponse: StatsApiResponse): StatsApiResponse => ({
+  ...statsResponse,
+  ok: true,
+  meta: statsResponse.meta ?? {
+    source: "db_live",
+    population_id: MAP_POPULATION_ID,
+    as_of: new Date().toISOString(),
+    acceptance_chain_missing_places: 0,
+    acceptance_unknown_chain_included: false,
+    accepts_with_chain_count: 0,
+    accepts_missing_chain_count: 0,
+    network_coverage: 0,
+  },
+});
+
+export const getStatsResponse = async (request: Request, options: StatsRouteOptions): Promise<Response> => {
   const filters = parseFilters(request);
-  const route = "api_stats";
+  const route = options.route;
   const requestId = resolveRequestId(request);
   const dataSource = getDataSourceSetting();
   const { shouldAttemptDb, shouldAllowJson, hasDb } = getDataSourceContext(dataSource);
 
   if (!hasDb && dataSource === "db") {
     return failureResponse(503, requestId, "db_connect_failed", "database unavailable");
+  }
+
+  const isUnfiltered = isUnfilteredRequest(filters);
+
+  if (options.allowUnfilteredFastPath && isUnfiltered && shouldAttemptDb) {
+    try {
+      const cachedResponse = await withDbTimeout(loadUnfilteredStatsSnapshotFastPath(route), {
+        message: "DB_TIMEOUT",
+      });
+      if (cachedResponse) {
+        return NextResponse.json<StatsApiResponse>(withOkMeta(cachedResponse), {
+          headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },
+        });
+      }
+    } catch (error) {
+      console.warn("[stats] fast path unavailable; falling back to live aggregation", {
+        requestId,
+        error: toErrorSummary(error),
+      });
+    }
   }
 
   if (!shouldAttemptDb) {
@@ -848,20 +892,7 @@ export async function GET(request: Request) {
 
     try {
       const jsonPlaces = await loadPlacesFromJsonFallback();
-      return NextResponse.json<StatsApiResponse>({
-        ...responseFromPlaces(filters, jsonPlaces),
-        ok: true,
-        meta: {
-          source: "db_live",
-          population_id: MAP_POPULATION_ID,
-          as_of: new Date().toISOString(),
-          acceptance_chain_missing_places: 0,
-          acceptance_unknown_chain_included: false,
-          accepts_with_chain_count: 0,
-          accepts_missing_chain_count: 0,
-          network_coverage: 0,
-        },
-      }, {
+      return NextResponse.json<StatsApiResponse>(withOkMeta(responseFromPlaces(filters, jsonPlaces)), {
         headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("json", true) },
       });
     } catch (error) {
@@ -874,20 +905,7 @@ export async function GET(request: Request) {
     const statsResponse = await withDbTimeout(loadStatsFromDb(route, filters), {
       message: "DB_TIMEOUT",
     });
-    return NextResponse.json<StatsApiResponse>({
-      ...statsResponse,
-      ok: true,
-      meta: statsResponse.meta ?? {
-        source: "db_live",
-        population_id: MAP_POPULATION_ID,
-        as_of: new Date().toISOString(),
-        acceptance_chain_missing_places: 0,
-        acceptance_unknown_chain_included: false,
-        accepts_with_chain_count: 0,
-        accepts_missing_chain_count: 0,
-        network_coverage: 0,
-      },
-    }, {
+    return NextResponse.json<StatsApiResponse>(withOkMeta(statsResponse), {
       headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },
     });
   } catch (error) {
@@ -904,20 +922,7 @@ export async function GET(request: Request) {
     // Production must never use JSON fallback for stats.
     try {
       const jsonPlaces = await loadPlacesFromJsonFallback();
-      return NextResponse.json<StatsApiResponse>({
-        ...responseFromPlaces(filters, jsonPlaces),
-        ok: true,
-        meta: {
-          source: "db_live",
-          population_id: MAP_POPULATION_ID,
-          as_of: new Date().toISOString(),
-          acceptance_chain_missing_places: 0,
-          acceptance_unknown_chain_included: false,
-          accepts_with_chain_count: 0,
-          accepts_missing_chain_count: 0,
-          network_coverage: 0,
-        },
-      }, {
+      return NextResponse.json<StatsApiResponse>(withOkMeta(responseFromPlaces(filters, jsonPlaces)), {
         headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("json", true) },
       });
     } catch (jsonError) {
@@ -925,4 +930,8 @@ export async function GET(request: Request) {
       return failureResponse(503, requestId, "unknown", "stats unavailable");
     }
   }
+};
+
+export async function GET(request: Request) {
+  return getStatsResponse(request, { route: "api_stats", allowUnfilteredFastPath: true });
 }

--- a/app/api/stats/snapshot/route.ts
+++ b/app/api/stats/snapshot/route.ts
@@ -1,1 +1,7 @@
-export { GET, revalidate } from "../route";
+import { getStatsResponse, revalidate } from "../route";
+
+export { revalidate };
+
+export async function GET(request: Request) {
+  return getStatsResponse(request, { route: "api_stats_snapshot", allowUnfilteredFastPath: true });
+}

--- a/lib/stats/snapshotFastPath.ts
+++ b/lib/stats/snapshotFastPath.ts
@@ -1,0 +1,86 @@
+import { dbQuery } from "@/lib/db";
+
+import type { StatsApiResponse } from "@/app/api/stats/route";
+
+type SnapshotSourceRow = {
+  payload: unknown;
+};
+
+const SNAPSHOT_TABLE_CANDIDATES = [
+  { table: "stats_cache", payloadColumn: "payload", timestampColumn: "as_of" },
+  { table: "stats_snapshot", payloadColumn: "payload", timestampColumn: "as_of" },
+  { table: "stats_snapshots", payloadColumn: "payload", timestampColumn: "as_of" },
+] as const;
+
+const quoteIdentifier = (identifier: string) => `"${identifier.replace(/"/g, '""')}"`;
+
+const tableExists = async (route: string, table: string) => {
+  const { rows } = await dbQuery<{ present: string | null }>(
+    "SELECT to_regclass($1) AS present",
+    [`public.${table}`],
+    { route },
+  );
+  return Boolean(rows[0]?.present);
+};
+
+const hasColumn = async (route: string, table: string, column: string) => {
+  const { rows } = await dbQuery<{ present: number }>(
+    `SELECT COUNT(*)::int AS present
+     FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = $1
+       AND column_name = $2`,
+    [table, column],
+    { route },
+  );
+  return (rows[0]?.present ?? 0) > 0;
+};
+
+const isStatsApiResponse = (value: unknown): value is StatsApiResponse => {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.total_places === "number" &&
+    typeof candidate.total_count === "number" &&
+    typeof candidate.countries === "number" &&
+    typeof candidate.cities === "number" &&
+    typeof candidate.categories === "number" &&
+    typeof candidate.accepting_any_count === "number"
+  );
+};
+
+export const loadUnfilteredStatsSnapshotFastPath = async (
+  route: string,
+): Promise<StatsApiResponse | null> => {
+  for (const candidate of SNAPSHOT_TABLE_CANDIDATES) {
+    const exists = await tableExists(route, candidate.table);
+    if (!exists) continue;
+
+    const [hasPayload, hasTimestamp] = await Promise.all([
+      hasColumn(route, candidate.table, candidate.payloadColumn),
+      hasColumn(route, candidate.table, candidate.timestampColumn),
+    ]);
+
+    if (!hasPayload || !hasTimestamp) continue;
+
+    const payloadSql = quoteIdentifier(candidate.payloadColumn);
+    const timestampSql = quoteIdentifier(candidate.timestampColumn);
+    const tableSql = quoteIdentifier(candidate.table);
+
+    const { rows } = await dbQuery<SnapshotSourceRow>(
+      `SELECT ${payloadSql} AS payload
+       FROM ${tableSql}
+       ORDER BY ${timestampSql} DESC
+       LIMIT 1`,
+      [],
+      { route },
+    );
+
+    const payload = rows[0]?.payload;
+    if (isStatsApiResponse(payload)) {
+      return payload;
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
### Motivation
- Reduce first-request spike for `/api/stats` and `/api/stats/snapshot` by returning a precomputed payload when the request has no filters.
- Preserve existing filtered behavior and response shape so snapshot/filtered pages remain unchanged.
- Make a safe, incremental change that requires no schema migrations and falls back to live aggregation if the fast path is unavailable.

### Description
- Introduced a shared handler `getStatsResponse()` in `app/api/stats/route.ts` and moved `/api/stats` to call it, keeping `StatsApiResponse` shape and cache headers unchanged.
- Added an unfiltered request detector (`FILTER_KEYS` all empty) and, for unfiltered requests only, attempt a fast path via `loadUnfilteredStatsSnapshotFastPath()` that reads the latest precomputed payload from `stats_cache` / `stats_snapshot` / `stats_snapshots` when present.
- Implemented `lib/stats/snapshotFastPath.ts` to safely check table/column existence and return a validated `StatsApiResponse` payload, otherwise return `null` to trigger the existing live aggregation path.
- Replaced the snapshot route re-export with an explicit `app/api/stats/snapshot/route.ts` that calls the shared handler so both `/api/stats` and `/api/stats/snapshot` can benefit from the fast path.

### Testing
- Ran linter with `npm run -s lint` which completed (existing unrelated warnings remained) and `npx eslint app/api/stats/route.ts app/api/stats/snapshot/route.ts lib/stats/snapshotFastPath.ts` which passed.
- Attempted unit test run with `npm run -s test:stats` which failed due to a pre-existing module resolution error in test harness (`Cannot find module '@/lib/db'`) unrelated to these changes.
- Ran TypeScript check with `npx tsc --noEmit` which reported pre-existing invalid characters in `tests/audit/*.spec.ts` and is unrelated to the stats fast-path changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac314334a083288e4b24fd0ac5345a)