### PR TITLE
feat(map): add world/low-zoom overview mode for production candidate

### DIFF
--- a/app/api/places/overview/route.ts
+++ b/app/api/places/overview/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { parseBbox } from "@/lib/geo/bbox";
+import { DbUnavailableError } from "@/lib/db";
+import {
+  buildDataSourceHeaders,
+  getDataSourceContext,
+  getDataSourceSetting,
+  withDbTimeout,
+} from "@/lib/dataSource";
+import { normalizeAcceptsAsset } from "@/lib/acceptsAsset";
+import { listPlacesOverviewForMap } from "@/lib/places/listPlacesOverviewForMap";
+
+const CACHE_CONTROL = "public, max-age=0, s-maxage=30, stale-while-revalidate=120";
+const NO_STORE = "no-store";
+
+const parseSearchTerm = (value: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim().replace(/\s+/g, " ");
+  if (!trimmed) return null;
+  return trimmed.slice(0, 120);
+};
+
+const parseZoom = (value: string | null): number => {
+  if (!value) return 2;
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return 2;
+  return Math.max(0, Math.min(parsed, 22));
+};
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const bboxResult = parseBbox(searchParams.get("bbox"));
+
+  const dataSource = getDataSourceSetting();
+  const { shouldAttemptDb, shouldAllowJson } = getDataSourceContext(dataSource);
+  const defaultSource = dataSource === "json" ? "json" : dataSource === "db" ? "db" : shouldAttemptDb ? "db" : "json";
+  const defaultHeaders = buildDataSourceHeaders(defaultSource, defaultSource === "json");
+
+  if (bboxResult.error) {
+    return NextResponse.json(
+      { ok: false, error: "INVALID_BBOX", message: bboxResult.error },
+      { status: 400, headers: { "Cache-Control": NO_STORE, ...defaultHeaders } },
+    );
+  }
+
+  const chainFilters = searchParams.getAll("chain").flatMap((v) => v.split(",")).map((v) => v.trim()).filter(Boolean);
+  const paymentFilters = searchParams.getAll("payment").flatMap((v) => v.split(",")).map((v) => v.trim()).filter(Boolean);
+
+  const filters = {
+    asset: normalizeAcceptsAsset(searchParams.get("asset")),
+    category: searchParams.get("category"),
+    country: searchParams.get("country"),
+    city: searchParams.get("city"),
+    bbox: bboxResult.bbox,
+    verification: searchParams.getAll("verification").flatMap((v) => v.split(",")).map((v) => v.trim()).filter(Boolean) as ("owner" | "community" | "directory" | "unverified")[],
+    payment: Array.from(new Set([...chainFilters, ...paymentFilters])).map((v) => v.toLowerCase()),
+    search: parseSearchTerm(searchParams.get("q")),
+    zoom: parseZoom(searchParams.get("zoom")),
+  };
+
+  try {
+    const result = await withDbTimeout(
+      listPlacesOverviewForMap({
+        dataSource: dataSource === "auto" ? "auto" : dataSource,
+        filters,
+      }),
+      { message: "DB_TIMEOUT" },
+    );
+
+    return NextResponse.json(
+      {
+        clusters: result.clusters,
+        totalPlaces: result.totalPlaces,
+        cellSizeDeg: result.cellSizeDeg,
+      },
+      {
+        headers: {
+          "Cache-Control": CACHE_CONTROL,
+          ...buildDataSourceHeaders(result.source, result.limited),
+          ...(result.lastUpdatedISO ? { "x-cpm-last-updated": result.lastUpdatedISO } : {}),
+        },
+      },
+    );
+  } catch (error) {
+    if (!shouldAllowJson || dataSource === "db") {
+      return NextResponse.json(
+        { ok: false, error: "DB_UNAVAILABLE" },
+        { status: 503, headers: { "Cache-Control": NO_STORE, ...buildDataSourceHeaders("db", true) } },
+      );
+    }
+    if (error instanceof DbUnavailableError) {
+      return NextResponse.json(
+        { ok: false, error: "DB_UNAVAILABLE" },
+        { status: 503, headers: { "Cache-Control": NO_STORE, ...buildDataSourceHeaders("db", true) } },
+      );
+    }
+    return NextResponse.json(
+      { ok: false, error: "FALLBACK_SNAPSHOT_UNAVAILABLE" },
+      { status: 503, headers: { "Cache-Control": NO_STORE, ...buildDataSourceHeaders("json", true) } },
+    );
+  }
+}

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -37,7 +37,8 @@ const HEADER_HEIGHT = 64;
 const DEFAULT_COORDINATES: [number, number] = [20, 0];
 const DEFAULT_ZOOM = 2;
 const MAX_CLIENT_LIMIT = 12000;
