### PR TITLE
CPM: /api/stats の集計ごとに計測ログを追加し timeout 到達時の診断情報を出力

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -423,17 +423,44 @@ const toFinalSqlForLog = (text: string, params: unknown[]) =>
     return quoteSqlValue(params[index]);
   });
 
+const shouldLogStatsDiagnostics = () =>
+  process.env.NODE_ENV !== "production" || process.env.CPM_STATS_DEBUG_TIMING === "1";
+
+const summarizeFiltersForLog = (filters: StatsFilters) => ({
+  country: filters.country || null,
+  city: filters.city || null,
+  category: filters.category || null,
+  accepted: filters.accepted || null,
+  verification: filters.verification || null,
+  promoted: filters.promoted || null,
+  source: filters.source || null,
+});
+
 const runStatsQuery = <T extends Record<string, unknown>>(
   label: string,
   sql: string,
   params: unknown[],
   route: string,
+  filters: StatsFilters,
 ) => {
   const finalSql = toFinalSqlForLog(sql, params);
-  return dbQuery<T>(sql, params, { route }).catch((error) => {
-    console.error(`[stats] query failed: ${label}`, { finalSql, params, error });
-    throw error;
-  });
+  const startedAt = Date.now();
+  return dbQuery<T>(sql, params, { route })
+    .then((result) => {
+      if (shouldLogStatsDiagnostics()) {
+        console.info("[stats] query timing", {
+          route,
+          query: label,
+          elapsed_ms: Date.now() - startedAt,
+          filters: summarizeFiltersForLog(filters),
+        });
+      }
+      return result;
+    })
+    .catch((error) => {
+      console.error(`[stats] query failed: ${label}`, { finalSql, params, error });
+      throw error;
+    });
 };
 
 type FilterSqlOptions = {
@@ -565,6 +592,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
     totalsSql,
     params,
     route,
+    filters,
   );
 
   const verificationPromise = verificationColumn
@@ -588,6 +616,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          GROUP BY 1`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [] as Array<{ key: string | null; total: string }> });
 
@@ -603,6 +632,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          LIMIT ${TOP_RANKING_LIMIT}`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [] as Array<{ key: string | null; total: string }> });
 
@@ -618,6 +648,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          LIMIT ${TOP_RANKING_LIMIT}`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [] as Array<{ key: string | null; total: string }> });
 
@@ -638,6 +669,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          LIMIT ${TOP_RANKING_LIMIT}`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [] as Array<{ key: string | null; total: string }> });
 
@@ -654,6 +686,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          LIMIT ${TOP_CHAIN_LIMIT}`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [] as Array<{ key: string | null; total: string }> });
 
@@ -670,6 +703,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          LIMIT ${TOP_CHAIN_LIMIT}`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [] as Array<{ key: string | null; total: string }> });
 
@@ -684,6 +718,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
             OR ${hasPaymentAsset ? "NULLIF(BTRIM(COALESCE(pa.asset, '')), '') IS NOT NULL" : "FALSE"}`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [{ total: "0" }] as Array<{ total: string }> });
 
@@ -701,6 +736,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          LIMIT ${TOP_MATRIX_LIMIT * TOP_MATRIX_LIMIT}`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [] as Array<{ asset: string | null; chain: string | null; total: string }> });
 
@@ -715,6 +751,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
            AND NULLIF(BTRIM(pa.chain), '') IS NULL`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [{ total: "0" }] as Array<{ total: string }> });
 
@@ -735,6 +772,7 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
          INNER JOIN filtered_places fp ON fp.id = pa.place_id`,
         params,
         route,
+        filters,
       )
     : Promise.resolve({ rows: [{ accepts_with_chain_count: "0", accepts_missing_chain_count: "0" }] as Array<{ accepts_with_chain_count: string; accepts_missing_chain_count: string }> });
 
