### PR TITLE
Separate map pins route and decouple marker fetching from list path

### DIFF
--- a/app/api/places/pins/route.ts
+++ b/app/api/places/pins/route.ts
@@ -1,0 +1,323 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { NextRequest, NextResponse } from "next/server";
+
+import { normalizeAcceptsAsset } from "@/lib/acceptsAsset";
+import {
+  buildDataSourceHeaders,
+  getDataSourceContext,
+  getDataSourceSetting,
+  withDbTimeout,
+} from "@/lib/dataSource";
+import { DbUnavailableError, dbQuery, hasDatabaseUrl } from "@/lib/db";
+import { isLegacyOrDemoId, LEGACY_TEST_IDS } from "@/lib/places/legacyFilters";
+import type { Place } from "@/types/places";
+
+const DEFAULT_LIMIT = 20000;
+const MAX_LIMIT = 25000;
+const CACHE_CONTROL = "public, max-age=0, s-maxage=30, stale-while-revalidate=120";
+const NO_STORE = "no-store";
+const FALLBACK_SNAPSHOT_FILE = path.join(process.cwd(), "data", "fallback", "published_places_snapshot.json");
+
+type PinVerification = "owner" | "community" | "directory" | "unverified";
+
+type PlacePin = {
+  id: string;
+  lat: number;
+  lng: number;
+  verification: PinVerification;
+};
+
+type PublishedSnapshot = {
+  meta?: { last_updated?: string };
+  places: Place[];
+};
+
+type PinFilters = {
+  asset: string | null;
+  category: string | null;
+  country: string | null;
+  city: string | null;
+  verification: PinVerification[];
+  payment: string[];
+  search: string | null;
+  limit: number;
+};
+
+const parsePositiveInt = (value: string | null): number | null => {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+};
+
+const parseSearchTerm = (value: string | null): string | null => {
+  if (!value) return null;
+  const trimmed = value.trim().replace(/\s+/g, " ");
+  if (!trimmed) return null;
+  return trimmed.slice(0, 120);
+};
+
+const normalizeVerification = (value: unknown): PinVerification => {
+  if (value === "owner" || value === "community" || value === "directory") {
+    return value;
+  }
+  return "unverified";
+};
+
+const createPinsResponse = (pins: PlacePin[], options: {
+  source: "db" | "json";
+  limited: boolean;
+  lastUpdatedISO?: string;
+}) => {
+  return NextResponse.json(pins, {
+    headers: {
+      "Cache-Control": CACHE_CONTROL,
+      "x-cpm-pins-total": String(pins.length),
+      ...buildDataSourceHeaders(options.source, options.limited),
+      ...(options.lastUpdatedISO ? { "x-cpm-last-updated": options.lastUpdatedISO } : {}),
+    },
+  });
+};
+
+const loadPinsFromSnapshot = async (filters: PinFilters): Promise<{ pins: PlacePin[]; lastUpdatedISO?: string }> => {
+  const raw = await fs.readFile(FALLBACK_SNAPSHOT_FILE, "utf8");
+  const parsed = JSON.parse(raw) as PublishedSnapshot;
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.places)) {
+    throw new Error("FALLBACK_SNAPSHOT_UNAVAILABLE");
+  }
+
+  const searchNeedle = filters.search?.toLowerCase() ?? null;
+
+  const pins = parsed.places
+    .filter((place) => {
+      if (typeof place.id !== "string" || !place.id) return false;
+      if (isLegacyOrDemoId(place.id) || LEGACY_TEST_IDS.has(place.id)) return false;
+      if (typeof place.lat !== "number" || typeof place.lng !== "number") return false;
+      if (!Number.isFinite(place.lat) || !Number.isFinite(place.lng)) return false;
+      if (filters.category && place.category !== filters.category) return false;
+      if (filters.country && place.country !== filters.country) return false;
+      if (filters.city && place.city !== filters.city) return false;
+      const verification = normalizeVerification(place.verification);
+      if (filters.verification.length && !filters.verification.includes(verification)) return false;
+      if (searchNeedle) {
+        const name = (place.name ?? "").toLowerCase();
+        const address = (place.address_full ?? place.address ?? "").toLowerCase();
+        if (!name.includes(searchNeedle) && !address.includes(searchNeedle)) return false;
+      }
+
+      const accepted = new Set(
+        [...(place.accepted ?? []), ...(place.supported_crypto ?? [])]
+          .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+          .map((value) => value.toLowerCase()),
+      );
+
+      if (filters.asset && !accepted.has(filters.asset.toLowerCase())) return false;
+      if (filters.payment.length > 0 && !filters.payment.some((payment) => accepted.has(payment.toLowerCase()))) {
+        return false;
+      }
+
+      return true;
+    })
+    .slice(0, filters.limit)
+    .map((place) => ({
+      id: place.id,
+      lat: place.lat,
+      lng: place.lng,
+      verification: normalizeVerification(place.verification),
+    }));
+
+  return { pins, lastUpdatedISO: parsed.meta?.last_updated };
+};
+
+const loadPinsFromDb = async (filters: PinFilters): Promise<{ pins: PlacePin[] } | null> => {
+  if (!hasDatabaseUrl()) return null;
+
+  const route = "api_places_pins";
+  const { rows: tableChecks } = await dbQuery<{ present: string | null; verifications: string | null; payments: string | null }>(
+    `SELECT
+      to_regclass('public.places') AS present,
+      to_regclass('public.verifications') AS verifications,
+      to_regclass('public.payment_accepts') AS payments`,
+    [],
+    { route },
+  );
+
+  if (!tableChecks[0]?.present) return null;
+
+  const { rows: placeColumns } = await dbQuery<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns
+     WHERE table_schema='public' AND table_name='places'
+       AND column_name IN ('status','is_demo','address')`,
+    [],
+    { route },
+  );
+  const hasCol = (name: string) => placeColumns.some((row) => row.column_name === name);
+
+  const where: string[] = ["p.lat IS NOT NULL", "p.lng IS NOT NULL"];
+  const paramsWhere: unknown[] = [];
+
+  if (filters.category) {
+    paramsWhere.push(filters.category);
+    where.push(`p.category = $${paramsWhere.length}`);
+  }
+  if (filters.country) {
+    paramsWhere.push(filters.country);
+    where.push(`p.country = $${paramsWhere.length}`);
+  }
+  if (filters.city) {
+    paramsWhere.push(filters.city);
+    where.push(`p.city = $${paramsWhere.length}`);
+  }
+  if (hasCol("status")) where.push("COALESCE(p.status, 'published') = 'published'");
+  if (hasCol("is_demo")) where.push("COALESCE(p.is_demo, false) = false");
+
+  paramsWhere.push(Array.from(LEGACY_TEST_IDS));
+  where.push(`NOT (p.id = ANY($${paramsWhere.length}::text[]))`);
+
+  const hasVerifications = Boolean(tableChecks[0]?.verifications);
+  const hasPayments = Boolean(tableChecks[0]?.payments);
+  let verificationField: string | null = null;
+  if (hasVerifications) {
+    const { rows: verificationColumns } = await dbQuery<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_schema='public' AND table_name='verifications' AND column_name IN ('level')`,
+      [],
+      { route },
+    );
+    if (verificationColumns.some((row) => row.column_name === "level")) verificationField = "v.level";
+  }
+
+  if (filters.search) {
+    paramsWhere.push(`%${filters.search}%`);
+    where.push(`(p.name ILIKE $${paramsWhere.length} OR COALESCE(p.address, '') ILIKE $${paramsWhere.length})`);
+  }
+
+  if (filters.verification.length > 0) {
+    if (!verificationField) {
+      if (!filters.verification.every((value) => value === "unverified")) {
+        return { pins: [] };
+      }
+    } else {
+      paramsWhere.push(filters.verification);
+      where.push(`COALESCE(${verificationField}, 'unverified') = ANY($${paramsWhere.length}::text[])`);
+    }
+  }
+
+  if (filters.asset) {
+    if (!hasPayments) return { pins: [] };
+    paramsWhere.push(filters.asset);
+    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND UPPER(COALESCE(pa.asset, '')) = $${paramsWhere.length})`);
+  }
+
+  if (filters.payment.length > 0) {
+    if (!hasPayments) return { pins: [] };
+    paramsWhere.push(filters.payment);
+    where.push(`EXISTS (SELECT 1 FROM payment_accepts pa WHERE pa.place_id = p.id AND (LOWER(pa.asset) = ANY($${paramsWhere.length}::text[]) OR LOWER(pa.chain) = ANY($${paramsWhere.length}::text[])))`);
+  }
+
+  const verificationSelect = verificationField
+    ? `COALESCE(${verificationField}, 'unverified') AS verification`
+    : "'unverified'::text AS verification";
+  const joinVerification = verificationField ? " LEFT JOIN verifications v ON v.place_id = p.id" : "";
+  const whereClause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+
+  const { rows } = await dbQuery<{ id: string; lat: number; lng: number; verification: string | null }>(
+    `SELECT p.id, p.lat, p.lng, ${verificationSelect}
+     FROM places p${joinVerification}
+     ${whereClause}
+     ORDER BY p.id ASC
+     LIMIT $${paramsWhere.length + 1}`,
+    [...paramsWhere, filters.limit],
+    { route },
+  );
+
+  return {
+    pins: rows.map((row) => ({
+      id: row.id,
+      lat: Number(row.lat),
+      lng: Number(row.lng),
+      verification: normalizeVerification(row.verification),
+    })),
+  };
+};
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const dataSource = getDataSourceSetting();
+  const { shouldAllowJson } = getDataSourceContext(dataSource);
+
+  const requestedLimit = parsePositiveInt(searchParams.get("limit"));
+  const limit = Math.min(requestedLimit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+  const chainFilters = searchParams.getAll("chain").flatMap((value) => value.split(",")).map((value) => value.trim()).filter(Boolean);
+  const paymentFilters = searchParams.getAll("payment").flatMap((value) => value.split(",")).map((value) => value.trim()).filter(Boolean);
+
+  const filters: PinFilters = {
+    asset: normalizeAcceptsAsset(searchParams.get("asset")),
+    category: searchParams.get("category"),
+    country: searchParams.get("country"),
+    city: searchParams.get("city"),
+    verification: searchParams
+      .getAll("verification")
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim())
+      .filter((value): value is PinVerification => ["owner", "community", "directory", "unverified"].includes(value)),
+    payment: Array.from(new Set([...chainFilters, ...paymentFilters])).map((value) => value.toLowerCase()),
+    search: parseSearchTerm(searchParams.get("q")),
+    limit,
+  };
+
+  if (dataSource !== "json") {
+    try {
+      const dbResult = await withDbTimeout(loadPinsFromDb(filters), { message: "DB_TIMEOUT" });
+      if (dbResult) {
+        return createPinsResponse(dbResult.pins, { source: "db", limited: false });
+      }
+    } catch (error) {
+      if (dataSource === "db") {
+        return NextResponse.json(
+          { ok: false, error: "DB_UNAVAILABLE" },
+          {
+            status: 503,
+            headers: { "Cache-Control": NO_STORE, "x-cpm-pins-total": "0", ...buildDataSourceHeaders("db", true) },
+          },
+        );
+      }
+      if (!(error instanceof DbUnavailableError)) {
+        console.warn("[pins] db query failed", error);
+      }
+    }
+  }
+
+  if (!shouldAllowJson) {
+    return NextResponse.json(
+      { ok: false, error: "DB_UNAVAILABLE" },
+      {
+        status: 503,
+        headers: { "Cache-Control": NO_STORE, "x-cpm-pins-total": "0", ...buildDataSourceHeaders("db", true) },
+      },
+    );
+  }
+
+  try {
+    const snapshotResult = await loadPinsFromSnapshot(filters);
+    return createPinsResponse(snapshotResult.pins, {
+      source: "json",
+      limited: true,
+      lastUpdatedISO: snapshotResult.lastUpdatedISO,
+    });
+  } catch {
+    return NextResponse.json(
+      [],
+      {
+        headers: {
+          "Cache-Control": NO_STORE,
+          "x-cpm-pins-total": "0",
+          ...buildDataSourceHeaders("json", true),
+        },
+      },
+    );
+  }
+}

--- a/components/map/MapClient.tsx
+++ b/components/map/MapClient.tsx
@@ -37,8 +37,8 @@ const HEADER_HEIGHT = 64;
 const DEFAULT_COORDINATES: [number, number] = [20, 0];
 const DEFAULT_ZOOM = 2;
 const MAX_CLIENT_LIMIT = 12000;
+const MAX_PIN_LIMIT = 20000;
 const BBOX_PRECISION = 3;
-const OVERVIEW_MAX_ZOOM = 3;
 
 const PIN_SVGS: Record<PinType, string> = {
   owner: `<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><g><path d="M16 2 C10 2,6 6.5,6 12 C6 20,16 30,16 30 C16 30,26 20,26 12 C26 6.5,22 2,16 2Z" fill="#F59E0B" stroke="white" stroke-width="2"/><circle cx="16" cy="12" r="4" fill="white"/></g></svg>`,
@@ -54,11 +54,18 @@ const normalizePinType = (verification: string): PinType => {
   return "unverified";
 };
 
-const placeToPin = (place: Place): Pin => ({
-  id: place.id,
-  lat: place.lat,
-  lng: place.lng,
-  verification: normalizePinType(place.verification),
+type MarkerPin = {
+  id: string;
+  lat: number;
+  lng: number;
+  verification: string;
+};
+
+const markerPinToPin = (pin: MarkerPin): Pin => ({
+  id: pin.id,
+  lat: pin.lat,
+  lng: pin.lng,
+  verification: normalizePinType(pin.verification),
 });
 
 const hasSummaryPlusForDrawer = (place: Place | null): boolean => {
@@ -123,18 +130,17 @@ export default function MapClient() {
     zoom: number;
   } | null>(null);
   const isFetchingMarkersRef = useRef(false);
-  const usingOverviewRef = useRef(false);
+  const markerPinsRef = useRef<MarkerPin[]>([]);
   const lastRequestKeyRef = useRef<string | null>(null);
+  const lastPinsFilterQueryRef = useRef<string | null>(null);
   const placesCacheRef = useRef<Map<string, { places: Place[]; limit: number; limited: boolean; lastUpdatedISO: string | null }>>(
     new Map(),
   );
-  const overviewCacheRef = useRef<Map<string, { clusters: ClusterResult[]; totalPlaces: number; limited: boolean; lastUpdatedISO: string | null }>>(
-    new Map(),
-  );
+  const markerPinsCacheRef = useRef<Map<string, { pins: MarkerPin[]; limited: boolean; lastUpdatedISO: string | null }>>(new Map());
   const lastRenderedClustersKeyRef = useRef<string | null>(null);
   const [isOverviewMode, setIsOverviewMode] = useState(false);
-  const [overviewTotalPlaces, setOverviewTotalPlaces] = useState<number | null>(null);
   const [places, setPlaces] = useState<Place[]>([]);
+  const [markerPinsTotal, setMarkerPinsTotal] = useState(0);
   const [placesStatus, setPlacesStatus] = useState<
     "idle" | "loading" | "success" | "error"
   >("loading");
@@ -457,11 +463,6 @@ export default function MapClient() {
 
           const marker = L.marker([lat, lng], { icon: clusterIcon });
           marker.on("click", () => {
-            if (usingOverviewRef.current) {
-              const nextZoom = Math.max(OVERVIEW_MAX_ZOOM + 1, Math.min(map.getZoom() + 2, 18));
-              map.flyTo([lat, lng], nextZoom, { animate: true });
-              return;
-            }
             const expansionZoom = clusterIndexRef.current?.getClusterExpansionZoom(clusterItem.id);
             if (expansionZoom !== undefined) {
               map.flyTo([lat, lng], expansionZoom, { animate: true });
@@ -622,8 +623,8 @@ export default function MapClient() {
         closeDrawer("map-blank-click");
       };
 
-      const buildIndexAndRender = (nextPlaces: Place[]) => {
-        const pins = nextPlaces.map(placeToPin);
+      const buildIndexAndRender = (markerPins: MarkerPin[]) => {
+        const pins = markerPins.map(markerPinToPin);
         clusterIndexRef.current = createSuperclusterIndex(pins);
         updateVisibleMarkers();
       };
@@ -631,103 +632,45 @@ export default function MapClient() {
       const buildRequestKey = (bboxKey: string, zoom: number, filterQuery: string) =>
         `${bboxKey}@${zoom}|${filterQuery}`;
 
-      const fetchOverviewForBbox = async (
-        bboxKey: string,
-        zoom: number,
-        filterQuery: string,
-        requestKey: string,
-      ) => {
-        if (!isMounted) return;
-        requestIdRef.current += 1;
-        const requestId = requestIdRef.current;
-        abortControllerRef.current?.abort();
-        const controller = new AbortController();
-        abortControllerRef.current = controller;
-
-        const cached = overviewCacheRef.current.get(requestKey);
+      const fetchMarkerPins = async (filterQuery: string) => {
+        const requestKey = filterQuery || "__all__";
+        const cached = markerPinsCacheRef.current.get(requestKey);
         if (cached) {
-          isFetchingMarkersRef.current = false;
-          setPlacesError(null);
-          placesRef.current = [];
-          setPlaces([]);
-          setLimitNotice(null);
-          setIsOverviewMode(true);
-          setOverviewTotalPlaces(cached.totalPlaces);
+          markerPinsRef.current = cached.pins;
+          setMarkerPinsTotal(cached.pins.length);
           setLimitedMode(cached.limited);
           setLimitedModeLastUpdatedISO(cached.lastUpdatedISO);
-          renderClusters(cached.clusters);
-          setPlacesStatus("success");
-          usingOverviewRef.current = true;
+          buildIndexAndRender(cached.pins);
           return;
         }
 
-        const hadPlaces = placesRef.current.length > 0;
-        isFetchingMarkersRef.current = true;
-        setPlacesStatus("loading");
-        setPlacesError(null);
-        if (!hadPlaces) {
-          setLimitNotice(null);
+        const params = new URLSearchParams(filterQuery.replace("?", ""));
+        params.set("limit", String(MAX_PIN_LIMIT));
+        const pageQuery = params.toString();
+        const response = await fetch(`/api/places/pins${pageQuery ? `?${pageQuery}` : ""}`);
+        if (!response.ok) {
+          throw new Error(`Pins request failed with status ${response.status}`);
         }
 
-        try {
-          const params = new URLSearchParams(filterQuery.replace("?", ""));
-          params.set("bbox", bboxKey);
-          params.set("zoom", String(zoom));
-          const pageQuery = params.toString();
-          const response = await fetch(`/api/places/overview${pageQuery ? `?${pageQuery}` : ""}`, {
-            signal: controller.signal,
-          });
-          if (!response.ok) {
-            throw new Error(`Request failed with status ${response.status}`);
-          }
-          const payload = (await response.json()) as {
-            clusters?: Array<{ id: string; lat: number; lng: number; count: number }>;
-            totalPlaces?: number;
-          };
-          const isLimited = isLimitedHeader(response.headers);
-          const lastUpdatedISO = getLastUpdatedHeader(response.headers);
-          if (!isMounted || requestIdRef.current !== requestId) return;
+        const nextPins = (await response.json()) as MarkerPin[];
+        const isLimited = isLimitedHeader(response.headers);
+        const lastUpdatedISO = getLastUpdatedHeader(response.headers);
+        const pinsTotalHeader = Number(response.headers.get("x-cpm-pins-total") ?? "");
+        const normalizedPinsTotal = Number.isFinite(pinsTotalHeader) && pinsTotalHeader >= 0 ? pinsTotalHeader : nextPins.length;
 
-          const nextClusters: ClusterResult[] = (payload.clusters ?? []).map((cluster, index) => ({
-            type: "cluster",
-            id: index + 1,
-            coordinates: [cluster.lng, cluster.lat],
-            pointCount: cluster.count,
-          }));
-
-          placesRef.current = [];
-          setPlaces([]);
-          setLimitNotice(null);
-          setIsOverviewMode(true);
-          setOverviewTotalPlaces(Number(payload.totalPlaces ?? 0));
-          setLimitedMode(isLimited);
-          setLimitedModeLastUpdatedISO(lastUpdatedISO);
-          isFetchingMarkersRef.current = false;
-          renderClusters(nextClusters);
-          usingOverviewRef.current = true;
-          overviewCacheRef.current.set(requestKey, {
-            clusters: nextClusters,
-            totalPlaces: Number(payload.totalPlaces ?? 0),
-            limited: isLimited,
-            lastUpdatedISO,
-          });
-          if (overviewCacheRef.current.size > 30) {
-            const [firstKey] = overviewCacheRef.current.keys();
-            if (firstKey) {
-              overviewCacheRef.current.delete(firstKey);
-            }
-          }
-          setPlacesStatus("success");
-        } catch (error) {
-          if (error instanceof DOMException && error.name === "AbortError") {
-            return;
-          }
-          console.error(error);
-          if (!isMounted || requestIdRef.current !== requestId) return;
-          isFetchingMarkersRef.current = false;
-          const message = "Failed to load map overview. Please try again.";
-          setPlacesError(message);
-          setPlacesStatus("error");
+        markerPinsRef.current = nextPins;
+        setMarkerPinsTotal(normalizedPinsTotal);
+        setLimitedMode(isLimited);
+        setLimitedModeLastUpdatedISO(lastUpdatedISO);
+        buildIndexAndRender(nextPins);
+        markerPinsCacheRef.current.set(requestKey, {
+          pins: nextPins,
+          limited: isLimited,
+          lastUpdatedISO,
+        });
+        if (markerPinsCacheRef.current.size > 20) {
+          const [firstKey] = markerPinsCacheRef.current.keys();
+          if (firstKey) markerPinsCacheRef.current.delete(firstKey);
         }
       };
 
@@ -753,7 +696,6 @@ export default function MapClient() {
           setLimitNotice(cached.places.length >= cached.limit ? { count: cached.places.length, limit: cached.limit } : null);
           setLimitedMode(cached.limited);
           setLimitedModeLastUpdatedISO(cached.lastUpdatedISO);
-          buildIndexAndRender(cached.places);
           setPlacesStatus("success");
           return;
         }
@@ -804,13 +746,10 @@ export default function MapClient() {
           placesRef.current = nextPlaces;
           setPlaces(nextPlaces);
           setIsOverviewMode(false);
-          setOverviewTotalPlaces(null);
           setLimitedMode(isLimited);
           setLimitedModeLastUpdatedISO(lastUpdatedISO);
           setLimitNotice(nextPlaces.length >= limit ? { count: nextPlaces.length, limit } : null);
           isFetchingMarkersRef.current = false;
-          buildIndexAndRender(nextPlaces);
-          usingOverviewRef.current = false;
           placesCacheRef.current.set(requestKey, { places: nextPlaces, limit, limited: isLimited, lastUpdatedISO });
           if (placesCacheRef.current.size > 30) {
             const [firstKey] = placesCacheRef.current.keys();
@@ -851,15 +790,19 @@ export default function MapClient() {
           const pending = pendingFetchRef.current;
           if (!pending) return;
           if (!pending.force && pending.requestKey === lastRequestKeyRef.current) return;
+          const shouldFetchPins =
+            pending.force || lastPinsFilterQueryRef.current !== pending.filterQuery || markerPinsRef.current.length === 0;
           lastRequestKeyRef.current = pending.requestKey;
-          if (pending.zoom <= OVERVIEW_MAX_ZOOM) {
-            void fetchOverviewForBbox(
-              pending.bboxKey,
-              pending.zoom,
-              pending.filterQuery,
-              pending.requestKey,
-            );
-            return;
+          if (shouldFetchPins) {
+            lastPinsFilterQueryRef.current = pending.filterQuery;
+            void fetchMarkerPins(pending.filterQuery).catch((error) => {
+              console.error(error);
+              if (!isMounted) return;
+              setPlacesError("Failed to load map pins. Please try again.");
+              if (markerPinsRef.current.length === 0) {
+                setPlacesStatus("error");
+              }
+            });
           }
           void fetchPlacesForBbox(pending.bboxKey, pending.zoom, pending.filterQuery, pending.requestKey);
         }, 120);
@@ -1001,7 +944,7 @@ export default function MapClient() {
     setSelectionNotice("Selected place is outside the current map area or filters.");
   }, [isOverviewMode, places, placesStatus, router, selectedPlaceId, selectedPlaceParam]);
 
-  const displayPlaceCount = isOverviewMode ? (overviewTotalPlaces ?? 0) : places.length;
+  const displayPlaceCount = markerPinsTotal;
 
   useEffect(() => {
     if (!fetchPlacesRef.current) return;


### PR DESCRIPTION
### Motivation
- Restore the fast local move/zoom recluster behavior from the prior PR while fixing the broken `/api/places/pins` path. 
- Ensure map marker retrieval is a minimal, map-focused path that does not import sidebar/list constraints or cause 503s when the DB is flaky. 
- Fully separate marker (map) and list/sidebar fetch paths so list caps cannot affect world/overview marker coverage. 

### Description
- Added a dedicated map pins endpoint `app/api/places/pins/route.ts` that returns a minimal payload `[{ id, lat, lng, verification }]`, supports `limit` up to 25,000 (default 20,000), and adds header `x-cpm-pins-total` for explicit pin totals. 
- Pins route is DB-first with `DATA_SOURCE=auto` fallback to the published snapshot so normal map requests return arrays instead of 503 when the DB is unavailable. 
- Updated `components/map/MapClient.tsx` to fetch markers exclusively from `GET /api/places/pins` (marker cache + recluster kept client-side) while preserving existing `GET /api/places` usage for the sidebar/list; marker and list flows are fully decoupled and the map count badge is now driven by the pins total. 
- No changes to DB schema, docs, or data; `listPlacesForMap` is not used by the new pins endpoint and list-side caps remain unchanged. 

### Testing
- `npm run -s lint` executed successfully (repo warnings unchanged). 
- `npm run -s test -- tests/places-bbox.test.ts` was attempted but overall test run failed due to unrelated local test harness module resolution (`Cannot find module '@/lib/db'`), not caused by these changes. 
- Ran the dev server and exercised the route with `curl` against a local `next dev` instance; `GET /api/places/pins?limit=20000` returned a JSON array and headers including `x-cpm-pins-total: 976`, `x-cpm-data-source: json`, and `x-cpm-last-updated`. 
- Local checks (via `jq` on the returned payload) produced: `pins_total=976`, Japan bbox count ≈ `45`, Thailand bbox count ≈ `76`, and `/api/stats` total places `5` in the local snapshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15f8f54148328a51f9479b440de3c)