### PR TITLE
CPM: debug-only stats fast-path miss reason logging

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -10,7 +10,10 @@ import {
   getDataSourceSetting,
   withDbTimeout,
 } from "@/lib/dataSource";
-import { loadUnfilteredStatsSnapshotFastPath } from "@/lib/stats/snapshotFastPath";
+import {
+  type StatsSnapshotFastPathResult,
+  loadUnfilteredStatsSnapshotFastPath,
+} from "@/lib/stats/snapshotFastPath";
 import { getMapDisplayableWhereClauses, isMapDisplayablePlace } from "@/lib/stats/mapPopulation";
 import { normalizeAcceptanceChainKey } from "@/lib/stats/acceptance";
 
@@ -936,11 +939,12 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
     livePathSuccess: false,
   };
   let timeoutMs: number | null = null;
+  let fastPathMiss: StatsSnapshotFastPathResult["miss"];
 
   if (allowUnfilteredFastPath && isUnfiltered && shouldAttemptDb) {
     pathState.enteredFastPath = true;
     try {
-      const cachedResponse = await withDbTimeout(loadUnfilteredStatsSnapshotFastPath(route), {
+      const fastPathResult = await withDbTimeout(loadUnfilteredStatsSnapshotFastPath(route), {
         message: "DB_TIMEOUT",
         onTimeout: ({ timeoutMs: timeoutMsValue, message }) => {
           timeoutMs = timeoutMsValue;
@@ -953,11 +957,23 @@ export const getStatsResponse = async (request: Request, options: StatsRouteOpti
           });
         },
       });
-      if (cachedResponse) {
-        return NextResponse.json<StatsApiResponse>(withOkMeta(cachedResponse, "snapshot_fast_path"), {
+      fastPathMiss = fastPathResult.miss;
+
+      if (fastPathResult.payload) {
+        return NextResponse.json<StatsApiResponse>(withOkMeta(fastPathResult.payload, "snapshot_fast_path"), {
           headers: { "Cache-Control": CACHE_CONTROL, ...buildDataSourceHeaders("db", false) },
         });
       }
+      if (diagnosticsEnabled && fastPathMiss) {
+        console.info("[stats] fast path miss", {
+          route,
+          miss_reason: fastPathMiss.reason,
+          table: fastPathMiss.table ?? null,
+          enteredFastPath: pathState.enteredFastPath,
+          enteredLiveFallback: true,
+        });
+      }
+
       pathState.enteredLiveFallback = true;
     } catch (error) {
       pathState.enteredLiveFallback = true;

--- a/lib/stats/snapshotFastPath.ts
+++ b/lib/stats/snapshotFastPath.ts
@@ -6,6 +6,20 @@ type SnapshotSourceRow = {
   payload: unknown;
 };
 
+export type StatsSnapshotFastPathMissReason =
+  | "table_missing"
+  | "column_missing"
+  | "payload_invalid"
+  | "exception";
+
+export type StatsSnapshotFastPathResult = {
+  payload: StatsApiResponse | null;
+  miss?: {
+    reason: StatsSnapshotFastPathMissReason;
+    table?: string;
+  };
+};
+
 const SNAPSHOT_TABLE_CANDIDATES = [
   { table: "stats_cache", payloadColumn: "payload", timestampColumn: "as_of" },
   { table: "stats_snapshot", payloadColumn: "payload", timestampColumn: "as_of" },
@@ -51,36 +65,59 @@ const isStatsApiResponse = (value: unknown): value is StatsApiResponse => {
 
 export const loadUnfilteredStatsSnapshotFastPath = async (
   route: string,
-): Promise<StatsApiResponse | null> => {
+): Promise<StatsSnapshotFastPathResult> => {
+  let miss: StatsSnapshotFastPathResult["miss"];
+
   for (const candidate of SNAPSHOT_TABLE_CANDIDATES) {
-    const exists = await tableExists(route, candidate.table);
-    if (!exists) continue;
+    try {
+      const exists = await tableExists(route, candidate.table);
+      if (!exists) {
+        miss = miss ?? { reason: "table_missing", table: candidate.table };
+        continue;
+      }
 
-    const [hasPayload, hasTimestamp] = await Promise.all([
-      hasColumn(route, candidate.table, candidate.payloadColumn),
-      hasColumn(route, candidate.table, candidate.timestampColumn),
-    ]);
+      const [hasPayload, hasTimestamp] = await Promise.all([
+        hasColumn(route, candidate.table, candidate.payloadColumn),
+        hasColumn(route, candidate.table, candidate.timestampColumn),
+      ]);
 
-    if (!hasPayload || !hasTimestamp) continue;
+      if (!hasPayload || !hasTimestamp) {
+        miss = { reason: "column_missing", table: candidate.table };
+        continue;
+      }
 
-    const payloadSql = quoteIdentifier(candidate.payloadColumn);
-    const timestampSql = quoteIdentifier(candidate.timestampColumn);
-    const tableSql = quoteIdentifier(candidate.table);
+      const payloadSql = quoteIdentifier(candidate.payloadColumn);
+      const timestampSql = quoteIdentifier(candidate.timestampColumn);
+      const tableSql = quoteIdentifier(candidate.table);
 
-    const { rows } = await dbQuery<SnapshotSourceRow>(
-      `SELECT ${payloadSql} AS payload
-       FROM ${tableSql}
-       ORDER BY ${timestampSql} DESC
-       LIMIT 1`,
-      [],
-      { route },
-    );
+      const { rows } = await dbQuery<SnapshotSourceRow>(
+        `SELECT ${payloadSql} AS payload
+         FROM ${tableSql}
+         ORDER BY ${timestampSql} DESC
+         LIMIT 1`,
+        [],
+        { route },
+      );
 
-    const payload = rows[0]?.payload;
-    if (isStatsApiResponse(payload)) {
-      return payload;
+      const payload = rows[0]?.payload;
+      if (isStatsApiResponse(payload)) {
+        return { payload };
+      }
+
+      miss = { reason: "payload_invalid", table: candidate.table };
+    } catch {
+      return {
+        payload: null,
+        miss: {
+          reason: "exception",
+          table: candidate.table,
+        },
+      };
     }
   }
 
-  return null;
+  return {
+    payload: null,
+    miss,
+  };
 };


### PR DESCRIPTION
### Motivation

- Make it possible to unambiguously determine why the unfiltered stats fast path missed for `/api/stats` and `/api/stats/snapshot` without changing production response shape.
- Restrict the change to observability only and ensure miss details are emitted only during debug diagnostics so production noise is avoided.
- Limit scope to stats logic only and avoid any schema/migration changes.

### Description

- Add `StatsSnapshotFastPathMissReason` and `StatsSnapshotFastPathResult` types and change `loadUnfilteredStatsSnapshotFastPath` to return a structured result `{ payload, miss? }` instead of a nullable payload in `lib/stats/snapshotFastPath.ts`.
- Classify miss reasons as `table_missing`, `column_missing`, `payload_invalid`, and `exception`, and include the failing candidate `table` when available.
- Wire the new result in `getStatsResponse` (import `type StatsSnapshotFastPathResult`) and when diagnostics are enabled (`shouldLogStatsDiagnostics()`), emit a debug-only `console.info` containing `route`, `miss_reason`, `table`, `enteredFastPath`, and `enteredLiveFallback`.
- Preserve fast-path success behavior and `meta.source = "snapshot_fast_path"` override, and do not alter normal response body shape or any DB schema.

### Testing

- Ran `npx eslint lib/stats/snapshotFastPath.ts app/api/stats/route.ts`, which succeeded.
- Ran `npm run test:stats`, which mostly executed but failed due to unrelated environment/module resolution (`Cannot find module '@/lib/db'`) in existing tests, so full test-suite validation is blocked by unrelated test setup issues.
- Ran `npx tsc --noEmit`, which reported unrelated TypeScript errors in `tests/audit/*.spec.ts`, so type-checking the entire repo is also blocked by preexisting test files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8369dd4c8328a503b628306ad48d)