### PR TITLE
stats: mark fast-path responses via `meta.source = "snapshot_fast_path"`

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -69,7 +69,7 @@ export type StatsApiResponse = {
   generated_at?: string;
   limited?: boolean;
   meta?: {
-    source: "db_live";
+    source: "db_live" | "snapshot_fast_path";
     population_id: typeof MAP_POPULATION_ID;
     as_of: string;
     acceptance_chain_missing_places: number;
@@ -79,6 +79,8 @@ export type StatsApiResponse = {
     network_coverage: number;
   };
 };
+
+type StatsMetaSource = NonNullable<StatsApiResponse["meta"]>["source"];
 
 type StatsUnavailableResponse = {
   ok: false;
@@ -892,11 +894,9 @@ const loadStatsFromDb = async (route: string, filters: StatsFilters): Promise<St
   return fetchDbSnapshotV4(route, filters);
 };
 
-const withOkMeta = (statsResponse: StatsApiResponse): StatsApiResponse => ({
-  ...statsResponse,
-  ok: true,
-  meta: statsResponse.meta ?? {
-    source: "db_live",
+const withOkMeta = (statsResponse: StatsApiResponse, sourceOverride?: StatsMetaSource): StatsApiResponse => {
+  const fallbackMeta = {
+    source: "db_live" as const,
     population_id: MAP_POPULATION_ID,
     as_of: new Date().toISOString(),
     acceptance_chain_missing_places: 0,
@@ -904,8 +904,17 @@ const withOkMeta = (statsResponse: StatsApiResponse): StatsApiResponse => ({
     accepts_with_chain_count: 0,
     accepts_missing_chain_count: 0,
     network_coverage: 0,
-  },
-});
+  };
+
+  return {
+    ...statsResponse,
+    ok: true,
+    meta: {
+      ...(statsResponse.meta ?? fallbackMeta),
+      ...(sourceOverride ? { source: sourceOverride } : {}),
+    },
+  };
+};
 
 export const getStatsResponse = async (request: Request, options: StatsRouteOptions): Promise<Response> => {
   const filters = parseFilters(request);
@@ -945,7 +954,7 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
         },
       });
       if (cachedResponse) {
-        return NextResponse.json<StatsApiResponse>(withOkMeta(cachedResponse), {
+        return NextResponse.json<StatsApiResponse>(withOkMeta(cachedResponse, "snapshot_fast_path"), {
           headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },
         });
       }


### PR DESCRIPTION
### Motivation

- Unfiltered fast-path (snapshot) responses could carry the same `meta.source` as live DB responses, making it impossible to distinguish fast-path success from a live aggregation fallback using only the production API response.
- The change aims to improve observability only, without changing response shape or live-path semantics.

### Description

- Added `"snapshot_fast_path"` to the `meta.source` union in the `StatsApiResponse` type and introduced a helper `StatsMetaSource` type for the source enum.
- Extended `withOkMeta` to accept an optional `sourceOverride` and to merge it into the existing `meta` while preserving all other `meta` fields or generating the previous fallback meta when missing.
- When the unfiltered fast path returns a cached response, the code now calls `withOkMeta(..., "snapshot_fast_path")` so `meta.source` is overwritten only for fast-path success, while live-path responses remain `db_live` and existing diagnostic logs are unchanged.
- The only file changed is `app/api/stats/route.ts` and the response shape is preserved.

### Testing

- Ran `npm run lint` which completed successfully (only existing Next.js lint warnings reported).
- Ran `npm run test:stats` which failed in this environment due to an unrelated module resolution error for `@/lib/db` in the generated test harness, so tests could not fully complete; the failure is unrelated to the changes made.
- Verified locally in-code that fast-path return now uses `withOkMeta(..., "snapshot_fast_path")` and that live path still returns `meta.source: "db_live"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7d7a224c8328bf1995ec5669c89b)