### PR TITLE
Enable explicit --live Overpass fetch for OSM raw candidate import (no DB writes)

### DIFF
--- a/docs/import-osm-raw-candidates.md
+++ b/docs/import-osm-raw-candidates.md
@@ -1,7 +1,25 @@
-# OSM raw candidate import (Phase 1 / implementation-only)
+# OSM raw candidate import (Phase 1 / raw候補取得)
 
-このジョブは `scripts/import_osm_raw_candidates.ts` を使って、OSM/Overpass から取得可能な構造を実装します。  
-**このフェーズでは実データ取得を実行しません。** `--dry-run` が必須で、fixture からのみ生成します。
+このジョブは `scripts/import_osm_raw_candidates.ts` を使って、OSM 候補を **region 単位**で raw JSONL に保存します。  
+Phase 1 では **DB 書込なし（insert / update / delete なし）** で、保存対象は raw JSONL とログのみです。
+
+## 安全ガード（最重要）
+
+- デフォルトは安全側: `--live` を付けない限り実通信しません。
+- `--dry-run` 指定時: fixture を読み込んで変換のみ実行します。
+- `--live` 指定時のみ: Overpass へ実通信します。
+- `--dry-run` と `--live` の同時指定はエラーです。
+
+## CLI オプション
+
+- `--region`（必須）: 出力・ログを分離する region 名
+- `--limit`（必須運用）: 最大書込件数
+- `--out`: Raw JSONL 出力先（省略時: `data/import/raw/raw_osm_candidates.<region>.jsonl`）
+- `--log`: ログ出力先（省略時: `data/import/logs/raw_osm_candidates.<region>.log`）
+- `--dry-run`: fixture モード
+- `--live`: Overpass 実通信モード（明示必須）
+- `--fixture`: fixture JSON パス（dry-run 時に使用）
+- `--overpass-url`: Overpass endpoint（live 時に使用）
 
 ## 出力先
 
@@ -25,36 +43,86 @@ raw 段階は「crypto payment candidate を広く拾う」目的で、次の合
 
 > `payment:cash` / `payment:credit_cards` / `payment:debit_cards` / `payment:contactless` など一般決済タグは対象外。
 
-## 小試走（fixture / dry-run のみ）
+## dry-run 実行例（fixture のみ）
 
 ```bash
 node --import tsx scripts/import_osm_raw_candidates.ts \
   --region japan \
-  --limit 1000 \
+  --limit 300 \
   --out data/import/raw/raw_osm_candidates.japan.jsonl \
-  --dry-run
-```
-
-fixture を差し替える場合:
-
-```bash
-node --import tsx scripts/import_osm_raw_candidates.ts \
-  --region germany \
-  --limit 200 \
+  --log data/import/logs/raw_osm_candidates.japan.log \
   --fixture scripts/fixtures/osm_candidates_sample.json \
   --dry-run
 ```
 
