### PR TITLE
CPM: Add minimal debug-gated diagnostics for /api/stats 500 failures

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -436,6 +436,22 @@ const summarizeFiltersForLog = (filters: StatsFilters) => ({
   source: filters.source || null,
 });
 
+const summarizeErrorForLog = (error: unknown) => {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack_head: error.stack?.split("\n").slice(0, 5).join("\n") ?? null,
+    };
+  }
+
+  return {
+    message: toErrorSummary(error),
+    name: null,
+    stack_head: null,
+  };
+};
+
 const runStatsQuery = <T extends Record<string, unknown>>(
   label: string,
   sql: string,
@@ -895,6 +911,8 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
   const filters = parseFilters(request);
   const route = options.route;
   const requestId = resolveRequestId(request);
+  const allowUnfilteredFastPath = Boolean(options.allowUnfilteredFastPath);
+  const diagnosticsEnabled = shouldLogStatsDiagnostics();
   const dataSource = getDataSourceSetting();
   const { shouldAttemptDb, shouldAllowJson, hasDb } = getDataSourceContext(dataSource);
 
@@ -903,17 +921,25 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
   }
 
   const isUnfiltered = isUnfilteredRequest(filters);
+  const pathState = {
+    enteredFastPath: false,
+    enteredLiveFallback: false,
+    livePathSuccess: false,
+  };
+  let timeoutMs: number | null = null;
 
-  if (options.allowUnfilteredFastPath && isUnfiltered && shouldAttemptDb) {
+  if (allowUnfilteredFastPath && isUnfiltered && shouldAttemptDb) {
+    pathState.enteredFastPath = true;
     try {
       const cachedResponse = await withDbTimeout(loadUnfilteredStatsSnapshotFastPath(route), {
         message: "DB_TIMEOUT",
-        onTimeout: ({ timeoutMs, message }) => {
-          if (!shouldLogStatsDiagnostics()) return;
-          console.info("[stats] db timeout reached", {
+        onTimeout: ({ timeoutMs: timeoutMsValue, message }) => {
+          timeoutMs = timeoutMsValue;
+          if (!diagnosticsEnabled) return;
+          console.info("[stats] fast path timeout", {
             route,
             filters: summarizeFiltersForLog(filters),
-            timeout_ms: timeoutMs,
+            timeout_ms: timeoutMsValue,
             message,
           });
         },
@@ -923,7 +949,9 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
           headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },
         });
       }
+      pathState.enteredLiveFallback = true;
     } catch (error) {
+      pathState.enteredLiveFallback = true;
       console.warn("[stats] fast path unavailable; falling back to live aggregation", {
         requestId,
         error: toErrorSummary(error),
@@ -949,18 +977,28 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
   }
 
   try {
+    pathState.enteredLiveFallback = true;
     const statsResponse = await withDbTimeout(loadStatsFromDb(route, filters), {
       message: "DB_TIMEOUT",
-      onTimeout: ({ timeoutMs, message }) => {
-        if (!shouldLogStatsDiagnostics()) return;
-        console.info("[stats] db timeout reached", {
+      onTimeout: ({ timeoutMs: timeoutMsValue, message }) => {
+        timeoutMs = timeoutMsValue;
+        if (!diagnosticsEnabled) return;
+        console.info("[stats] live path timeout", {
           route,
           filters: summarizeFiltersForLog(filters),
-          timeout_ms: timeoutMs,
+          timeout_ms: timeoutMsValue,
           message,
         });
       },
     });
+    pathState.livePathSuccess = true;
+    if (diagnosticsEnabled) {
+      console.info("[stats] live path success", {
+        route,
+        filters: summarizeFiltersForLog(filters),
+        source: statsResponse.meta?.source ?? "db_live",
+      });
+    }
     return NextResponse.json<StatsApiResponse>(withOkMeta(statsResponse), {
       headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },
     });
@@ -968,6 +1006,24 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
     const code = classifyFailure(error);
     const errorSummary = toErrorSummary(error);
     console.error("[stats] failed to load stats snapshot", { requestId, code, error: errorSummary, detail: error });
+
+    if (diagnosticsEnabled) {
+      const errorInfo = summarizeErrorForLog(error);
+      console.error("[stats] failure diagnostic", {
+        route,
+        filters: summarizeFiltersForLog(filters),
+        allowUnfilteredFastPath,
+        isUnfilteredRequest: isUnfiltered,
+        enteredFastPath: pathState.enteredFastPath,
+        enteredLiveFallback: pathState.enteredLiveFallback,
+        livePathSuccess: pathState.livePathSuccess,
+        failure_code: code,
+        error_message: errorInfo.message,
+        error_name: errorInfo.name,
+        error_stack_head: errorInfo.stack_head,
+        timeout_ms: timeoutMs,
+      });
+    }
 
     if (!shouldAllowJson || process.env.NODE_ENV === "production") {
       const status = code === "db_connect_failed" ? 503 : 500;


### PR DESCRIPTION
### Motivation
- Capture the real exception context for observed `GET /api/stats?country=DE` 500s so we can determine whether failures are timeouts, SQL/connect errors, or unexpected data without changing response shape.
- Keep the change narrowly focused to stats logic and only emit diagnostics when explicitly enabled to avoid noisy production logs.

### Description
- Added a compact error summarizer `summarizeErrorForLog` and a `diagnosticsEnabled` flag driven by `NODE_ENV !== "production" || CPM_STATS_DEBUG_TIMING === "1"` to bound logged details and gate output.
- Track fast-path / live-path state with a small `pathState` object and capture `allowUnfilteredFastPath`, `isUnfilteredRequest`, `enteredFastPath`, `enteredLiveFallback`, `livePathSuccess`, and `timeout_ms` to include in diagnostics.
- Hooked into `withDbTimeout(..., onTimeout)` separately for fast-path and live-path to log `route`, `filters`, `timeout_ms`, and `message` under the debug gate, and added a debug-gated `live path success` info log before returning live results.
- Consolidated the catch logging to emit a single `console.error("[stats] failure diagnostic", {...})` object containing `route`, summarized `filters`, path state, classified `failure_code`, bounded error `message`/`name`/`stack_head`, and `timeout_ms`; only `app/api/stats/route.ts` was modified and response/status/cache headers are unchanged.

### Testing
- Ran `npx eslint app/api/stats/route.ts` which succeeded.
- Launched dev server with `CPM_STATS_DEBUG_TIMING=1 NODE_ENV=development npm run dev` and exercised `GET /api/stats`, `GET /api/stats?country=AQ`, and `GET /api/stats?country=DE` with `curl`, confirming handlers return `ok=true` and debug logs are produced only when enabled.
- Ran `npm run test:stats` which failed due to an unrelated local test/module resolution issue (`Cannot find module '@/lib/db'`) in generated `.tmp-tests`, not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad4dc532e883288ed4b13e4d491cf4)