### PR TITLE
PR-08: Remove `Disallow: /_next/` from robots output

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,7 +7,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: '/',
-      disallow: ['/api/', '/_next/', '/internal', '/internal/'],
+      disallow: ['/api/', '/internal', '/internal/'],
     },
     sitemap: `${SITE_URL}/sitemap.xml`,
   };


### PR DESCRIPTION
### Motivation
- Prevent blocking Next.js delivery assets from crawlers so rendering resources (JS/CSS under `/_next/`) can be crawled, while keeping this as a minimal robots-only change.

### Description
- Updated `app/robots.ts` to remove only `'/_next/'` from the `disallow` list and kept `'/api/'`, `'/internal'`, `'/internal/'` and the sitemap (`https://www.cryptopaymap.com/sitemap.xml`) unchanged.

### Testing
- Ran `npm run lint` and `npm run build`, both completed successfully (lint emitted unrelated warnings but did not fail).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad9d104fb88328925b41b80658b96a)