-## 本番取得コマンド例（将来運用時の参考。今回実行禁止）
-
-> 以下は将来の運用時に使う想定の例です。Phase 1 では実行しません。
+## live 実行例（小規模）
 
 ```bash
 node --import tsx scripts/import_osm_raw_candidates.ts \
-  --region europe-west \
-  --limit 5000 \
-  --out data/import/raw/raw_osm_candidates.europe-west.jsonl \
-  --dry-run
+  --region japan \
+  --limit 300 \
+  --out data/import/raw/raw_osm_candidates.japan.jsonl \
+  --log data/import/logs/raw_osm_candidates.japan.log \
+  --overpass-url https://overpass-api.de/api/interpreter \
+  --live
+```
+
+## live 実行例（本番拡張時の region 分割）
+
+```bash
+node --import tsx scripts/import_osm_raw_candidates.ts --region japan --limit 500 --out data/import/raw/raw_osm_candidates.japan.jsonl --log data/import/logs/raw_osm_candidates.japan.log --live
+node --import tsx scripts/import_osm_raw_candidates.ts --region germany --limit 500 --out data/import/raw/raw_osm_candidates.germany.jsonl --log data/import/logs/raw_osm_candidates.germany.log --live
+node --import tsx scripts/import_osm_raw_candidates.ts --region europe-west --limit 500 --out data/import/raw/raw_osm_candidates.europe-west.jsonl --log data/import/logs/raw_osm_candidates.europe-west.log --live
+```
+
+## ログ項目（live / dry-run 共通）
+
+- start/end timestamp
+- region
+- overpass url
+- loaded
+- written
+- skipped_missing_name
+- skipped_non_candidate
+- skipped_missing_coords
+- skipped_duplicate
+- failed_transform
+- failed_fetch
+- mode（fixture / live）
+
+想定ログ（例）:
+
+```text
+[mode] live
+[start] timestamp=2026-03-08T16:10:00.000Z region=japan dry_run=false live=true limit=300
+[overpass_url] https://overpass-api.de/api/interpreter
+...
+[summary] loaded=428
+[summary] written=300
+[summary] skipped_missing_name=8
+[summary] skipped_non_candidate=60
+[summary] skipped_missing_coords=5
+[summary] skipped_duplicate=3
+[summary] failed_transform=0
+[summary] failed_fetch=0
+[end] timestamp=2026-03-08T16:10:20.000Z region=japan
+[done] out=data/import/raw/raw_osm_candidates.japan.jsonl
+```
+
+## 失敗時の再実行
+
+- fetch 失敗時は region 単位で失敗終了します（他 region に影響なし）。
+- 同一 region を同じ `--region` / `--out` / `--log` で再実行してください。
+- 例:
+
+```bash
+node --import tsx scripts/import_osm_raw_candidates.ts \
+  --region japan \
+  --limit 300 \
+  --out data/import/raw/raw_osm_candidates.japan.jsonl \
+  --log data/import/logs/raw_osm_candidates.japan.log \
+  --overpass-url https://overpass-api.de/api/interpreter \
+  --live
 ```
 
 ## chain candidate 判定
@@ -63,31 +131,6 @@ node --import tsx scripts/import_osm_raw_candidates.ts \
 - `payment:onchain=yes|only` かつ `currency:XBT=yes` (または `currency:BTC=yes`) → `raw_chain_candidate=Bitcoin`, `raw_chain_confidence=medium`
 - payment/currency タグはあるが上記に合致しない（例: `currency:BCH=yes`, `currency:ETH=yes`, `currency:USDT=yes`） → `raw_chain_candidate=null`, `raw_chain_confidence=low`
 - payment/currency タグが存在しない → `raw_chain_candidate=null`, `raw_chain_confidence=none`
-
-## 注意
-
-- 実通信（Overpass/OSM API）は Phase 1 では禁止。
-- DB への insert/update/delete はこのジョブでは行わない。
-- region 単位で再実行可能（出力ファイルを region 別に分離）。
-
-## dry-run 想定出力
-
-標準出力（例）:
-
-```text
-dry-run complete: wrote 6 records to data/import/raw/raw_osm_candidates.japan.jsonl
-log file: data/import/logs/raw_osm_candidates.japan.log
-```
-
-ログ要約（例）:
-
-- loaded=12
-- written=6
-- skipped_missing_name=1
-- skipped_non_candidate=3  # cash/credit/debit only fixture
-- skipped_missing_coords=1
-- skipped_duplicate=1
-- failed_transform=0
 
 ## JSONL 1レコード例
 

--- a/scripts/import_osm_raw_candidates.ts
+++ b/scripts/import_osm_raw_candidates.ts
@@ -8,6 +8,7 @@ type Args = {
   out: string;
   log: string;
   dryRun: boolean;
+  live: boolean;
   fixture: string;
   overpassUrl: string;
 };