@@ -870,6 +908,15 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
     try {
       const cachedResponse = await withDbTimeout(loadUnfilteredStatsSnapshotFastPath(route), {
         message: "DB_TIMEOUT",
+        onTimeout: ({ timeoutMs, message }) => {
+          if (!shouldLogStatsDiagnostics()) return;
+          console.info("[stats] db timeout reached", {
+            route,
+            filters: summarizeFiltersForLog(filters),
+            timeout_ms: timeoutMs,
+            message,
+          });
+        },
       });
       if (cachedResponse) {
         return NextResponse.json<StatsApiResponse>(withOkMeta(cachedResponse), {
@@ -904,6 +951,15 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
   try {
     const statsResponse = await withDbTimeout(loadStatsFromDb(route, filters), {
       message: "DB_TIMEOUT",
+      onTimeout: ({ timeoutMs, message }) => {
+        if (!shouldLogStatsDiagnostics()) return;
+        console.info("[stats] db timeout reached", {
+          route,
+          filters: summarizeFiltersForLog(filters),
+          timeout_ms: timeoutMs,
+          message,
+        });
+      },
     });
     return NextResponse.json<StatsApiResponse>(withOkMeta(statsResponse), {
       headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },

--- a/lib/dataSource.ts
+++ b/lib/dataSource.ts
@@ -6,6 +6,7 @@ export type DataSourceResult = "db" | "json";
 type TimeoutOptions = {
   timeoutMs?: number;
   message?: string;
+  onTimeout?: (context: { timeoutMs: number; message: string }) => void;
 };
 
 // DATA_SOURCE=auto rules:
@@ -48,10 +49,12 @@ export const buildDataSourceHeaders = (source: DataSourceResult, limited: boolea
 export const withDbTimeout = async <T>(promise: Promise<T>, options: TimeoutOptions = {}) => {
   const timeoutMs = options.timeoutMs ?? DEFAULT_DB_TIMEOUT_MS;
   const message = options.message ?? "DB_TIMEOUT";
+  const onTimeout = options.onTimeout;
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
+      onTimeout?.({ timeoutMs, message });
       reject(new DbUnavailableError(message));
     }, timeoutMs);
   });


### PR DESCRIPTION
### Motivation
- `/api/stats?country=DE` がタイムアウトする原因を突き止め、どの集計クエリが支配的かを特定できるようにするため。 
- DE と AQ の差を実行時間ベースで比較し、単純なタイムアウト延長で済ませて良いか判断できる情報を得るため。

### Description
- `app/api/stats/route.ts`: 集計クエリ実行をラップする `runStatsQuery` を拡張し、`query`, `elapsed_ms`, `route`, `filters` をログ出力する計測を追加し、`fetchDbSnapshotV4` の主要集計（`totals`, `verification`, `category_ranking`, `country_ranking`, `city_ranking`, `top_chains`, `top_assets`, `accepting_any_count`, `asset_acceptance_matrix`, `acceptance_chain_missing_places`, `acceptance_coverage`）を計測経路に通すように変更しました. 
- 計測ログは本番汚染を避けるため `NODE_ENV !== "production"` または `CPM_STATS_DEBUG_TIMING=1` のときのみ出力するよう制限しました。 
- `lib/dataSource.ts`: `withDbTimeout` に `onTimeout` コールバックを追加し、stats ルートではタイムアウト到達時に `route`, `filters`, `timeout_ms`, `message` をログ出力するように呼び出し側で利用するようにしました（fast-path と live-path 両方に適用）。 
- 動作影響は stats 調査ログ追加に限定しており、API 応答スキーマ・DB スキーマ・マイグレーションには変更を加えていません。 

### Testing
- `next lint` 対象ファイル（`app/api/stats/route.ts` と `lib/dataSource.ts`）は問題なく通過しました。 
- `npm run test:stats` は環境側の既存問題で一部テストが失敗し（`Cannot find module '@/lib/db'` によるテスト実行エラー）、完全成功とはなりませんでした。 
- ローカルで `next dev` を起動して `/api/stats?country=DE` / `?country=AQ` / 無フィルタ を `curl` で実行しレスポンスを確認しましたが、この環境は JSON フォールバック（`x-cpm-data-source: json`）で DB 集計は実行されなかったため、クエリ単位の `elapsed_ms` 比較は未実行でした。 
- 本 PR の変更は DB 接続可能な環境で本番以外（`NODE_ENV !== "production"` または `CPM_STATS_DEBUG_TIMING=1`）において、各集計クエリの実行時間ログおよびタイムアウト到達ログ（`db timeout reached`）から支配的な集計を特定できることを確認できます。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac45950d5c832894e25b92faf32a3c)