### PR TITLE
Implement stats_cache persistence for unfiltered stats fast path

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -893,9 +893,12 @@ const fetchDbSnapshotV4 = async (route: string, filters: StatsFilters): Promise<
   };
 };
 
-const loadStatsFromDb = async (route: string, filters: StatsFilters): Promise<StatsApiResponse> => {
+export const loadStatsFromDb = async (route: string, filters: StatsFilters): Promise<StatsApiResponse> => {
   return fetchDbSnapshotV4(route, filters);
 };
+
+export const loadUnfilteredStatsFromDb = (route: string): Promise<StatsApiResponse> =>
+  loadStatsFromDb(route, { ...EMPTY_FILTERS });
 
 const withOkMeta = (statsResponse: StatsApiResponse, sourceOverride?: StatsMetaSource): StatsApiResponse => {
   const fallbackMeta = {

--- a/migrations/20260308_stats_cache.sql
+++ b/migrations/20260308_stats_cache.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS public.stats_cache (
+  cache_key TEXT PRIMARY KEY,
+  payload JSONB NOT NULL,
+  as_of TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS stats_cache_as_of_idx
+  ON public.stats_cache (as_of DESC);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "db:migrate:stats-timeseries": "tsx scripts/db_apply_sql.ts migrations/20260227_stats_timeseries.sql",
     "snapshot:build": "tsx scripts/build_published_places_snapshot.ts",
     "snapshot:verify": "tsx scripts/verify_published_places_snapshot.ts",
-    "import:osm:raw": "node --import tsx scripts/import_osm_raw_candidates.ts"
+    "import:osm:raw": "node --import tsx scripts/import_osm_raw_candidates.ts",
+    "db:migrate:stats-cache": "tsx scripts/db_apply_sql.ts migrations/20260308_stats_cache.sql",
+    "stats:cache:refresh": "tsx scripts/refresh_stats_cache.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.862.0",

--- a/scripts/refresh_stats_cache.ts
+++ b/scripts/refresh_stats_cache.ts
@@ -1,0 +1,48 @@
+import { dbQuery, hasDatabaseUrl } from "@/lib/db";
+import { loadUnfilteredStatsFromDb, type StatsApiResponse } from "@/app/api/stats/route";
+
+const ROUTE = "scripts_refresh_stats_cache";
+const CACHE_KEY = "global_unfiltered";
+
+const resolveAsOf = (payload: StatsApiResponse) => {
+  const candidate = payload.meta?.as_of;
+  if (!candidate) return new Date().toISOString();
+
+  const parsed = new Date(candidate);
+  if (Number.isNaN(parsed.getTime())) return new Date().toISOString();
+  return parsed.toISOString();
+};
+
+async function main() {
+  if (!hasDatabaseUrl()) {
+    console.error("Missing DATABASE_URL environment variable");
+    process.exit(1);
+  }
+
+  const payload = await loadUnfilteredStatsFromDb(ROUTE);
+  const asOf = resolveAsOf(payload);
+
+  await dbQuery(
+    `INSERT INTO stats_cache (cache_key, payload, as_of, updated_at)
+     VALUES ($1, $2::jsonb, $3::timestamptz, NOW())
+     ON CONFLICT (cache_key)
+     DO UPDATE SET
+       payload = EXCLUDED.payload,
+       as_of = EXCLUDED.as_of,
+       updated_at = NOW()`,
+    [CACHE_KEY, JSON.stringify(payload), asOf],
+    { route: ROUTE },
+  );
+
+  console.log("[refresh_stats_cache] done", {
+    cacheKey: CACHE_KEY,
+    asOf,
+    totalPlaces: payload.total_places,
+    source: payload.meta?.source ?? "db_live",
+  });
+}
+
+main().catch((error) => {
+  console.error("[refresh_stats_cache] failed", error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Provide a real `stats_cache` storage so the unfiltered stats fast path can return a saved snapshot instead of missing with `table_missing`.
- Avoid doing live aggregation for the unfiltered initial `/api/stats` and `/api/stats/snapshot` views by returning a precomputed payload while keeping filtered requests live.
- Preserve the existing `StatsApiResponse` shape and diagnostic signals so the UI and monitoring remain unchanged.

### Description
- Add a minimal migration to create `public.stats_cache` with `cache_key`, `payload JSONB`, `as_of TIMESTAMPTZ` and `updated_at`, plus an index on `as_of` for latest reads (`migrations/20260308_stats_cache.sql`).
- Export `loadUnfilteredStatsFromDb()` from `app/api/stats/route.ts` so the exact `StatsApiResponse` produced by live aggregation can be generated programmatically.
- Add `scripts/refresh_stats_cache.ts` which runs the unfiltered live aggregation and upserts the full JSON payload into `stats_cache` using `cache_key = "global_unfiltered"`.
- Add npm scripts `db:migrate:stats-cache` and `stats:cache:refresh` to apply the migration and populate the cache respectively, without changing filtered stats logic.

### Testing
- Ran `npm run test:stats`; result: failed due to an existing unrelated module-resolution error (`Cannot find module '@/lib/db'`) in the test environment.
- Ran `bash scripts/ci/check_stats_source.sh`; result: failed due to an existing baseline guard mismatch for `population_id` (pre-existing project condition).
- Ran `npm run stats:cache:refresh`; result: failed in this environment because `DATABASE_URL` is not configured, which is expected here (script requires DB connectivity).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8e646e7c8328a62614927cf8aa70)