@@ -80,6 +81,7 @@ const PAYMENT_ACCEPTED_VALUES = new Set(['yes', 'limited', 'only']);
 
 const DEFAULT_FIXTURE = 'scripts/fixtures/osm_candidates_sample.json';
 const DEFAULT_OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+const DEFAULT_FETCH_TIMEOUT_MS = 120_000;
 
 function parseArgs(argv: string[]): Args {
   const pairs = new Map<string, string | boolean>();
@@ -104,8 +106,9 @@ function parseArgs(argv: string[]): Args {
   }
 
   const dryRun = pairs.get('dry-run') === true;
-  if (!dryRun) {
-    throw new Error('This implementation is guarded: --dry-run is mandatory in this phase.');
+  const live = pairs.get('live') === true;
+  if (dryRun && live) {
+    throw new Error('--dry-run and --live cannot be used together');
   }
 
   const limitRaw = String(pairs.get('limit') || '1000');
@@ -123,7 +126,7 @@ function parseArgs(argv: string[]): Args {
   const fixture = String(pairs.get('fixture') || DEFAULT_FIXTURE);
   const overpassUrl = String(pairs.get('overpass-url') || DEFAULT_OVERPASS_URL);
 
-  return { region, limit, out, log, dryRun, fixture, overpassUrl };
+  return { region, limit, out, log, dryRun, live, fixture, overpassUrl };
 }
 
 function selectRegionPreset(region: string): RegionPreset {
@@ -313,22 +316,81 @@ async function loadFixtureElements(filePath: string): Promise<OsmElement[]> {
   return Array.isArray(parsed.elements) ? parsed.elements : [];
 }
 
+async function fetchOverpassElements(args: Args, query: string): Promise<OsmElement[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(args.overpassUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
+      },
+      body: `data=${encodeURIComponent(query)}`,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${responseText.slice(0, 500)}`);
+    }
+
+    const parsed = (await response.json()) as { elements?: OsmElement[] };
+    return Array.isArray(parsed.elements) ? parsed.elements : [];
+  } catch (error) {
+    if ((error as Error).name === 'AbortError') {
+      throw new Error(`overpass fetch timeout after ${String(DEFAULT_FETCH_TIMEOUT_MS)}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const query = buildOverpassQuery(args.region, args.limit);
   const ingestedAt = new Date().toISOString();
+  const startedAt = new Date().toISOString();
 
   await mkdir(path.dirname(args.out), { recursive: true });
   await mkdir(path.dirname(args.log), { recursive: true });
 
   const logs: string[] = [];
-  logs.push(`[start] region=${args.region} dry_run=${String(args.dryRun)} limit=${String(args.limit)}`);
+  const mode = args.live ? 'live' : 'fixture';
+  logs.push(`[mode] ${mode}`);
+  logs.push(
+    `[start] timestamp=${startedAt} region=${args.region} dry_run=${String(args.dryRun)} live=${String(args.live)} limit=${String(args.limit)}`,
+  );
+  logs.push(`[overpass_url] ${args.overpassUrl}`);
   logs.push(`[query] ${query.replace(/\s+/g, ' ').trim()}`);
   logs.push(`[query] payment_allowlist=${CRYPTO_PAYMENT_KEY_ALLOWLIST.join(',')}`);
   logs.push(`[query] currency_allowlist=${CRYPTO_CURRENCY_ALLOWLIST.join(',')}`);
-  logs.push('[guard] live fetch is disabled in this phase; fixture source only');
 
-  const sourceElements = await loadFixtureElements(args.fixture);
+  let failedFetch = 0;
+  let sourceElements: OsmElement[] = [];
+  if (args.live) {
+    try {
+      sourceElements = await fetchOverpassElements(args, query);
+    } catch (error) {
+      failedFetch = 1;
+      logs.push(`[error][fetch] ${(error as Error).message}`);
+      logs.push(`[summary] loaded=0`);
+      logs.push('[summary] written=0');
+      logs.push('[summary] skipped_missing_name=0');
+      logs.push('[summary] skipped_non_candidate=0');
+      logs.push('[summary] skipped_missing_coords=0');
+      logs.push('[summary] skipped_duplicate=0');
+      logs.push('[summary] failed_transform=0');
+      logs.push(`[summary] failed_fetch=${String(failedFetch)}`);
+      logs.push(`[end] timestamp=${new Date().toISOString()} region=${args.region}`);
+      await writeFile(args.log, `${logs.join('\n')}\n`, 'utf8');
+      throw new Error(`live fetch failed for region=${args.region}. see log: ${args.log}`);
+    }
+  } else {
+    logs.push(`[fixture] ${args.fixture}`);
+    sourceElements = await loadFixtureElements(args.fixture);
+  }
+
   let skippedInvalid = 0;
   let skippedDuplicate = 0;
   let skippedMissingName = 0;
@@ -391,11 +453,13 @@ async function main(): Promise<void> {
   logs.push(`[summary] skipped_missing_coords=${String(skippedMissingCoords)}`);
   logs.push(`[summary] skipped_duplicate=${String(skippedDuplicate)}`);
   logs.push(`[summary] failed_transform=${String(failedTransform)}`);
+  logs.push(`[summary] failed_fetch=${String(failedFetch)}`);
+  logs.push(`[end] timestamp=${new Date().toISOString()} region=${args.region}`);
   logs.push(`[done] out=${args.out}`);
 
   await writeFile(args.log, `${logs.join('\n')}\n`, 'utf8');
 
-  console.log(`dry-run complete: wrote ${records.length} records to ${args.out}`);
+  console.log(`${mode} run complete: wrote ${records.length} records to ${args.out}`);
   console.log(`log file: ${args.log}`);
 }
 


### PR DESCRIPTION
### Motivation

- Phase 1 needs to advance from fixture-only to optionally performing real Overpass fetches while remaining safe: live network I/O must be explicit and the job must never write to the DB.

### Description

- Added guarded runtime mode flags and behavior to `scripts/import_osm_raw_candidates.ts`, introducing `--live` (Overpass fetch) and preserving `--dry-run` (fixture) while rejecting `--dry-run` + `--live` combinations.
- Implemented Overpass HTTP fetch using `--overpass-url` with a request timeout and region-scoped failure handling that sets `failed_fetch` and exits the region run without touching any DB.
- Enhanced logging and outputs to include `mode`, start/end timestamps, `region`, `overpass_url`, `loaded`, `written`, `skipped_*` counters, `failed_transform` and `failed_fetch`, and ensured raw JSONL and log files are written per region.
- Updated documentation `docs/import-osm-raw-candidates.md` to describe CLI options, `--live` explicit requirement, fixture usage, live examples (small and region-split), DB-no-write guarantee, retry guidance, and expected log format.

### Testing

- Ran fixture dry-run: `node --import tsx scripts/import_osm_raw_candidates.ts --region japan --limit 20 --out /tmp/raw.japan.jsonl --log /tmp/raw.japan.log --dry-run --fixture scripts/fixtures/osm_candidates_sample.json --overpass-url https://overpass-api.de/api/interpreter` and it completed successfully (wrote records and produced log).
- Verified guard behavior: `node --import tsx scripts/import_osm_raw_candidates.ts --region japan --limit 20 --out /tmp/raw.japan.jsonl --log /tmp/raw.japan.log --dry-run --live` returned the expected guard error (`--dry-run and --live cannot be used together`).
- Verified fixture run for another region: `node --import tsx scripts/import_osm_raw_candidates.ts --region germany --limit 10 --out /tmp/raw.germany.jsonl --log /tmp/raw.germany.log --fixture scripts/fixtures/osm_candidates_sample.json` completed successfully.
- Attempted live fetch: `node --import tsx scripts/import_osm_raw_candidates.ts --region japan --limit 50 --out /tmp/raw.japan.live.jsonl --log /tmp/raw.japan.live.log --live --overpass-url https://overpass-api.de/api/interpreter` attempted a network fetch but failed in this environment and exited with `failed_fetch=1` in the log as designed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada2644270832894cff499ca6b6b8a)