-const BBOX_PRECISION = 6;
+const BBOX_PRECISION = 3;
+const OVERVIEW_MAX_ZOOM = 3;
 
 const PIN_SVGS: Record<PinType, string> = {
   owner: `<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g><path d="M16 2 C10 2,6 6.5,6 12 C6 20,16 30,16 30 C16 30,26 20,26 12 C26 6.5,22 2,16 2Z" fill="#F59E0B" stroke="white" stroke-width="2"/><circle cx="16" cy="12" r="4" fill="white"/></g></svg>`,
@@ -114,10 +115,17 @@ export default function MapClient() {
     force: boolean;
     zoom: number;
   } | null>(null);
+  const usingOverviewRef = useRef(false);
   const lastRequestKeyRef = useRef<string | null>(null);
   const placesCacheRef = useRef<Map<string, { places: Place[]; limit: number; limited: boolean; lastUpdatedISO: string | null }>>(
     new Map(),
   );
+  const overviewCacheRef = useRef<Map<string, { clusters: ClusterResult[]; totalPlaces: number; limited: boolean; lastUpdatedISO: string | null }>>(
+    new Map(),
+  );
+  const lastRenderedClustersKeyRef = useRef<string | null>(null);
+  const [isOverviewMode, setIsOverviewMode] = useState(false);
+  const [overviewTotalPlaces, setOverviewTotalPlaces] = useState<number | null>(null);
   const [places, setPlaces] = useState<Place[]>([]);
   const [placesStatus, setPlacesStatus] = useState<
     "idle" | "loading" | "success" | "error"
@@ -407,6 +415,19 @@ export default function MapClient() {
 
       if (!markerLayerRef.current || !L || !map) return;
 
+      const clustersKey = clusters
+        .map((clusterItem) => {
+          if (clusterItem.type === "cluster") {
+            return `c:${clusterItem.coordinates[0].toFixed(4)}:${clusterItem.coordinates[1].toFixed(4)}:${clusterItem.pointCount}`;
+          }
+          return `p:${clusterItem.id}:${clusterItem.coordinates[0].toFixed(4)}:${clusterItem.coordinates[1].toFixed(4)}`;
+        })
+        .join("|");
+      if (lastRenderedClustersKeyRef.current === clustersKey) {
+        return;
+      }
+      lastRenderedClustersKeyRef.current = clustersKey;
+
       stopRenderFrame();
       const nextLayer = L.layerGroup();
       const nextMarkers = new Map<string, import("leaflet").Marker>();
@@ -425,9 +446,12 @@ export default function MapClient() {
 
           const marker = L.marker([lat, lng], { icon: clusterIcon });
           marker.on("click", () => {
-            const expansionZoom = clusterIndexRef.current?.getClusterExpansionZoom(
-              clusterItem.id,
-            );
+            if (usingOverviewRef.current) {
+              const nextZoom = Math.max(OVERVIEW_MAX_ZOOM + 1, Math.min(map.getZoom() + 2, 18));
+              map.flyTo([lat, lng], nextZoom, { animate: true });
+              return;
+            }
+            const expansionZoom = clusterIndexRef.current?.getClusterExpansionZoom(clusterItem.id);
             if (expansionZoom !== undefined) {
               map.flyTo([lat, lng], expansionZoom, { animate: true });
             }
@@ -469,12 +493,13 @@ export default function MapClient() {
         } else {
           renderFrameRef.current = null;
           if (!mapInstanceRef.current) return;
-          if (markerLayerRef.current) {
-            map.removeLayer(markerLayerRef.current);
-          }
+          const previousLayer = markerLayerRef.current;
           nextLayer.addTo(map);
           markerLayerRef.current = nextLayer;
           markersRef.current = nextMarkers;
+          if (previousLayer) {
+            map.removeLayer(previousLayer);
+          }
         }
       };
 
@@ -594,6 +619,102 @@ export default function MapClient() {
       const buildRequestKey = (bboxKey: string, zoom: number, filterQuery: string) =>
         `${bboxKey}@${zoom}|${filterQuery}`;
 
+      const fetchOverviewForBbox = async (
+        bboxKey: string,
+        zoom: number,
+        filterQuery: string,
+        requestKey: string,
+      ) => {
+        if (!isMounted) return;
+        requestIdRef.current += 1;
+        const requestId = requestIdRef.current;
+        abortControllerRef.current?.abort();
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        const cached = overviewCacheRef.current.get(requestKey);
+        if (cached) {
+          setPlacesError(null);
+          placesRef.current = [];
+          setPlaces([]);
+          setLimitNotice(null);
+          setIsOverviewMode(true);
+          setOverviewTotalPlaces(cached.totalPlaces);
+          setLimitedMode(cached.limited);
+          setLimitedModeLastUpdatedISO(cached.lastUpdatedISO);
+          renderClusters(cached.clusters);
+          setPlacesStatus("success");
+          usingOverviewRef.current = true;
+          return;
+        }
+
+        const hadPlaces = placesRef.current.length > 0;
+        setPlacesStatus("loading");
+        setPlacesError(null);
+        if (!hadPlaces) {
+          setLimitNotice(null);
+        }
+
+        try {
+          const params = new URLSearchParams(filterQuery.replace("?", ""));
+          params.set("bbox", bboxKey);
+          params.set("zoom", String(zoom));
+          const pageQuery = params.toString();
+          const response = await fetch(`/api/places/overview${pageQuery ? `?${pageQuery}` : ""}`, {
+            signal: controller.signal,
+          });
+          if (!response.ok) {
+            throw new Error(`Request failed with status ${response.status}`);
+          }
+          const payload = (await response.json()) as {
+            clusters?: Array<{ id: string; lat: number; lng: number; count: number }>;
+            totalPlaces?: number;
+          };
+          const isLimited = isLimitedHeader(response.headers);
+          const lastUpdatedISO = getLastUpdatedHeader(response.headers);
+          if (!isMounted || requestIdRef.current !== requestId) return;
+
+          const nextClusters: ClusterResult[] = (payload.clusters ?? []).map((cluster, index) => ({
+            type: "cluster",
+            id: index + 1,
+            coordinates: [cluster.lng, cluster.lat],
+            pointCount: cluster.count,
+          }));
+
+          placesRef.current = [];
+          setPlaces([]);
+          setLimitNotice(null);
+          setIsOverviewMode(true);
+          setOverviewTotalPlaces(Number(payload.totalPlaces ?? 0));
+          setLimitedMode(isLimited);
+          setLimitedModeLastUpdatedISO(lastUpdatedISO);
+          renderClusters(nextClusters);
+          usingOverviewRef.current = true;
+          overviewCacheRef.current.set(requestKey, {
+            clusters: nextClusters,
+            totalPlaces: Number(payload.totalPlaces ?? 0),
+            limited: isLimited,
+            lastUpdatedISO,
+          });
+          if (overviewCacheRef.current.size > 30) {
+            const [firstKey] = overviewCacheRef.current.keys();
+            if (firstKey) {
+              overviewCacheRef.current.delete(firstKey);
+            }
+          }
+          setPlacesStatus("success");
+        } catch (error) {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          console.error(error);
+          if (!isMounted || requestIdRef.current !== requestId) return;
+          const message = "Failed to load map overview. Please try again.";
+          setPlacesError(message);
+          setPlacesStatus("error");
+        }
+      };
+
       const fetchPlacesForBbox = async (
         bboxKey: string,
         zoom: number,
@@ -664,10 +785,13 @@ export default function MapClient() {
 
           placesRef.current = nextPlaces;
           setPlaces(nextPlaces);
+          setIsOverviewMode(false);
+          setOverviewTotalPlaces(null);
           setLimitedMode(isLimited);
           setLimitedModeLastUpdatedISO(lastUpdatedISO);
           setLimitNotice(nextPlaces.length >= limit ? { count: nextPlaces.length, limit } : null);
           buildIndexAndRender(nextPlaces);
+          usingOverviewRef.current = false;
           placesCacheRef.current.set(requestKey, { places: nextPlaces, limit, limited: isLimited, lastUpdatedISO });
           if (placesCacheRef.current.size > 30) {
             const [firstKey] = placesCacheRef.current.keys();
@@ -708,12 +832,16 @@ export default function MapClient() {
           if (!pending) return;
           if (!pending.force && pending.requestKey === lastRequestKeyRef.current) return;
           lastRequestKeyRef.current = pending.requestKey;
-          void fetchPlacesForBbox(
-            pending.bboxKey,
-            pending.zoom,
-            pending.filterQuery,
-            pending.requestKey,
-          );
+          if (pending.zoom <= OVERVIEW_MAX_ZOOM) {
+            void fetchOverviewForBbox(
+              pending.bboxKey,
+              pending.zoom,
+              pending.filterQuery,
+              pending.requestKey,
+            );
+            return;
+          }
+          void fetchPlacesForBbox(pending.bboxKey, pending.zoom, pending.filterQuery, pending.requestKey);
         }, 120);
       };
 
@@ -832,6 +960,7 @@ export default function MapClient() {
 
 
   useEffect(() => {
+    if (isOverviewMode) return;
     if (!selectedPlaceId || placesStatus !== "success") return;
     const selectedStillExists = places.some((place) => place.id === selectedPlaceId);
     if (selectedStillExists) {
@@ -850,7 +979,9 @@ export default function MapClient() {
     }
 
     setSelectionNotice("Selected place is outside the current map area or filters.");
-  }, [places, placesStatus, router, selectedPlaceId, selectedPlaceParam]);
+  }, [isOverviewMode, places, placesStatus, router, selectedPlaceId, selectedPlaceParam]);
+
+  const displayPlaceCount = isOverviewMode ? (overviewTotalPlaces ?? 0) : places.length;
 
   useEffect(() => {
     if (!fetchPlacesRef.current) return;
@@ -1000,9 +1131,13 @@ export default function MapClient() {
                 />
                 <div className="mt-4 space-y-2">
                   <div className="text-sm font-semibold text-gray-800">
-                    Places ({places.length})
+                    Places ({displayPlaceCount})
                   </div>
-                  {places.length === 0 ? (
+                  {isOverviewMode ? (
+                    <div className="rounded-xl border border-sky-200 bg-sky-50 p-3 text-sm text-sky-800">
+                      Low-zoom overview mode is active. Zoom in to browse place list.
+                    </div>
+                  ) : places.length === 0 ? (
                     <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm text-gray-700">
                       <div className="font-semibold">No places for current filters.</div>
                       <button
@@ -1048,7 +1183,7 @@ export default function MapClient() {
           </button>
           <div className="cpm-map-places-pill" role="status" aria-live="polite">
             <span>
-              {places.length} place{places.length === 1 ? "" : "s"}
+              {displayPlaceCount} place{displayPlaceCount === 1 ? "" : "s"}
             </span>
             {placesStatus === "loading" ? (
               <span className="cpm-inline-loading-spinner" aria-hidden />
@@ -1066,6 +1201,13 @@ export default function MapClient() {
   };
 
   const renderPlaceList = useCallback(() => {
+    if (isOverviewMode) {
+      return (
+        <div className="rounded-lg border border-sky-200 bg-sky-50 p-3 text-sm text-sky-800">
+          Overview mode: aggregated markers are shown at low zoom. Zoom in for place-level list.
+        </div>
+      );
+    }
     if (!places.length) {
       return (
         <div className="rounded-lg border border-gray-100 bg-gray-50 p-3 text-sm text-gray-600">
@@ -1103,7 +1245,7 @@ export default function MapClient() {
         })}
       </div>
     );
-  }, [openDrawerForPlace, places, selectedPlaceId]);
+  }, [isOverviewMode, openDrawerForPlace, places, selectedPlaceId]);
 
   useEffect(() => {
     const map = mapInstanceRef.current;
@@ -1247,7 +1389,7 @@ export default function MapClient() {
 />
           <div className="mt-4 inline-flex items-center gap-2 rounded-md bg-gray-50 px-3 py-2 text-sm font-semibold text-gray-700">
             <span>
-              Showing {places.length} place{places.length === 1 ? "" : "s"}
+              Showing {displayPlaceCount} place{displayPlaceCount === 1 ? "" : "s"}
             </span>
             {placesStatus === "loading" ? (
               <span className="cpm-inline-loading-spinner" aria-hidden />
@@ -1291,6 +1433,11 @@ export default function MapClient() {
         {limitNotice && placesStatus !== "loading" && (
           <div className="pointer-events-none absolute inset-x-0 top-4 z-40 mx-auto w-[min(90%,520px)] rounded-md border border-amber-200 bg-amber-50/95 px-4 py-2 text-sm font-medium text-amber-900 shadow-sm backdrop-blur">
             Too many results ({limitNotice.count} of {limitNotice.limit}). Zoom in to narrow down.
+          </div>
+        )}
+        {!limitNotice && placesStatus === "success" && isOverviewMode && (
+          <div className="pointer-events-none absolute inset-x-0 top-4 z-40 mx-auto w-[min(90%,580px)] rounded-md border border-sky-200 bg-sky-50/95 px-4 py-2 text-sm font-medium text-sky-900 shadow-sm backdrop-blur">
+            Overview mode: aggregated markers are shown at low zoom. Zoom in for place-level pins and list.
           </div>
         )}
         <div

--- a/docs/api.md
+++ b/docs/api.md
@@ -83,6 +83,7 @@ internal 系は **運営のみ**が触れる。
 | Route                                                         | 用途                                             |
 | ------------------------------------------------------------- | ---------------------------------------------- |
 | `GET /api/places`                                             | 地図用の全店舗取得（軽量版）                                 |
+| `GET /api/places/overview`                                    | world / low-zoom 用の集約マーカー取得                         |
 | `GET /api/places/[id]`                                        | 個別店舗詳細（Drawer用）                                |
 | `GET /api/places/by-id?id=...`                                | 個別店舗詳細（cpm/osm IDの安全取得）                     |
 | `GET /api/stats`                                              | v3 コア統計                                        |
@@ -258,7 +259,39 @@ type SubmissionMedia = {
 ## 4.1 GET `/api/places/by-id?id=...`
 
 * `id`: `cpm:...` / `osm:...` をクエリで指定
-* Response：`PlaceDetail`
+
+---
+
+## 4.2 GET `/api/places/overview`（world / low-zoom）
+
+### Description
+
+world / low-zoom の地図表示向けに、place 一覧ではなく **集約済みクラスタ点**を返す。
+
+### Query
+
+`/api/places` と同様の filter query（`bbox`, `q`, `country`, `city`, `category`, `chain`, `payment`, `verification`, `asset`）に加えて:
+
+* `zoom`（現在の map zoom）
+
+### Response
+
+```ts
+type PlacesOverviewResponse = {
+  clusters: {
+    id: string
+    lat: number
+    lng: number
+    count: number
+  }[]
+  totalPlaces: number
+  cellSizeDeg: number
+}
+```
+
+* `clusters`: 表示用の集約マーカー
+* `totalPlaces`: filter適用後の総 place 件数
+* `cellSizeDeg`: 集約に使ったグリッドの粒度（度）
 
 ---
 

--- a/docs/state-machine-site.md
+++ b/docs/state-machine-site.md
@@ -26,7 +26,8 @@ stateDiagram-v2
   %% =========================
   state RouteHomeMap {
     [*] --> MapLoad
-    MapLoad --> MapIdle : places list loaded
+    MapLoad --> MapIdle : places list loaded (mid/high zoom)
+    MapLoad --> MapIdle : overview clusters loaded (world/low zoom)
     MapLoad --> MapEmpty : no results
     MapLoad --> MapDegraded : data source degraded (db down/json)
     MapLoad --> MapError : fetch failed (network/parse)

--- a/lib/places/listPlacesOverviewForMap.ts
+++ b/lib/places/listPlacesOverviewForMap.ts
@@ -1,0 +1,317 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { normalizeAccepted } from "@/lib/accepted";
+import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+import type { ParsedBbox } from "@/lib/geo/bbox";
+import { places as fallbackPlaces } from "@/lib/data/places";
+import { getMapDisplayableWhereClauses, isMapDisplayablePlace } from "@/lib/stats/mapPopulation";
+import type { Place } from "@/types/places";
+
+import { isLegacyOrDemoId, LEGACY_TEST_IDS } from "./legacyFilters";
+
+type PublishedSnapshot = {
+  meta?: { last_updated?: string };
+  places: Place[];
+};
+
+const FALLBACK_SNAPSHOT_FILE = path.join(process.cwd(), "data", "fallback", "published_places_snapshot.json");
+
+export type ListPlacesOverviewFilters = {
+  asset: string | null;
+  category: string | null;
+  country: string | null;
+  city: string | null;
+  bbox: ParsedBbox[] | null;
+  verification: Place["verification"][];
+  payment: string[];
+  search: string | null;
+  zoom: number;
+};
+
+export type OverviewCluster = {
+  id: string;
+  lat: number;
+  lng: number;
+  count: number;
+};
+
+export type ListPlacesOverviewResult = {
+  clusters: OverviewCluster[];
+  totalPlaces: number;
+  cellSizeDeg: number;
+  source: "db" | "json";
+  limited: boolean;
+  lastUpdatedISO?: string;
+};
+
+const normalizeText = (value: string | null | undefined): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : null;
+};
+
+const getBaseCellSizeDeg = (zoom: number): number => {
+  if (zoom <= 1) return 12;
+  if (zoom <= 2) return 6;
+  if (zoom <= 3) return 3;
+  return 1.5;
+};
+
+const getTargetClusterBudget = (zoom: number): number => {
+  if (zoom <= 1) return 24;
+  if (zoom <= 2) return 36;
+  if (zoom <= 3) return 72;
+  return 120;
+};
+
+const aggregateToGrid = (points: Array<{ id: string; lat: number; lng: number }>, cellSizeDeg: number): OverviewCluster[] => {
+  const buckets = new Map<string, { count: number; latSum: number; lngSum: number }>();
+
+  points.forEach((point) => {
+    const cellLng = Math.floor((point.lng + 180) / cellSizeDeg);
+    const cellLat = Math.floor((point.lat + 90) / cellSizeDeg);
+    const key = `${cellLng}:${cellLat}`;
+    const current = buckets.get(key) ?? { count: 0, latSum: 0, lngSum: 0 };
+    current.count += 1;
+    current.latSum += point.lat;
+    current.lngSum += point.lng;
+    buckets.set(key, current);
+  });
+
+  return Array.from(buckets.entries())
+    .map(([key, value]) => ({
+      id: `grid:${key}`,
+      lat: Number((value.latSum / value.count).toFixed(6)),
+      lng: Number((value.lngSum / value.count).toFixed(6)),
+      count: value.count,
+    }))
+    .sort((a, b) => b.count - a.count);
+};
+
+const aggregateToGridWithBudget = (
+  points: Array<{ id: string; lat: number; lng: number }>,
+  zoom: number,
+): { clusters: OverviewCluster[]; cellSizeDeg: number } => {
+  const target = getTargetClusterBudget(zoom);
+  let cellSizeDeg = getBaseCellSizeDeg(zoom);
+  let clusters = aggregateToGrid(points, cellSizeDeg);
+
+  let guard = 0;
+  while (clusters.length > target && guard < 8) {
+    cellSizeDeg *= 1.5;
+    clusters = aggregateToGrid(points, cellSizeDeg);
+    guard += 1;
+  }
+
+  return { clusters, cellSizeDeg };
+};
+
+const loadPlacesFromSnapshot = async (): Promise<PublishedSnapshot> => {
+  const raw = await fs.readFile(FALLBACK_SNAPSHOT_FILE, "utf8");
+  const parsed = JSON.parse(raw);
+  if (parsed && typeof parsed === "object" && Array.isArray((parsed as PublishedSnapshot).places)) {
+    return parsed as PublishedSnapshot;
+  }
+  throw new Error("FALLBACK_SNAPSHOT_UNAVAILABLE");
+};
+
+const loadOverviewPointsFromDb = async (
+  filters: ListPlacesOverviewFilters,
+): Promise<{ points: Array<{ id: string; lat: number; lng: number }>; total: number } | null> => {
+  if (!hasDatabaseUrl()) return null;
+
+  const route = "api_places_overview";
+
+  const { rows: tableChecks } = await dbQuery<{ present: string | null; verifications: string | null; payments: string | null }>(
+    `SELECT
+      to_regclass('public.places') AS present,
+      to_regclass('public.verifications') AS verifications,
+      to_regclass('public.payment_accepts') AS payments`,
+    [],
+    { route },
+  );
+  if (!tableChecks[0]?.present) return null;
+
+  const { rows: placeColumns } = await dbQuery<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='places'
+       AND column_name IN ('geom','status','is_demo','address')`,
+    [],
+    { route },
+  );
+  const hasCol = (name: string) => placeColumns.some((r) => r.column_name === name);
+
+  const where: string[] = [...getMapDisplayableWhereClauses("p")];
+  const paramsWhere: unknown[] = [];
+
+  if (filters.category) {
+    paramsWhere.push(filters.category);
+    where.push(`p.category = $${paramsWhere.length}`);
+  }
+  if (filters.country) {
+    paramsWhere.push(filters.country);
+    where.push(`p.country = $${paramsWhere.length}`);
+  }
+  if (filters.city) {
+    paramsWhere.push(filters.city);
+    where.push(`p.city = $${paramsWhere.length}`);
+  }
+  if (hasCol("status")) where.push("COALESCE(p.status, 'published') = 'published'");
+  if (hasCol("is_demo")) where.push("COALESCE(p.is_demo, false) = false");
+
+  paramsWhere.push(Array.from(LEGACY_TEST_IDS));
+  where.push(`NOT (p.id = ANY($${paramsWhere.length}::text[]))`);
+
+  const hasVerifications = Boolean(tableChecks[0]?.verifications);
+  const hasPayments = Boolean(tableChecks[0]?.payments);
+  let verificationField: string | null = null;
+  if (hasVerifications) {
+    const { rows: verificationColumns } = await dbQuery<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_schema='public' AND table_name='verifications' AND column_name IN ('level')`,
+      [],
+      { route },
+    );
+    if (verificationColumns.some((row) => row.column_name === "level")) verificationField = "v.level";
+  }
+
+  if (filters.bbox?.length) {
+    const useGeom = hasCol("geom");
+    const clauses: string[] = [];
+    for (const bbox of filters.bbox) {
+      const start = paramsWhere.length + 1;
+      if (useGeom) {
+        paramsWhere.push(bbox.minLng, bbox.minLat, bbox.maxLng, bbox.maxLat);
+        clauses.push(`ST_Intersects(p.geom::geometry, ST_MakeEnvelope($${start}, $${start + 1}, $${start + 2}, $${start + 3}, 4326))`);
+      } else {
+        paramsWhere.push(bbox.minLng, bbox.maxLng, bbox.minLat, bbox.maxLat);
+        clauses.push(`(p.lng BETWEEN $${start} AND $${start + 1} AND p.lat BETWEEN $${start + 2} AND $${start + 3})`);
+      }
+    }
+    where.push(clauses.length > 1 ? `(${clauses.join(" OR ")})` : clauses[0]);
+  }
+
+  if (filters.search) {
+    paramsWhere.push(`%${filters.search}%`);
+    where.push(`(p.name ILIKE $${paramsWhere.length} OR COALESCE(p.address, '') ILIKE $${paramsWhere.length})`);
+  }
+
+  if (filters.verification.length) {
+    if (!verificationField) {
+      if (!filters.verification.every((v) => v === "unverified")) return { points: [], total: 0 };
+    } else {
+      paramsWhere.push(filters.verification);
+      where.push(`COALESCE(${verificationField}, 'unverified') = ANY($${paramsWhere.length}::text[])`);
+    }
+  }
+
+  if (filters.asset) {
+    if (!hasPayments) return { points: [], total: 0 };
+    paramsWhere.push(filters.asset);
+    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND UPPER(COALESCE(pa.asset, '')) = $${paramsWhere.length})`);
+  }
+
+  if (filters.payment.length) {
+    if (!hasPayments) return { points: [], total: 0 };
+    paramsWhere.push(filters.payment);
+    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND (LOWER(pa.asset) = ANY($${paramsWhere.length}::text[]) OR LOWER(pa.chain) = ANY($${paramsWhere.length}::text[])))`);
+  }
+
+  const joinVerification = verificationField ? " LEFT JOIN verifications v ON v.place_id = p.id" : "";
+  const whereClause = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+  const [countResult, placesResult] = await Promise.all([
+    dbQuery<{ total: number }>(
+      `SELECT COUNT(DISTINCT p.id)::int AS total
+       FROM places p${joinVerification}
+       ${whereClause}`,
+      paramsWhere,
+      { route },
+    ),
+    dbQuery<{ id: string; lat: number; lng: number }>(
+      `SELECT p.id, p.lat, p.lng
+       FROM places p${joinVerification}
+       ${whereClause}`,
+      paramsWhere,
+      { route },
+    ),
+  ]);
+
+  const total = Number(countResult.rows[0]?.total ?? 0);
+  const points = placesResult.rows.map((row) => ({ id: row.id, lat: Number(row.lat), lng: Number(row.lng) }));
+
+  return { points, total };
+};
+
+export async function listPlacesOverviewForMap(options: {
+  dataSource: "db" | "json" | "auto";
+  filters: ListPlacesOverviewFilters;
+}): Promise<ListPlacesOverviewResult> {
+  if (options.dataSource !== "json") {
+    try {
+      const dbResult = await loadOverviewPointsFromDb(options.filters);
+      if (dbResult) {
+        const aggregated = aggregateToGridWithBudget(dbResult.points, options.filters.zoom);
+        return {
+          clusters: aggregated.clusters,
+          totalPlaces: dbResult.total,
+          cellSizeDeg: aggregated.cellSizeDeg,
+          source: "db",
+          limited: false,
+        };
+      }
+    } catch (error) {
+      if (options.dataSource === "db") throw error;
+      if (!(error instanceof DbUnavailableError)) {
+        console.warn("[places-overview] failed to load from database", error);
+      }
+    }
+
+    if (options.dataSource === "db") {
+      throw new Error("DB_UNAVAILABLE");
+    }
+  }
+
+  const snapshot = await loadPlacesFromSnapshot();
+  const filtered = snapshot.places
+    .filter((place) => !isLegacyOrDemoId(place.id))
+    .filter((place) => isMapDisplayablePlace(place))
+    .filter((place) => (options.filters.category ? place.category === options.filters.category : true))
+    .filter((place) => (options.filters.country ? place.country === options.filters.country : true))
+    .filter((place) => (options.filters.city ? place.city === options.filters.city : true))
+    .filter((place) => (options.filters.verification.length ? options.filters.verification.includes(place.verification) : true))
+    .filter((place) => {
+      if (!options.filters.asset) return true;
+      const accepted = normalizeAccepted([], place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? []);
+      return accepted.some((entry) => entry === options.filters.asset || entry.startsWith(`${options.filters.asset}@`));
+    })
+    .filter((place) => {
+      if (!options.filters.payment.length) return true;
+      const chains = (place.supported_crypto?.length ? place.supported_crypto : place.accepted ?? []).map((item) => item.toLowerCase());
+      return options.filters.payment.some((chain) => chains.includes(chain));
+    })
+    .filter((place) => {
+      if (!options.filters.bbox?.length) return true;
+      return options.filters.bbox.some(({ minLng, minLat, maxLng, maxLat }) =>
+        place.lng >= minLng && place.lng <= maxLng && place.lat >= minLat && place.lat <= maxLat,
+      );
+    })
+    .filter((place) => {
+      if (!options.filters.search) return true;
+      const target = `${place.name ?? ""} ${place.address ?? ""}`.toLowerCase();
+      return target.includes(options.filters.search.toLowerCase());
+    });
+
+  const points = filtered.map((place) => ({ id: place.id, lat: place.lat, lng: place.lng }));
+  const aggregated = aggregateToGridWithBudget(points, options.filters.zoom);
+
+  return {
+    clusters: aggregated.clusters,
+    totalPlaces: filtered.length,
+    cellSizeDeg: aggregated.cellSizeDeg,
+    source: "json",
+    limited: true,
+    lastUpdatedISO: normalizeText(snapshot.meta?.last_updated) ?? undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- add dedicated `GET /api/places/overview` for world / low-zoom map mode
- switch `/map` to overview mode at low zoom and existing place-level fetch at higher zoom
- keep place detail and stats behavior unchanged
- include docs updates for overview route/state path

## Why
- world / low-zoom map view was sticking to `/api/places?...limit=2000`
- this improves world overview UX without bundling the production DB bulk import decision

## Included
- app/api/places/overview/route.ts
- components/map/MapClient.tsx
- docs/api.md
- docs/state-machine-site.md
- lib/places/listPlacesOverviewForMap.ts

## Not included
- production DB bulk import rollout
- docs/tmp tracking notes from test branch

## Verification
- overview API: `clusters=32`, `totalPlaces=12751`, `cellSizeDeg=13.5`
- detail API returns Boatcenter Lugano for `osm:node:10004226017`
- stats API remains `total_places=12751`, `countries=15`, `cities=3769`, `categories=44`
- local map confirmed world / low-zoom overview mode behavior on test DB